### PR TITLE
Fix memory64: u64 offset decoding and address handling

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -24,7 +24,7 @@ pub const WaitQueue = struct {
     waiters: std.ArrayList(Waiter) = .empty,
 
     const Waiter = struct {
-        addr: u32,
+        addr: u64,
         cond: std.Thread.Condition = .{},
     };
 
@@ -170,9 +170,11 @@ pub const Memory = struct {
     }
 
     /// Read a typed value at offset + address (little-endian).
-    pub fn read(self: *const Memory, comptime T: type, offset: u32, address: u32) !T {
-        const effective = @as(u33, offset) + @as(u33, address);
-        if (effective + @sizeOf(T) > self.data.items.len) return error.OutOfBoundsMemoryAccess;
+    /// For memory64, offset and address may be full u64; overflow → OOB.
+    pub fn read(self: *const Memory, comptime T: type, offset: u64, address: u64) !T {
+        const effective, const overflow = @addWithOverflow(offset, address);
+        const len = self.data.items.len;
+        if (overflow != 0 or len < @sizeOf(T) or effective > len - @sizeOf(T)) return error.OutOfBoundsMemoryAccess;
 
         const ptr: *const [@sizeOf(T)]u8 = @ptrCast(&self.data.items[effective]);
         return switch (T) {
@@ -185,9 +187,11 @@ pub const Memory = struct {
     }
 
     /// Write a typed value at offset + address (little-endian).
-    pub fn write(self: *Memory, comptime T: type, offset: u32, address: u32, value: T) !void {
-        const effective = @as(u33, offset) + @as(u33, address);
-        if (effective + @sizeOf(T) > self.data.items.len) return error.OutOfBoundsMemoryAccess;
+    /// For memory64, offset and address may be full u64; overflow → OOB.
+    pub fn write(self: *Memory, comptime T: type, offset: u64, address: u64, value: T) !void {
+        const effective, const overflow = @addWithOverflow(offset, address);
+        const len = self.data.items.len;
+        if (overflow != 0 or len < @sizeOf(T) or effective > len - @sizeOf(T)) return error.OutOfBoundsMemoryAccess;
 
         const ptr: *[@sizeOf(T)]u8 = @ptrCast(&self.data.items[effective]);
         switch (T) {
@@ -209,7 +213,7 @@ pub const Memory = struct {
 
     /// memory.atomic.wait32: block until notified or timeout.
     /// Returns 0 (ok/woken), 1 (not-equal), 2 (timed-out).
-    pub fn atomicWait32(self: *Memory, addr: u32, expected: i32, timeout_ns: i64) !i32 {
+    pub fn atomicWait32(self: *Memory, addr: u64, expected: i32, timeout_ns: i64) !i32 {
         if (!self.is_shared_memory) return error.Trap;
         const loaded = try self.read(i32, 0, addr);
         if (loaded != expected) return 1; // not-equal
@@ -246,7 +250,7 @@ pub const Memory = struct {
 
     /// memory.atomic.wait64: block until notified or timeout.
     /// Returns 0 (ok/woken), 1 (not-equal), 2 (timed-out).
-    pub fn atomicWait64(self: *Memory, addr: u32, expected: i64, timeout_ns: i64) !i32 {
+    pub fn atomicWait64(self: *Memory, addr: u64, expected: i64, timeout_ns: i64) !i32 {
         if (!self.is_shared_memory) return error.Trap;
         const loaded = try self.read(i64, 0, addr);
         if (loaded != expected) return 1; // not-equal
@@ -279,7 +283,7 @@ pub const Memory = struct {
 
     /// memory.atomic.notify: wake up to `count` waiters at `addr`.
     /// Returns the number of waiters woken.
-    pub fn atomicNotify(self: *Memory, addr: u32, count: u32) !i32 {
+    pub fn atomicNotify(self: *Memory, addr: u64, count: u32) !i32 {
         // Notify is valid on non-shared memory (returns 0 per spec).
         _ = try self.read(u32, 0, addr); // bounds check
         if (count == 0) return 0; // wake 0 threads

--- a/src/module.zig
+++ b/src/module.zig
@@ -884,7 +884,7 @@ pub const Module = struct {
                 0x28...0x3E => { // memory load/store
                     const align_flags = try r.readU32();
                     if (align_flags & 0x40 != 0) _ = try r.readU32(); // memidx (multi-memory)
-                    _ = try r.readU32(); // offset
+                    _ = try r.readU64(); // offset (u64 for memory64)
                 },
                 0x3F, 0x40 => _ = try r.readU32(), // memory.size/grow (memidx)
                 0xD0 => _ = try r.readI33(), // ref.null (heap type, S33 LEB128)
@@ -910,12 +910,12 @@ pub const Module = struct {
                     if (sub <= 11 or sub == 92 or sub == 93) {
                         // v128.load/store variants (0-11), load32/64_zero (92-93) — memarg
                         const simd_align = try r.readU32();
-                        _ = try r.readU32(); // offset
+                        _ = try r.readU64(); // offset (u64 for memory64)
                         if (simd_align & 0x40 != 0) _ = try r.readU32(); // memidx
                     } else if (sub >= 84 and sub <= 91) {
                         // v128.load*_lane (84-87), v128.store*_lane (88-91) — memarg + lane_index
                         const lane_align = try r.readU32();
-                        _ = try r.readU32(); // offset
+                        _ = try r.readU64(); // offset (u64 for memory64)
                         if (lane_align & 0x40 != 0) _ = try r.readU32(); // memidx
                         _ = try r.readByte();
                     } else if (sub == 12) {
@@ -965,7 +965,7 @@ pub const Module = struct {
                     } else {
                         // All other atomic ops have memarg (align + offset)
                         _ = try r.readU32(); // align
-                        _ = try r.readU32(); // offset
+                        _ = try r.readU64(); // offset (u64 for memory64)
                     }
                 },
                 else => {}, // opcodes with no immediates

--- a/src/predecode.zig
+++ b/src/predecode.zig
@@ -240,7 +240,14 @@ pub fn predecode(alloc: Allocator, bytecode: []const u8) PredecodeError!?*IrFunc
                     @intCast(reader.readU32() catch return error.InvalidWasm)
                 else
                     0;
-                const offset = reader.readU32() catch return error.InvalidWasm;
+                // memory64: offset is u64 LEB128 (safe to read u64 always — validation already passed)
+                const offset64 = reader.readU64() catch return error.InvalidWasm;
+                // Bail to bytecode interpreter if offset > u32_max (very rare, memory64 only)
+                const offset = std.math.cast(u32, offset64) orelse {
+                    code.deinit(alloc);
+                    pool64.deinit(alloc);
+                    return null;
+                };
                 try code.append(alloc, .{ .opcode = @intCast(byte), .extra = memidx, .operand = offset });
             },
 
@@ -481,7 +488,7 @@ fn predecodeSimd(alloc: Allocator, code: *std.ArrayList(PreInstr), pool64: *std.
                 @intCast(reader.readU32() catch return false)
             else
                 0;
-            const offset = reader.readU32() catch return false;
+            const offset = std.math.cast(u32, reader.readU64() catch return false) orelse return false;
             try code.append(alloc, .{ .opcode = ir_op, .extra = memidx, .operand = offset });
         },
         // v128.const (0x0C): 16 raw bytes → store as 2 pool64 entries
@@ -516,7 +523,7 @@ fn predecodeSimd(alloc: Allocator, code: *std.ArrayList(PreInstr), pool64: *std.
                 @intCast(reader.readU32() catch return false)
             else
                 0;
-            const offset = reader.readU32() catch return false;
+            const offset = std.math.cast(u32, reader.readU64() catch return false) orelse return false;
             const lane = reader.readByte() catch return false;
             // Pack lane into extra high byte, memidx into extra low byte
             try code.append(alloc, .{ .opcode = ir_op, .extra = (@as(u16, lane) << 8) | memidx, .operand = offset });

--- a/src/validate.zig
+++ b/src/validate.zig
@@ -972,7 +972,11 @@ const Validator = struct {
         const align_val = align_byte & 0x3F;
         const has_memidx = (align_byte & 0x40) != 0;
         const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
-        _ = try reader.readU32(); // offset
+        // memory64: offset is u64 LEB128
+        if (self.memAddrType(memidx) == .i64)
+            _ = try reader.readU64()
+        else
+            _ = try reader.readU32();
 
         if (naturalAlignment(op)) |nat| {
             if (align_val > nat) return error.InvalidAlignment;
@@ -990,7 +994,11 @@ const Validator = struct {
         const align_val = align_byte & 0x3F;
         const has_memidx = (align_byte & 0x40) != 0;
         const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
-        _ = try reader.readU32(); // offset
+        // memory64: offset is u64 LEB128
+        if (self.memAddrType(memidx) == .i64)
+            _ = try reader.readU64()
+        else
+            _ = try reader.readU32();
 
         if (naturalAlignment(op)) |nat| {
             if (align_val > nat) return error.InvalidAlignment;
@@ -1194,7 +1202,11 @@ const Validator = struct {
         const align_val = align_byte & 0x3F;
         const has_memidx = (align_byte & 0x40) != 0;
         const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
-        _ = try reader.readU32(); // offset
+        // memory64: offset is u64 LEB128
+        if (self.memAddrType(memidx) == .i64)
+            _ = try reader.readU64()
+        else
+            _ = try reader.readU32();
 
         // Check memory index
         const total_mems = self.module.num_imported_memories + self.module.memories.items.len;
@@ -1244,10 +1256,10 @@ const Validator = struct {
                 const align_byte = try reader.readU32();
                 const align_val = align_byte & 0x3F;
                 const has_memidx = (align_byte & 0x40) != 0;
-                if (has_memidx) _ = try reader.readU32();
-                _ = try reader.readU32(); // offset
+                const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
+                if (self.memAddrType(memidx) == .i64) _ = try reader.readU64() else _ = try reader.readU32();
                 if (align_val > 4) return error.InvalidAlignment; // natural = 16 = 2^4
-                try self.popI32(); // address
+                _ = try self.popExpecting(self.memAddrType(memidx)); // address
                 try self.pushVal(.v128);
             },
             // v128.load8x8_s/u, load16x4_s/u, load32x2_s/u (1-6) — memarg, natural align 8 (2^3)
@@ -1255,10 +1267,10 @@ const Validator = struct {
                 const align_byte = try reader.readU32();
                 const align_val = align_byte & 0x3F;
                 const has_memidx = (align_byte & 0x40) != 0;
-                if (has_memidx) _ = try reader.readU32();
-                _ = try reader.readU32();
+                const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
+                if (self.memAddrType(memidx) == .i64) _ = try reader.readU64() else _ = try reader.readU32();
                 if (align_val > 3) return error.InvalidAlignment;
-                try self.popI32();
+                _ = try self.popExpecting(self.memAddrType(memidx));
                 try self.pushVal(.v128);
             },
             // v128.load8_splat(7), load16_splat(8), load32_splat(9), load64_splat(10) — memarg
@@ -1271,11 +1283,11 @@ const Validator = struct {
                 const align_byte = try reader.readU32();
                 const align_val = align_byte & 0x3F;
                 const has_memidx = (align_byte & 0x40) != 0;
-                if (has_memidx) _ = try reader.readU32();
-                _ = try reader.readU32();
+                const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
+                if (self.memAddrType(memidx) == .i64) _ = try reader.readU64() else _ = try reader.readU32();
                 if (align_val > 4) return error.InvalidAlignment;
                 try self.popV128(); // value
-                try self.popI32(); // address
+                _ = try self.popExpecting(self.memAddrType(memidx)); // address
             },
             // v128.const (12) — 16 bytes immediate
             12 => { _ = try reader.readBytes(16); try self.pushVal(.v128); },
@@ -1419,10 +1431,10 @@ const Validator = struct {
         const align_byte = try reader.readU32();
         const align_val = align_byte & 0x3F;
         const has_memidx = (align_byte & 0x40) != 0;
-        if (has_memidx) _ = try reader.readU32();
-        _ = try reader.readU32(); // offset
+        const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
+        if (self.memAddrType(memidx) == .i64) _ = try reader.readU64() else _ = try reader.readU32();
         if (align_val > natural_align) return error.InvalidAlignment;
-        try self.popI32(); // address
+        _ = try self.popExpecting(self.memAddrType(memidx)); // address
         try self.pushVal(.v128);
     }
 
@@ -1430,13 +1442,13 @@ const Validator = struct {
         const align_byte = try reader.readU32();
         const align_val = align_byte & 0x3F;
         const has_memidx = (align_byte & 0x40) != 0;
-        if (has_memidx) _ = try reader.readU32();
-        _ = try reader.readU32(); // offset
+        const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
+        if (self.memAddrType(memidx) == .i64) _ = try reader.readU64() else _ = try reader.readU32();
         const lane = try reader.readByte();
         if (align_val > natural_align) return error.InvalidAlignment;
         if (lane >= max_lanes) return error.InvalidLaneIndex;
         try self.popV128(); // existing vector
-        try self.popI32(); // address
+        _ = try self.popExpecting(self.memAddrType(memidx)); // address
         try self.pushVal(.v128);
     }
 
@@ -1444,13 +1456,13 @@ const Validator = struct {
         const align_byte = try reader.readU32();
         const align_val = align_byte & 0x3F;
         const has_memidx = (align_byte & 0x40) != 0;
-        if (has_memidx) _ = try reader.readU32();
-        _ = try reader.readU32(); // offset
+        const memidx: u32 = if (has_memidx) try reader.readU32() else 0;
+        if (self.memAddrType(memidx) == .i64) _ = try reader.readU64() else _ = try reader.readU32();
         const lane = try reader.readByte();
         if (align_val > natural_align) return error.InvalidAlignment;
         if (lane >= max_lanes) return error.InvalidLaneIndex;
         try self.popV128(); // vector value
-        try self.popI32(); // address
+        _ = try self.popExpecting(self.memAddrType(memidx)); // address
     }
 
     fn validateLane(self: *Validator, reader: *Reader, max_lanes: u8) !void {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -2820,9 +2820,10 @@ pub const Vm = struct {
 
         // All other atomic ops have memarg (align + offset)
         const align_flags = try reader.readU32();
-        const offset = try reader.readU32();
-        _ = align_flags; // alignment validated at decode time
-        const m = instance.getMemory(0) catch return error.OutOfBoundsMemoryAccess;
+        const memidx: u16 = if (align_flags & 0x40 != 0) @intCast(try reader.readU32()) else 0;
+        const m = instance.getMemory(memidx) catch return error.OutOfBoundsMemoryAccess;
+        // memory64: offset is u64 LEB128
+        const offset: u64 = if (m.is_64) try reader.readU64() else try reader.readU32();
 
         switch (atomic_op) {
             .atomic_fence => unreachable, // handled above
@@ -2830,8 +2831,9 @@ pub const Vm = struct {
             // ---- Wait/Notify ----
             .memory_atomic_notify => {
                 const count: u32 = @bitCast(self.popI32());
-                const addr: u32 = @bitCast(self.popI32());
-                const effective_addr = addr +% offset;
+                const addr: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+                const effective_addr, const ov = @addWithOverflow(addr, offset);
+                if (ov != 0) return error.OutOfBoundsMemoryAccess;
                 if (effective_addr % 4 != 0) return error.Trap; // unaligned atomic
                 const result = m.atomicNotify(effective_addr, count) catch return error.OutOfBoundsMemoryAccess;
                 try self.pushI32(result);
@@ -2839,8 +2841,9 @@ pub const Vm = struct {
             .memory_atomic_wait32 => {
                 const timeout: i64 = self.popI64();
                 const expected: i32 = self.popI32();
-                const addr: u32 = @bitCast(self.popI32());
-                const effective_addr = addr +% offset;
+                const addr: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+                const effective_addr, const ov = @addWithOverflow(addr, offset);
+                if (ov != 0) return error.OutOfBoundsMemoryAccess;
                 if (effective_addr % 4 != 0) return error.Trap; // unaligned atomic
                 const result = m.atomicWait32(effective_addr, expected, timeout) catch |err| switch (err) {
                     error.Trap => return error.Trap,
@@ -2851,8 +2854,9 @@ pub const Vm = struct {
             .memory_atomic_wait64 => {
                 const timeout: i64 = self.popI64();
                 const expected: i64 = self.popI64();
-                const addr: u32 = @bitCast(self.popI32());
-                const effective_addr = addr +% offset;
+                const addr: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+                const effective_addr, const ov = @addWithOverflow(addr, offset);
+                if (ov != 0) return error.OutOfBoundsMemoryAccess;
                 if (effective_addr % 8 != 0) return error.Trap; // unaligned atomic
                 const result = m.atomicWait64(effective_addr, expected, timeout) catch |err| switch (err) {
                     error.Trap => return error.Trap,
@@ -2950,32 +2954,38 @@ pub const Vm = struct {
 
     const RmwOp = enum { add, sub, @"and", @"or", xor, xchg };
 
-    fn atomicLoad(self: *Vm, comptime MemT: type, comptime ResultT: type, offset: u32, m: *WasmMemory) WasmError!void {
-        const addr: u32 = @bitCast(self.popI32());
-        if (@sizeOf(MemT) > 1 and (addr +% offset) % @sizeOf(MemT) != 0) return error.Trap;
+    fn atomicLoad(self: *Vm, comptime MemT: type, comptime ResultT: type, offset: u64, m: *WasmMemory) WasmError!void {
+        const addr: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+        const effective, const ov = @addWithOverflow(addr, offset);
+        if (ov != 0) return error.OutOfBoundsMemoryAccess;
+        if (@sizeOf(MemT) > 1 and effective % @sizeOf(MemT) != 0) return error.Trap;
         const val = m.read(MemT, offset, addr) catch return error.OutOfBoundsMemoryAccess;
         const result: ResultT = @intCast(val);
         try self.push(asU64(ResultT, result));
     }
 
-    fn atomicStore(self: *Vm, comptime MemT: type, comptime pop_type: enum { i32, i64 }, offset: u32, m: *WasmMemory) WasmError!void {
+    fn atomicStore(self: *Vm, comptime MemT: type, comptime pop_type: enum { i32, i64 }, offset: u64, m: *WasmMemory) WasmError!void {
         const val: MemT = switch (pop_type) {
             .i32 => @truncate(@as(u32, @bitCast(self.popI32()))),
             .i64 => @truncate(@as(u64, @bitCast(self.popI64()))),
         };
-        const addr: u32 = @bitCast(self.popI32());
-        if (@sizeOf(MemT) > 1 and (addr +% offset) % @sizeOf(MemT) != 0) return error.Trap;
+        const addr: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+        const effective, const ov = @addWithOverflow(addr, offset);
+        if (ov != 0) return error.OutOfBoundsMemoryAccess;
+        if (@sizeOf(MemT) > 1 and effective % @sizeOf(MemT) != 0) return error.Trap;
         m.write(MemT, offset, addr, val) catch return error.OutOfBoundsMemoryAccess;
     }
 
-    fn atomicRmw(self: *Vm, comptime MemT: type, comptime ResultT: type, comptime op: RmwOp, offset: u32, m: *WasmMemory) WasmError!void {
+    fn atomicRmw(self: *Vm, comptime MemT: type, comptime ResultT: type, comptime op: RmwOp, offset: u64, m: *WasmMemory) WasmError!void {
         const operand: MemT = switch (ResultT) {
             u32 => @truncate(@as(u32, @bitCast(self.popI32()))),
             u64 => @truncate(@as(u64, @bitCast(self.popI64()))),
             else => unreachable,
         };
-        const addr: u32 = @bitCast(self.popI32());
-        if (@sizeOf(MemT) > 1 and (addr +% offset) % @sizeOf(MemT) != 0) return error.Trap;
+        const addr: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+        const effective, const ov = @addWithOverflow(addr, offset);
+        if (ov != 0) return error.OutOfBoundsMemoryAccess;
+        if (@sizeOf(MemT) > 1 and effective % @sizeOf(MemT) != 0) return error.Trap;
         const old = m.read(MemT, offset, addr) catch return error.OutOfBoundsMemoryAccess;
         const new_val: MemT = switch (op) {
             .add => old +% operand,
@@ -2990,7 +3000,7 @@ pub const Vm = struct {
         try self.push(asU64(ResultT, result));
     }
 
-    fn atomicCmpxchg(self: *Vm, comptime MemT: type, comptime ResultT: type, offset: u32, m: *WasmMemory) WasmError!void {
+    fn atomicCmpxchg(self: *Vm, comptime MemT: type, comptime ResultT: type, offset: u64, m: *WasmMemory) WasmError!void {
         const replacement: MemT = switch (ResultT) {
             u32 => @truncate(@as(u32, @bitCast(self.popI32()))),
             u64 => @truncate(@as(u64, @bitCast(self.popI64()))),
@@ -3001,8 +3011,10 @@ pub const Vm = struct {
             u64 => @truncate(@as(u64, @bitCast(self.popI64()))),
             else => unreachable,
         };
-        const addr: u32 = @bitCast(self.popI32());
-        if (@sizeOf(MemT) > 1 and (addr +% offset) % @sizeOf(MemT) != 0) return error.Trap;
+        const addr: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+        const effective, const ov = @addWithOverflow(addr, offset);
+        if (ov != 0) return error.OutOfBoundsMemoryAccess;
+        if (@sizeOf(MemT) > 1 and effective % @sizeOf(MemT) != 0) return error.Trap;
         const loaded = m.read(MemT, offset, addr) catch return error.OutOfBoundsMemoryAccess;
         if (loaded == expected) {
             m.write(MemT, offset, addr, replacement) catch return error.OutOfBoundsMemoryAccess;
@@ -3022,14 +3034,14 @@ pub const Vm = struct {
             // ---- Memory operations (36.2) ----
             .v128_load => {
                 const ma = try readMemarg(reader, instance);
-                const base = @as(u32, @bitCast(self.popI32()));
+                const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
                 const val = ma.mem.read(u128, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
                 try self.pushV128(val);
             },
             .v128_store => {
                 const ma = try readMemarg(reader, instance);
                 const val = self.popV128();
-                const base = @as(u32, @bitCast(self.popI32()));
+                const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
                 ma.mem.write(u128, ma.offset, base, val) catch return error.OutOfBoundsMemoryAccess;
             },
             .v128_const => {
@@ -3042,28 +3054,28 @@ pub const Vm = struct {
             // Splat loads
             .v128_load8_splat => {
                 const ma = try readMemarg(reader, instance);
-                const base = @as(u32, @bitCast(self.popI32()));
+                const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
                 const val = ma.mem.read(u8, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
                 const vec: @Vector(16, u8) = @splat(val);
                 try self.pushV128(@bitCast(vec));
             },
             .v128_load16_splat => {
                 const ma = try readMemarg(reader, instance);
-                const base = @as(u32, @bitCast(self.popI32()));
+                const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
                 const val = ma.mem.read(u16, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
                 const vec: @Vector(8, u16) = @splat(val);
                 try self.pushV128(@bitCast(vec));
             },
             .v128_load32_splat => {
                 const ma = try readMemarg(reader, instance);
-                const base = @as(u32, @bitCast(self.popI32()));
+                const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
                 const val = ma.mem.read(u32, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
                 const vec: @Vector(4, u32) = @splat(val);
                 try self.pushV128(@bitCast(vec));
             },
             .v128_load64_splat => {
                 const ma = try readMemarg(reader, instance);
-                const base = @as(u32, @bitCast(self.popI32()));
+                const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
                 const val = ma.mem.read(u64, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
                 const vec: @Vector(2, u64) = @splat(val);
                 try self.pushV128(@bitCast(vec));
@@ -3080,13 +3092,13 @@ pub const Vm = struct {
             // Zero-extending loads
             .v128_load32_zero => {
                 const ma = try readMemarg(reader, instance);
-                const base = @as(u32, @bitCast(self.popI32()));
+                const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
                 const val = ma.mem.read(u32, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
                 try self.pushV128(@as(u128, val));
             },
             .v128_load64_zero => {
                 const ma = try readMemarg(reader, instance);
-                const base = @as(u32, @bitCast(self.popI32()));
+                const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
                 const val = ma.mem.read(u64, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
                 try self.pushV128(@as(u128, val));
             },
@@ -3958,12 +3970,12 @@ pub const Vm = struct {
     ) WasmError!void {
         const N = 16 / @sizeOf(WideT); // number of lanes
         const ma = try readMemarg(reader, instance);
-        const base = @as(u32, @bitCast(self.popI32()));
+        const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         const m = ma.mem;
         // Read N narrow values
         const byte_count = N * @sizeOf(NarrowT);
-        const effective = @as(u33, ma.offset) + @as(u33, base);
-        if (effective + byte_count > m.data.items.len) return error.OutOfBoundsMemoryAccess;
+        const effective, const ov = @addWithOverflow(ma.offset, base);
+        if (ov != 0 or m.data.items.len < byte_count or effective > m.data.items.len - byte_count) return error.OutOfBoundsMemoryAccess;
         var narrow: [N]NarrowT = undefined;
         for (&narrow, 0..) |*n, i| {
             const ptr: *const [@sizeOf(NarrowT)]u8 = @ptrCast(&m.data.items[effective + i * @sizeOf(NarrowT)]);
@@ -3988,9 +4000,8 @@ pub const Vm = struct {
         const ma = try readMemarg(reader, instance);
         const lane = try reader.readByte();
         var vec: @Vector(N, T) = @bitCast(self.popV128());
-        const base = @as(u32, @bitCast(self.popI32()));
-        const m = ma.mem;
-        const val = m.read(T, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
+        const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+        const val = ma.mem.read(T, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
         vec[lane] = val;
         try self.pushV128(@bitCast(vec));
     }
@@ -4006,9 +4017,8 @@ pub const Vm = struct {
         const ma = try readMemarg(reader, instance);
         const lane = try reader.readByte();
         const vec: @Vector(N, T) = @bitCast(self.popV128());
-        const base = @as(u32, @bitCast(self.popI32()));
-        const m = ma.mem;
-        m.write(T, ma.offset, base, vec[lane]) catch return error.OutOfBoundsMemoryAccess;
+        const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
+        ma.mem.write(T, ma.offset, base, vec[lane]) catch return error.OutOfBoundsMemoryAccess;
     }
 
     // SIMD helper: lane-wise comparison producing all-ones/all-zeros result
@@ -7570,8 +7580,8 @@ pub const Vm = struct {
     // ================================================================
 
     fn memLoadCached(self: *Vm, comptime LoadT: type, comptime ResultT: type, offset: u32, cached_mem: ?*WasmMemory) WasmError!void {
-        const base = @as(u32, @bitCast(self.popI32()));
         const m = cached_mem orelse return error.OutOfBoundsMemoryAccess;
+        const base: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         const val = m.read(LoadT, offset, base) catch return error.OutOfBoundsMemoryAccess;
         const result: ResultT = if (@bitSizeOf(LoadT) == @bitSizeOf(ResultT))
             @bitCast(val)
@@ -7581,8 +7591,8 @@ pub const Vm = struct {
     }
 
     fn memLoadFloatCached(self: *Vm, comptime T: type, offset: u32, cached_mem: ?*WasmMemory) WasmError!void {
-        const base = @as(u32, @bitCast(self.popI32()));
         const m = cached_mem orelse return error.OutOfBoundsMemoryAccess;
+        const base: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         const val = m.read(T, offset, base) catch return error.OutOfBoundsMemoryAccess;
         switch (T) {
             f32 => try self.pushF32(val),
@@ -7593,8 +7603,8 @@ pub const Vm = struct {
 
     fn memStoreCached(self: *Vm, comptime T: type, offset: u32, cached_mem: ?*WasmMemory) WasmError!void {
         const val: T = @truncate(self.pop());
-        const base = @as(u32, @bitCast(self.popI32()));
         const m = cached_mem orelse return error.OutOfBoundsMemoryAccess;
+        const base: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         m.write(T, offset, base, val) catch return error.OutOfBoundsMemoryAccess;
     }
 
@@ -7604,8 +7614,8 @@ pub const Vm = struct {
             f64 => self.popF64(),
             else => unreachable,
         };
-        const base = @as(u32, @bitCast(self.popI32()));
         const m = cached_mem orelse return error.OutOfBoundsMemoryAccess;
+        const base: u64 = if (m.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         m.write(T, offset, base, val) catch return error.OutOfBoundsMemoryAccess;
     }
 
@@ -7621,18 +7631,19 @@ pub const Vm = struct {
     // ================================================================
 
     /// Read memarg from bytecode stream, returning offset and resolved memory.
-    /// Handles multi-memory: bit 6 of alignment signals memidx follows.
-    fn readMemarg(reader: *Reader, instance: *Instance) !struct { offset: u32, mem: *WasmMemory } {
+    /// Handles multi-memory (bit 6 of alignment) and memory64 (u64 offset).
+    fn readMemarg(reader: *Reader, instance: *Instance) !struct { offset: u64, mem: *WasmMemory } {
         const align_flags = try reader.readU32();
         const memidx: u16 = if (align_flags & 0x40 != 0) @intCast(try reader.readU32()) else 0;
-        const offset = try reader.readU32();
         const m = instance.getMemory(memidx) catch return error.OutOfBoundsMemoryAccess;
+        // memory64: offset is u64 LEB128
+        const offset: u64 = if (m.is_64) try reader.readU64() else try reader.readU32();
         return .{ .offset = offset, .mem = m };
     }
 
     fn memLoad(self: *Vm, comptime LoadT: type, comptime ResultT: type, reader: *Reader, instance: *Instance) WasmError!void {
         const ma = try readMemarg(reader, instance);
-        const base = @as(u32, @bitCast(self.popI32()));
+        const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         const val = ma.mem.read(LoadT, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
         const result: ResultT = if (@bitSizeOf(LoadT) == @bitSizeOf(ResultT))
             @bitCast(val)
@@ -7643,7 +7654,7 @@ pub const Vm = struct {
 
     fn memLoadFloat(self: *Vm, comptime T: type, reader: *Reader, instance: *Instance) WasmError!void {
         const ma = try readMemarg(reader, instance);
-        const base = @as(u32, @bitCast(self.popI32()));
+        const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         const val = ma.mem.read(T, ma.offset, base) catch return error.OutOfBoundsMemoryAccess;
         switch (T) {
             f32 => try self.pushF32(val),
@@ -7655,7 +7666,7 @@ pub const Vm = struct {
     fn memStore(self: *Vm, comptime T: type, reader: *Reader, instance: *Instance) WasmError!void {
         const ma = try readMemarg(reader, instance);
         const val: T = @truncate(self.pop());
-        const base = @as(u32, @bitCast(self.popI32()));
+        const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         ma.mem.write(T, ma.offset, base, val) catch return error.OutOfBoundsMemoryAccess;
     }
 
@@ -7666,14 +7677,14 @@ pub const Vm = struct {
             f64 => self.popF64(),
             else => unreachable,
         };
-        const base = @as(u32, @bitCast(self.popI32()));
+        const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         ma.mem.write(T, ma.offset, base, val) catch return error.OutOfBoundsMemoryAccess;
     }
 
     fn memStoreTrunc(self: *Vm, comptime StoreT: type, comptime _: type, reader: *Reader, instance: *Instance) WasmError!void {
         const ma = try readMemarg(reader, instance);
         const val: StoreT = @truncate(self.pop());
-        const base = @as(u32, @bitCast(self.popI32()));
+        const base: u64 = if (ma.mem.is_64) self.popU64() else @as(u32, @bitCast(self.popI32()));
         ma.mem.write(StoreT, ma.offset, base, val) catch return error.OutOfBoundsMemoryAccess;
     }
 


### PR DESCRIPTION
## Summary

- Fix memory64 u64 LEB128 offset decoding across decoder, validator, predecoder, and VM
- Fix memory64 i64 address popping for all memory operations (load/store/atomic/SIMD)
- Add overflow detection in Memory.read/write for memory64 effective address computation

Fixes CI failures introduced by wasm-tools 1.246.1 bump (PR #21) which correctly encodes memory64 offsets as u64.

## Test plan

- [x] `zig build test` — Mac + Ubuntu (0 fail, 0 leak)
- [x] Spec tests — 62,263/62,263 (100%, 0 skip) — Mac + Ubuntu
- [x] E2E tests — 795/795 Mac, 792/792 Ubuntu (3 new tests from updated wasmtime)
- [x] Real-world compat — 50/50 Mac + Ubuntu
- [x] FFI tests — 68/68 Mac + Ubuntu
- [x] Minimal build — Mac + Ubuntu