### PR TITLE
Make zwasm_module_invoke args const across Zig, header, and Rust example

### DIFF
--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -16,7 +16,7 @@ unsafe extern "C" {
     fn zwasm_module_invoke(
         module: *mut zwasm_module_t,
         name: *const std::ffi::c_char,
-        args: *mut u64,
+        args: *const u64,
         nargs: u32,
         results: *mut u64,
         nresults: u32,

--- a/include/zwasm.h
+++ b/include/zwasm.h
@@ -173,7 +173,7 @@ bool zwasm_module_validate(const uint8_t *wasm_ptr, size_t len);
  * @return true on success, false on error.
  */
 bool zwasm_module_invoke(zwasm_module_t *module, const char *name,
-                         uint64_t *args, uint32_t nargs,
+                         const uint64_t *args, uint32_t nargs,
                          uint64_t *results, uint32_t nresults);
 
 /**

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -398,7 +398,7 @@ export fn zwasm_module_validate(wasm_ptr: [*]const u8, len: usize) bool {
 export fn zwasm_module_invoke(
     module: *zwasm_module_t,
     name_ptr: [*:0]const u8,
-    args: ?[*]u64,
+    args: ?[*]const u64,
     nargs: u32,
     results: ?[*]u64,
     nresults: u32,
@@ -406,7 +406,7 @@ export fn zwasm_module_invoke(
     clearError();
     const name = std.mem.sliceTo(name_ptr, 0);
     var empty = [_]u64{};
-    const args_slice: []u64 = if (args) |a| a[0..nargs] else &empty;
+    const args_slice: []const u64 = if (args) |a| a[0..nargs] else &empty;
     const results_slice: []u64 = if (results) |r| r[0..nresults] else &empty;
     module.module.invoke(name, args_slice, results_slice) catch |err| {
         setError(err);

--- a/src/types.zig
+++ b/src/types.zig
@@ -452,14 +452,14 @@ pub const WasmModule = struct {
 
     /// Invoke an exported function by name.
     /// Args and results are passed as u64 arrays.
-    pub fn invoke(self: *WasmModule, name: []const u8, args: []u64, results: []u64) !void {
+    pub fn invoke(self: *WasmModule, name: []const u8, args: []const u64, results: []u64) !void {
         self.vm.reset();
         try self.vm.invoke(&self.instance, name, args, results);
     }
 
     /// Invoke using only the stack-based interpreter, bypassing RegIR and JIT.
     /// Used by differential testing to get a reference result.
-    pub fn invokeInterpreterOnly(self: *WasmModule, name: []const u8, args: []u64, results: []u64) !void {
+    pub fn invokeInterpreterOnly(self: *WasmModule, name: []const u8, args: []const u64, results: []u64) !void {
         self.vm.reset();
         self.vm.force_interpreter = true;
         defer self.vm.force_interpreter = false;


### PR DESCRIPTION
This PR makes the args parameter of zwasm_module_invoke read-only across the stack.

args is input-only, so it should be const.
Before this change, it was mutable in Zig/C, which forced Rust code to cast immutable slices to mutable pointers.

### Changes
- Change Zig signature from ?[*]u64 to ?[*]const u64
- Regenerate/update C header so args becomes const uint64_t *
- Update Rust example/wrapper usage to match the const API
- Keep results mutable (output buffer), unchanged

### Why
- Better API correctness: input is explicitly read-only
- Safer Rust FFI usage (no unnecessary mutable cast)
- Clearer intent for users and maintainers

Fixes #15