### PR TITLE
Add -Dpic and -Dcompiler-rt build options for static library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,17 @@ jobs:
           rustup target add wasm32-wasip1
           rustc --version
 
-      - name: Run Rust FFI example
+      - name: Run Rust FFI example (dynamic)
         if: runner.os != 'Windows'
         run: cd examples/rust && cargo run
+
+      - name: Build static library (PIC + compiler_rt)
+        if: runner.os != 'Windows'
+        run: zig build static-lib -Dpic=true -Dcompiler-rt=true
+
+      - name: Run static link tests
+        if: runner.os != 'Windows'
+        run: bash test/c_api/run_static_link_test.sh
 
       - name: Install wasm-tools
         run: |

--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,10 @@ pub fn build(b: *std.Build) void {
     const enable_threads = b.option(bool, "threads", "Enable threads/atomics (default: true)") orelse true;
     const enable_component = b.option(bool, "component", "Enable component model (default: true)") orelse true;
 
+    // Static library options — needed when linking libzwasm.a from non-Zig toolchains
+    const enable_pic = b.option(bool, "pic", "Enable Position Independent Code for static library") orelse false;
+    const bundle_compiler_rt = b.option(bool, "compiler-rt", "Bundle compiler_rt into static library") orelse false;
+
     const build_zon = @import("build.zig.zon");
 
     const options = b.addOptions();
@@ -167,6 +171,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = if (lib_optimize) optimize else if (optimize == .Debug) .ReleaseSafe else optimize,
         .link_libc = true,
+        .pic = if (enable_pic) true else null,
     });
     lib_static_mod.addOptions("build_options", options);
     const lib_static = b.addLibrary(.{
@@ -174,6 +179,7 @@ pub fn build(b: *std.Build) void {
         .name = "zwasm",
         .root_module = lib_static_mod,
     });
+    lib_static.bundle_compiler_rt = bundle_compiler_rt;
     lib_static.installHeader(b.path("include/zwasm.h"), "zwasm.h");
 
     // Separate steps to avoid Zig 0.15.2 build graph shuffle bug

--- a/examples/rust/build.rs
+++ b/examples/rust/build.rs
@@ -10,7 +10,21 @@ fn main() {
         .canonicalize()
         .expect("zig-out/lib not found — run `zig build lib` first");
 
-    println!("cargo:rustc-link-search=native={}", lib_dir.display());
-    println!("cargo:rustc-link-lib=zwasm");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lib_dir.display());
+    if env::var("ZWASM_STATIC").is_ok() {
+        // Static linking: requires libzwasm.a built with -Dpic=true -Dcompiler-rt=true
+        // Copy only the .a to a temp dir to prevent the linker from picking the .dylib/.so
+        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let static_dir = out_dir.join("zwasm_static");
+        std::fs::create_dir_all(&static_dir).unwrap();
+        std::fs::copy(lib_dir.join("libzwasm.a"), static_dir.join("libzwasm.a")).unwrap();
+        println!("cargo:rustc-link-search=native={}", static_dir.display());
+        println!("cargo:rustc-link-lib=static=zwasm");
+        println!("cargo:rustc-link-lib=c");
+        println!("cargo:rustc-link-lib=m");
+    } else {
+        // Dynamic linking (default)
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        println!("cargo:rustc-link-lib=zwasm");
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lib_dir.display());
+    }
 }

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -10,7 +10,7 @@ struct zwasm_module_t {
     _private: [u8; 0],
 }
 
-#[link(name = "zwasm")]
+// Linking is handled by build.rs (supports both static and dynamic)
 unsafe extern "C" {
     fn zwasm_module_new(wasm_ptr: *const u8, len: usize) -> *mut zwasm_module_t;
     fn zwasm_module_invoke(

--- a/test/c_api/run_static_link_test.sh
+++ b/test/c_api/run_static_link_test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# run_static_link_test.sh — Test linking libzwasm.a from non-Zig toolchains
+#
+# Simulates real-world usage: build static lib with PIC + compiler_rt,
+# then link with system cc and cargo (Rust) directly.
+#
+# Usage:
+#   bash test/c_api/run_static_link_test.sh [--build]
+#
+# Options:
+#   --build   Force rebuild of static library (default: skip if exists)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+BUILD=false
+for arg in "$@"; do
+    case "$arg" in
+        --build) BUILD=true ;;
+    esac
+done
+
+LIB="zig-out/lib/libzwasm.a"
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"; }
+
+# --- Build static library with PIC + compiler_rt ---
+if $BUILD || [ ! -f "$LIB" ]; then
+    echo "Building static library (PIC + compiler_rt)..."
+    zig build static-lib -Dpic=true -Dcompiler-rt=true
+fi
+
+echo ""
+echo "=== Static Link Tests ==="
+echo ""
+
+# --- Test 1: C direct link with system cc ---
+echo "[1/3] C direct link (cc)"
+TMPBIN=$(mktemp /tmp/zwasm_static_XXXXXX)
+if cc -o "$TMPBIN" examples/c/hello.c -Iinclude "$LIB" -lc -lm 2>/tmp/zwasm_cc_err.txt; then
+    OUTPUT=$("$TMPBIN" 2>&1)
+    if [ "$OUTPUT" = "f() = 42" ]; then
+        pass "cc link + run"
+    else
+        fail "cc link ok but output='$OUTPUT' (expected 'f() = 42')"
+    fi
+else
+    fail "cc link failed: $(cat /tmp/zwasm_cc_err.txt)"
+fi
+rm -f "$TMPBIN" /tmp/zwasm_cc_err.txt
+
+# --- Test 2: C direct link with system cc (PIE) ---
+echo "[2/3] C direct link (cc -pie)"
+TMPBIN=$(mktemp /tmp/zwasm_static_XXXXXX)
+PIE_FLAG=""
+if [[ "$(uname)" != "Darwin" ]]; then
+    PIE_FLAG="-pie"
+fi
+if cc $PIE_FLAG -o "$TMPBIN" examples/c/hello.c -Iinclude "$LIB" -lc -lm 2>/tmp/zwasm_cc_pie_err.txt; then
+    OUTPUT=$("$TMPBIN" 2>&1)
+    if [ "$OUTPUT" = "f() = 42" ]; then
+        pass "cc PIE link + run"
+    else
+        fail "cc PIE link ok but output='$OUTPUT' (expected 'f() = 42')"
+    fi
+else
+    fail "cc PIE link failed: $(cat /tmp/zwasm_cc_pie_err.txt)"
+fi
+rm -f "$TMPBIN" /tmp/zwasm_cc_pie_err.txt
+
+# --- Test 3: Rust static link (cargo) ---
+echo "[3/3] Rust static link (cargo)"
+if command -v cargo >/dev/null 2>&1; then
+    # Clean to avoid stale cached dylib-linked binary
+    cargo clean --manifest-path examples/rust/Cargo.toml 2>/dev/null || true
+    if ZWASM_STATIC=1 cargo build --manifest-path examples/rust/Cargo.toml 2>/tmp/zwasm_cargo_err.txt; then
+        OUTPUT=$(ZWASM_STATIC=1 cargo run --manifest-path examples/rust/Cargo.toml 2>&1)
+        if echo "$OUTPUT" | grep -q "f() = 42"; then
+            pass "cargo static link + run"
+        else
+            fail "cargo build ok but output='$OUTPUT' (expected 'f() = 42')"
+        fi
+    else
+        fail "cargo build failed: $(cat /tmp/zwasm_cargo_err.txt)"
+    fi
+    rm -f /tmp/zwasm_cargo_err.txt
+else
+    echo "  SKIP: cargo not found"
+fi
+
+# --- Summary ---
+echo ""
+echo "=== Summary: $PASS passed, $FAIL failed (of $TOTAL) ==="
+
+exit $FAIL


### PR DESCRIPTION
## Summary

- Add `-Dpic` and `-Dcompiler-rt` build options to `build.zig` for static library (`libzwasm.a`)
- Linking from non-Zig toolchains (`cc`, `cargo`) on Linux fails without these due to missing PIC relocations and `__zig_probe_stack`/`fmaf` symbols
- Add real-world static link test script covering C direct link, C PIE, and Rust cargo static linking
- Add static link tests to CI (macOS + Ubuntu)

Usage: `zig build static-lib -Dpic=true -Dcompiler-rt=true`

Closes #23

## Test plan

- [x] Reproduced link failure on Ubuntu x86_64 without options
- [x] Verified fix on macOS ARM64 (3/3 pass: cc, cc PIE, cargo static)
- [x] Verified fix on Ubuntu x86_64 (3/3 pass: cc, cc PIE, cargo static)
- [x] Existing tests unaffected (unit tests, c-test, FFI 68/68, Rust dynamic)