### PR TITLE
Refactor module loading API using Config-based entrypoint

### DIFF
--- a/docs/api-boundary.md
+++ b/docs/api-boundary.md
@@ -12,6 +12,7 @@ Types and functions listed here are covered by SemVer guarantees.
 | `WasmValType` | Enum of Wasm value types (i32, i64, f32, f64, v128, funcref, externref) | v0.1.0 |
 | `ExportInfo` | Metadata for an exported function (name, param/result types) | v0.1.0 |
 | `ImportEntry` | Maps an import module name to a source | v0.2.0 |
+| `WasmModule.Config`| Unified loading configuration | vNEXT |
 | `ImportSource` | Union: wasm_module or host_fns | v0.2.0 |
 | `HostFnEntry` | A single host function (name, callback, context) | v0.2.0 |
 | `HostFn` | Function type: `fn (*anyopaque, usize) anyerror!void` | v0.2.0 |
@@ -26,12 +27,13 @@ Types and functions listed here are covered by SemVer guarantees.
 
 | Method | Signature | Since |
 |--------|-----------|-------|
+| `loadWithOptions` | `(Allocator, []const u8, Config) !*WasmModule` | vNEXT |
 | `load` | `(Allocator, []const u8) !*WasmModule` | v0.1.0 |
 | `loadFromWat` | `(Allocator, []const u8) !*WasmModule` | v0.2.0 |
 | `loadWasi` | `(Allocator, []const u8) !*WasmModule` | v0.2.0 |
 | `loadWasiWithOptions` | `(Allocator, []const u8, WasiOptions) !*WasmModule` | v0.2.0 |
-| `loadWithImports` | `(Allocator, []const u8, []const ImportEntry) !*WasmModule` | v0.2.0 |
-| `loadWasiWithImports` | `(Allocator, []const u8, []const ImportEntry, WasiOptions) !*WasmModule` | v0.2.0 |
+| `loadWithImports` | `(Allocator, []const u8, ?[]const ImportEntry) !*WasmModule` | v0.2.0 |
+| `loadWasiWithImports` | `(Allocator, []const u8, ?[]const ImportEntry, WasiOptions) !*WasmModule` | v0.2.0 |
 | `loadWithFuel` | `(Allocator, []const u8, u64) !*WasmModule` | v0.3.0 |
 | `deinit` | `(*WasmModule) void` | v0.1.0 |
 | `invoke` | `(*WasmModule, []const u8, []u64, []u64) !void` | v0.1.0 |

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -208,7 +208,7 @@ Key function groups:
 
 | Group | Functions |
 |-------|-----------|
-| Config | `zwasm_config_new`, `zwasm_config_delete`, `zwasm_config_set_allocator` |
+| Config | `zwasm_config_new`, `zwasm_config_delete`, `zwasm_config_set_allocator`, `zwasm_config_set_fuel`, `..._set_timeout`, `..._set_max_memory`, `..._set_force_interpreter` |
 | Module | `zwasm_module_new`, `zwasm_module_new_configured`, `zwasm_module_delete` |
 | WASI | `zwasm_module_new_wasi`, `zwasm_module_new_wasi_configured2` |
 | Invoke | `zwasm_module_invoke`, `zwasm_module_invoke_start` |

--- a/include/zwasm.h
+++ b/include/zwasm.h
@@ -93,6 +93,26 @@ void zwasm_config_set_allocator(zwasm_config_t *config,
                                 zwasm_alloc_fn_t alloc_fn,
                                 zwasm_free_fn_t free_fn, void *ctx);
 
+/**
+ * Set the instruction fuel limit. Traps when exhausted.
+ */
+void zwasm_config_set_fuel(zwasm_config_t *config, uint64_t fuel);
+
+/**
+ * Set the execution timeout in milliseconds.
+ */
+void zwasm_config_set_timeout(zwasm_config_t *config, uint64_t timeout_ms);
+
+/**
+ * Set the memory ceiling in bytes (limits memory.grow).
+ */
+void zwasm_config_set_max_memory(zwasm_config_t *config, uint64_t max_memory_bytes);
+
+/**
+ * Force the use of the interpreter only (bypass RegIR and JIT).
+ */
+void zwasm_config_set_force_interpreter(zwasm_config_t *config, bool force_interpreter);
+
 /* ================================================================
  * Module lifecycle
  * ================================================================ */

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -93,6 +93,11 @@ const CAllocatorWrapper = struct {
 const CApiConfig = struct {
     c_alloc: ?*CAllocatorWrapper = null,
 
+    fuel: ?u64 = null,
+    timeout_ms: ?u64 = null,
+    max_memory_bytes: ?u64 = null,
+    force_interpreter: ?bool = null,
+
     fn deinit(self: *CApiConfig) void {
         if (self.c_alloc) |ca| page_alloc.destroy(ca);
     }
@@ -101,6 +106,16 @@ const CApiConfig = struct {
     fn getAllocator(self: *CApiConfig) ?std.mem.Allocator {
         if (self.c_alloc) |ca| return ca.allocator();
         return null;
+    }
+
+    /// Build a WasmModule.Config from this C API config.
+    fn toModuleConfig(self: *CApiConfig) types.WasmModule.Config {
+        return .{
+            .fuel = self.fuel,
+            .timeout_ms = self.timeout_ms,
+            .max_memory_bytes = self.max_memory_bytes,
+            .force_interpreter = self.force_interpreter,
+        };
     }
 };
 
@@ -126,40 +141,42 @@ const CApiModule = struct {
     module: *WasmModule,
 
     fn create(wasm_bytes: []const u8, wasi: bool) !*CApiModule {
-        return createWithAllocator(wasm_bytes, wasi, null);
+        return createConfigured(wasm_bytes, wasi, null);
     }
 
-    fn createWithAllocator(wasm_bytes: []const u8, wasi: bool, custom_alloc: ?std.mem.Allocator) !*CApiModule {
+    fn createConfigured(wasm_bytes: []const u8, wasi: bool, config: ?*CApiConfig) !*CApiModule {
         const self = try std.heap.page_allocator.create(CApiModule);
         errdefer std.heap.page_allocator.destroy(self);
 
-        const allocator = custom_alloc orelse default_allocator;
+        const allocator = if (config) |c| c.getAllocator() orelse default_allocator else default_allocator;
+        var mod_cfg = if (config) |c| c.toModuleConfig() else types.WasmModule.Config{};
+        mod_cfg.wasi = wasi;
 
-        self.module = if (wasi)
-            try WasmModule.loadWasi(allocator, wasm_bytes)
-        else
-            try WasmModule.load(allocator, wasm_bytes);
+        self.module = try WasmModule.loadWithOptions(allocator, wasm_bytes, mod_cfg);
         return self;
     }
 
     fn createWasiConfigured(wasm_bytes: []const u8, opts: WasiOptions) !*CApiModule {
-        return createWasiConfiguredWithAllocator(wasm_bytes, opts, null);
+        return createWasiConfiguredEx(wasm_bytes, opts, null);
     }
 
-    fn createWasiConfiguredWithAllocator(wasm_bytes: []const u8, opts: WasiOptions, custom_alloc: ?std.mem.Allocator) !*CApiModule {
+    fn createWasiConfiguredEx(wasm_bytes: []const u8, opts: WasiOptions, config: ?*CApiConfig) !*CApiModule {
         const self = try std.heap.page_allocator.create(CApiModule);
         errdefer std.heap.page_allocator.destroy(self);
 
-        const allocator = custom_alloc orelse default_allocator;
+        const allocator = if (config) |c| c.getAllocator() orelse default_allocator else default_allocator;
+        var mod_cfg = if (config) |c| c.toModuleConfig() else types.WasmModule.Config{};
+        mod_cfg.wasi = true;
+        mod_cfg.wasi_options = opts;
 
-        self.module = try WasmModule.loadWasiWithOptions(allocator, wasm_bytes, opts);
+        self.module = try WasmModule.loadWithOptions(allocator, wasm_bytes, mod_cfg);
         return self;
     }
 
     fn createWithImports(wasm_bytes: []const u8, imports: []const types.ImportEntry) !*CApiModule {
         const self = try std.heap.page_allocator.create(CApiModule);
         errdefer std.heap.page_allocator.destroy(self);
-        self.module = try WasmModule.loadWithImports(default_allocator, wasm_bytes, imports);
+        self.module = try WasmModule.loadWithOptions(default_allocator, wasm_bytes, .{ .imports = imports });
         return self;
     }
 
@@ -281,6 +298,22 @@ export fn zwasm_config_set_allocator(
     config.c_alloc = wrapper;
 }
 
+export fn zwasm_config_set_fuel(config: *zwasm_config_t, fuel: u64) void {
+    config.fuel = fuel;
+}
+
+export fn zwasm_config_set_timeout(config: *zwasm_config_t, timeout_ms: u64) void {
+    config.timeout_ms = timeout_ms;
+}
+
+export fn zwasm_config_set_max_memory(config: *zwasm_config_t, max_memory_bytes: u64) void {
+    config.max_memory_bytes = max_memory_bytes;
+}
+
+export fn zwasm_config_set_force_interpreter(config: *zwasm_config_t, force_interpreter: bool) void {
+    config.force_interpreter = force_interpreter;
+}
+
 // ============================================================
 // Module lifecycle
 // ============================================================
@@ -309,8 +342,7 @@ export fn zwasm_module_new_wasi(wasm_ptr: [*]const u8, len: usize) ?*zwasm_modul
 /// Pass null for config to use default allocator (same as zwasm_module_new).
 export fn zwasm_module_new_configured(wasm_ptr: [*]const u8, len: usize, config: ?*zwasm_config_t) ?*zwasm_module_t {
     clearError();
-    const custom_alloc = if (config) |c| c.getAllocator() else null;
-    return CApiModule.createWithAllocator(wasm_ptr[0..len], false, custom_alloc) catch |err| {
+    return CApiModule.createConfigured(wasm_ptr[0..len], false, config) catch |err| {
         setError(err);
         return null;
     };
@@ -395,8 +427,7 @@ export fn zwasm_module_new_wasi_configured2(
         .stdio_ownership = stdio_ownership2,
     };
 
-    const custom_alloc = if (config) |c| c.getAllocator() else null;
-    return CApiModule.createWasiConfiguredWithAllocator(wasm_ptr[0..len], opts, custom_alloc) catch |err| {
+    return CApiModule.createWasiConfiguredEx(wasm_ptr[0..len], opts, config) catch |err| {
         setError(err);
         return null;
     };
@@ -1171,4 +1202,24 @@ test "c_api: module_new_wasi_configured2 with null config" {
     const module = zwasm_module_new_wasi_configured2(MINIMAL_WASM.ptr, MINIMAL_WASM.len, wasi_config, null);
     try testing.expect(module != null);
     zwasm_module_delete(module.?);
+}
+
+test "c_api: config set vm limits" {
+    const config = zwasm_config_new().?;
+    defer zwasm_config_delete(config);
+
+    zwasm_config_set_fuel(config, 9999);
+    zwasm_config_set_timeout(config, 1000);
+    zwasm_config_set_max_memory(config, 65536);
+    zwasm_config_set_force_interpreter(config, true);
+
+    const module = zwasm_module_new_configured(MINIMAL_WASM.ptr, MINIMAL_WASM.len, config);
+    try testing.expect(module != null);
+    defer zwasm_module_delete(module.?);
+
+    const mod = &module.?.module.*;
+    try testing.expectEqual(@as(?u64, 9999), mod.vm.fuel);
+    try testing.expectEqual(@as(?u64, 65536), mod.vm.max_memory_bytes);
+    try testing.expectEqual(true, mod.vm.force_interpreter);
+    try testing.expect(mod.vm.deadline_ns != null);
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -309,6 +309,13 @@ fn cmdRun(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Writer
         func_args_start = args.len;
     }
 
+    const base_cfg = types.WasmModule.Config{
+        .fuel = fuel,
+        .timeout_ms = timeout_ms,
+        .max_memory_bytes = max_memory_bytes,
+        .force_interpreter = force_interpreter,
+    };
+
     const path = wasm_path orelse {
         try stderr.print("error: no wasm file specified\n", .{});
         try stderr.flush();
@@ -349,22 +356,25 @@ fn cmdRun(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Writer
             return false;
         };
         // Load with already-loaded linked modules as imports (transitive chains)
-        const lm = if (import_entries.items.len > 0)
-            types.WasmModule.loadWithImports(allocator, link_bytes, import_entries.items) catch
-                // Retry without imports if the linked module doesn't need them
-                types.WasmModule.load(allocator, link_bytes) catch |err| {
-                allocator.free(link_bytes);
-                try stderr.print("error: failed to load linked module '{s}': {s}\n", .{ lpath, formatWasmError(err) });
-                try stderr.flush();
-                return false;
+        var cfg = base_cfg;
+        cfg.imports = import_entries.items;
+        const lm = types.WasmModule.loadWithOptions(allocator, link_bytes, cfg) catch |err| blk: {
+            // Retry without imports if the linked module doesn't need them
+            if (err == error.ImportNotFound and cfg.imports.len > 0) {
+                var retry_cfg = base_cfg;
+                retry_cfg.imports = &.{};
+                break :blk types.WasmModule.loadWithOptions(allocator, link_bytes, retry_cfg) catch |retry_err| {
+                    allocator.free(link_bytes);
+                    try stderr.print("error: failed to load linked module '{s}': {s}\n", .{ lpath, formatWasmError(retry_err) });
+                    try stderr.flush();
+                    return false;
+                };
             }
-        else
-            types.WasmModule.load(allocator, link_bytes) catch |err| {
-                allocator.free(link_bytes);
-                try stderr.print("error: failed to load linked module '{s}': {s}\n", .{ lpath, formatWasmError(err) });
-                try stderr.flush();
-                return false;
-            };
+            allocator.free(link_bytes);
+            try stderr.print("error: failed to load linked module '{s}': {s}\n", .{ lpath, formatWasmError(err) });
+            try stderr.flush();
+            return false;
+        };
         try linked_bytes.append(allocator, link_bytes);
         try linked_modules.append(allocator, lm);
         try import_entries.append(allocator, .{
@@ -374,7 +384,7 @@ fn cmdRun(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Writer
     }
 
     if (batch_mode) {
-        return cmdBatch(allocator, wasm_bytes, import_entries.items, link_names.items, linked_modules.items, stdout, stderr, trace_categories, dump_regir_func, dump_jit_func);
+        return cmdBatch(allocator, wasm_bytes, import_entries.items, link_names.items, linked_modules.items, stdout, stderr, trace_categories, dump_regir_func, dump_jit_func, base_cfg);
     }
 
     const imports_slice: ?[]const types.ImportEntry = if (import_entries.items.len > 0)
@@ -395,11 +405,22 @@ fn cmdRun(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Writer
         };
 
         const module = load_blk: {
-            if (imports_slice != null) {
+            const wasi_cfg = blk: {
+                var c = base_cfg;
+                c.wasi = true;
+                c.wasi_options = wasi_opts;
+                break :blk c;
+            };
+
+            if (import_entries.items.len > 0) {
                 // With --link: try imports only, then imports + WASI
-                break :load_blk types.WasmModule.loadWithImports(allocator, wasm_bytes, imports_slice.?) catch |err| {
+                var imports_only_cfg = base_cfg;
+                imports_only_cfg.imports = imports_slice.?;
+                break :load_blk types.WasmModule.loadWithOptions(allocator, wasm_bytes, imports_only_cfg) catch |err| {
                     if (err == error.ImportNotFound) {
-                        break :load_blk types.WasmModule.loadWasiWithImports(allocator, wasm_bytes, imports_slice, wasi_opts) catch |err2| {
+                        var imports_wasi_cfg = wasi_cfg;
+                        imports_wasi_cfg.imports = imports_slice.?;
+                        break :load_blk types.WasmModule.loadWithOptions(allocator, wasm_bytes, imports_wasi_cfg) catch |err2| {
                             try stderr.print("error: failed to load module: {s}\n", .{formatWasmError(err2)});
                             try stderr.flush();
                             return false;
@@ -411,9 +432,10 @@ fn cmdRun(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Writer
                 };
             }
             // No --link: try plain, then WASI
-            break :load_blk types.WasmModule.load(allocator, wasm_bytes) catch |err| {
+            const plain_cfg = base_cfg;
+            break :load_blk types.WasmModule.loadWithOptions(allocator, wasm_bytes, plain_cfg) catch |err| {
                 if (err == error.ImportNotFound) {
-                    break :load_blk types.WasmModule.loadWasiWithOptions(allocator, wasm_bytes, wasi_opts) catch |err2| {
+                    break :load_blk types.WasmModule.loadWithOptions(allocator, wasm_bytes, wasi_cfg) catch |err2| {
                         try stderr.print("error: failed to load module: {s}\n", .{formatWasmError(err2)});
                         try stderr.flush();
                         return false;
@@ -455,12 +477,6 @@ fn cmdRun(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Writer
         if (trace_categories != 0 or dump_regir_func != null or dump_jit_func != null) {
             module.vm.trace = &trace_config;
         }
-
-        // Apply resource limits
-        module.vm.max_memory_bytes = max_memory_bytes;
-        module.fuel = fuel;
-        module.timeout_ms = timeout_ms;
-        module.force_interpreter = force_interpreter;
 
         // Lookup export info for type-aware parsing and validation
         const export_info = module.getExportInfo(func_name);
@@ -564,15 +580,20 @@ fn cmdRun(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Writer
             try wasi_args_list.append(allocator, @ptrCast(a));
         }
 
-        // Run as WASI module (_start), with --link imports if provided
-        const wasi_opts2: types.WasiOptions = .{
+        const wasi_opts: types.WasiOptions = .{
             .args = wasi_args_list.items,
             .env_keys = env_keys.items,
             .env_vals = env_vals.items,
             .preopen_paths = preopen_paths.items,
             .caps = caps,
         };
-        var module = types.WasmModule.loadWasiWithImports(allocator, wasm_bytes, imports_slice, wasi_opts2) catch |err| {
+
+        // Run as WASI module (_start), with --link imports if provided
+        var cfg = base_cfg;
+        cfg.wasi = true;
+        cfg.wasi_options = wasi_opts;
+        cfg.imports = imports_slice orelse &.{};
+        var module = types.WasmModule.loadWithOptions(allocator, wasm_bytes, cfg) catch |err| {
             try stderr.print("error: failed to load WASI module: {s}\n", .{formatWasmError(err)});
             try stderr.flush();
             return false;
@@ -604,12 +625,6 @@ fn cmdRun(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Writer
         if (trace_categories != 0 or dump_regir_func != null or dump_jit_func != null) {
             module.vm.trace = &wasi_trace_config;
         }
-
-        // Apply resource limits
-        module.vm.max_memory_bytes = max_memory_bytes;
-        module.fuel = fuel;
-        module.timeout_ms = timeout_ms;
-        module.force_interpreter = force_interpreter;
 
         var no_args = [_]u64{};
         var no_results = [_]u64{};
@@ -671,7 +686,7 @@ fn cmdCompile(allocator: Allocator, args: []const []const u8, stdout: *std.Io.Wr
     defer allocator.free(wasm_bytes);
 
     // Load module (with WASI to handle any imports)
-    var module = types.WasmModule.loadWasi(allocator, wasm_bytes) catch |err| {
+    var module = types.WasmModule.loadWithOptions(allocator, wasm_bytes, .{ .wasi = true }) catch |err| {
         try stderr.print("error: failed to load module: {s}\n", .{formatWasmError(err)});
         try stderr.flush();
         return false;
@@ -1234,20 +1249,15 @@ fn threadRunner(ctx: *ThreadCtx) void {
 /// Batch mode: read invocations from stdin, one per line.
 /// Protocol: "invoke <func> [arg1 arg2 ...]"
 /// Output: "ok [val1 val2 ...]" or "error <message>"
-fn cmdBatch(allocator: Allocator, wasm_bytes: []const u8, imports: []const types.ImportEntry, link_names: []const []const u8, linked_modules: []const *types.WasmModule, stdout: *std.Io.Writer, stderr: *std.Io.Writer, trace_categories: u8, dump_regir_func: ?u32, dump_jit_func: ?u32) !bool {
+fn cmdBatch(allocator: Allocator, wasm_bytes: []const u8, imports: []const types.ImportEntry, link_names: []const []const u8, linked_modules: []const *types.WasmModule, stdout: *std.Io.Writer, stderr: *std.Io.Writer, trace_categories: u8, dump_regir_func: ?u32, dump_jit_func: ?u32, base_cfg: types.WasmModule.Config) !bool {
     _ = stderr;
-    var module = if (imports.len > 0)
-        types.WasmModule.loadWithImports(allocator, wasm_bytes, imports) catch |err| {
-            try stdout.print("error load {s}\n", .{@errorName(err)});
-            try stdout.flush();
-            return false;
-        }
-    else
-        types.WasmModule.load(allocator, wasm_bytes) catch |err| {
-            try stdout.print("error load {s}\n", .{@errorName(err)});
-            try stdout.flush();
-            return false;
-        };
+    var cfg = base_cfg;
+    cfg.imports = imports;
+    var module = types.WasmModule.loadWithOptions(allocator, wasm_bytes, cfg) catch |err| {
+        try stdout.print("error load {s}\n", .{@errorName(err)});
+        try stdout.flush();
+        return false;
+    };
     defer module.deinit();
 
     // Enable tracing if requested

--- a/src/component.zig
+++ b/src/component.zig
@@ -1144,7 +1144,7 @@ pub const ComponentInstance = struct {
     pub fn instantiate(self: *ComponentInstance) !void {
         // Phase 1: Load embedded core modules
         for (self.comp.core_modules.items) |mod_bytes| {
-            const m = try types.WasmModule.load(self.alloc, mod_bytes);
+            const m = try types.WasmModule.loadWithOptions(self.alloc, mod_bytes, .{});
             self.core_modules.append(self.alloc, m) catch return error.OutOfMemory;
         }
 
@@ -1164,9 +1164,9 @@ pub const ComponentInstance = struct {
         // Phase 1: Load embedded core modules with imports
         for (self.comp.core_modules.items) |mod_bytes| {
             const m = if (imports.len > 0)
-                try types.WasmModule.loadWithImports(self.alloc, mod_bytes, imports)
+                try types.WasmModule.loadWithOptions(self.alloc, mod_bytes, .{ .imports = imports })
             else
-                try types.WasmModule.load(self.alloc, mod_bytes);
+                try types.WasmModule.loadWithOptions(self.alloc, mod_bytes, .{});
             self.core_modules.append(self.alloc, m) catch return error.OutOfMemory;
         }
 

--- a/src/fuzz_gen.zig
+++ b/src/fuzz_gen.zig
@@ -1721,7 +1721,7 @@ fn loadAndExercise(alloc: Allocator, wasm: []const u8) void {
 
         // Call multiple times to trigger JIT compilation
         for (0..FUZZ_JIT_CALLS) |_| {
-            module.vm.fuel = FUZZ_FUEL;
+            module.fuel = FUZZ_FUEL;
             module.invoke(ei.name, arg_slice, result_slice) catch break;
         }
     }

--- a/src/fuzz_loader.zig
+++ b/src/fuzz_loader.zig
@@ -79,7 +79,7 @@ fn fuzzOne(allocator: std.mem.Allocator, input: []const u8) void {
 
         // Call multiple times to trigger JIT compilation
         for (0..JIT_CALLS) |_| {
-            module.vm.fuel = FUEL_LIMIT;
+            module.fuel = FUEL_LIMIT;
             module.invoke(ei.name, arg_slice, result_slice) catch break;
         }
     }

--- a/src/fuzz_wat_loader.zig
+++ b/src/fuzz_wat_loader.zig
@@ -64,7 +64,7 @@ fn fuzzOne(allocator: std.mem.Allocator, wat_source: []const u8) void {
 
         // Call multiple times to trigger JIT compilation
         for (0..JIT_CALLS) |_| {
-            module.vm.fuel = FUEL_LIMIT;
+            module.fuel = FUEL_LIMIT;
             module.invoke(ei.name, arg_slice, result_slice) catch break;
         }
     }

--- a/src/types.zig
+++ b/src/types.zig
@@ -232,24 +232,41 @@ pub const WasmModule = struct {
     vm: *rt.vm_mod.Vm = undefined,
     /// Owned wasm bytes (from WAT conversion). Freed on deinit.
     owned_wasm_bytes: ?[]const u8 = null,
-
-    /// Persistent fuel budget.
+    /// Persistent fuel budget from Config. Decremented across all invocations.
     fuel: ?u64 = null,
-    /// Persistent timeout setting.
+    /// Persistent timeout setting from Config. Applied at start of every invocation.
     timeout_ms: ?u64 = null,
+    /// Persistent memory limit from Config. Applied at start of every invocation.
+    max_memory_bytes: ?u64 = null,
     /// Persistent interpreter-only flag. When non-null, `invoke()` applies this
     /// to `vm.force_interpreter` before each call; when null, `vm.force_interpreter`
     /// is left untouched so callers may set it directly on `self.vm`.
     force_interpreter: ?bool = null,
 
+    /// Configuration for module loading.
+    pub const Config = struct {
+        wasi: bool = false,
+        wasi_options: ?WasiOptions = null,
+        imports: []const ImportEntry = &.{},
+        fuel: ?u64 = null,
+        timeout_ms: ?u64 = null,
+        max_memory_bytes: ?u64 = null,
+        force_interpreter: ?bool = null,
+    };
+
+    /// Load a Wasm module from binary bytes with explicit configuration.
+    pub fn loadWithOptions(allocator: Allocator, wasm_bytes: []const u8, config: Config) !*WasmModule {
+        return loadCore(allocator, wasm_bytes, config);
+    }
+
     /// Load a Wasm module from binary bytes, decode, and instantiate.
     pub fn load(allocator: Allocator, wasm_bytes: []const u8) !*WasmModule {
-        return loadCore(allocator, wasm_bytes, false, null, null, null, null);
+        return loadWithOptions(allocator, wasm_bytes, .{});
     }
 
     /// Load with a fuel limit (traps start function if it exceeds the limit).
     pub fn loadWithFuel(allocator: Allocator, wasm_bytes: []const u8, fuel: u64) !*WasmModule {
-        return loadCore(allocator, wasm_bytes, false, null, fuel, null, null);
+        return loadWithOptions(allocator, wasm_bytes, .{ .fuel = fuel });
     }
 
     /// Load a module from WAT (WebAssembly Text Format) source.
@@ -257,7 +274,7 @@ pub const WasmModule = struct {
     pub fn loadFromWat(allocator: Allocator, wat_source: []const u8) !*WasmModule {
         const wasm_bytes = try rt.wat.watToWasm(allocator, wat_source);
         errdefer allocator.free(wasm_bytes);
-        const self = try loadCore(allocator, wasm_bytes, false, null, null, null, null);
+        const self = try loadWithOptions(allocator, wasm_bytes, .{});
         self.owned_wasm_bytes = wasm_bytes;
         return self;
     }
@@ -266,14 +283,14 @@ pub const WasmModule = struct {
     pub fn loadFromWatWithFuel(allocator: Allocator, wat_source: []const u8, fuel: u64) !*WasmModule {
         const wasm_bytes = try rt.wat.watToWasm(allocator, wat_source);
         errdefer allocator.free(wasm_bytes);
-        const self = try loadCore(allocator, wasm_bytes, false, null, fuel, null, null);
+        const self = try loadWithOptions(allocator, wasm_bytes, .{ .fuel = fuel });
         self.owned_wasm_bytes = wasm_bytes;
         return self;
     }
 
     /// Load a WASI module — registers wasi_snapshot_preview1 imports.
     pub fn loadWasi(allocator: Allocator, wasm_bytes: []const u8) !*WasmModule {
-        return loadCore(allocator, wasm_bytes, true, null, null, null, null);
+        return loadWithOptions(allocator, wasm_bytes, .{ .wasi = true });
     }
 
     /// Apply WasiOptions to a WasiContext (shared logic for all WASI loaders).
@@ -310,23 +327,17 @@ pub const WasmModule = struct {
 
     /// Load a WASI module with custom args, env, and preopened directories.
     pub fn loadWasiWithOptions(allocator: Allocator, wasm_bytes: []const u8, opts: WasiOptions) !*WasmModule {
-        const self = try loadCore(allocator, wasm_bytes, true, null, null, null, null);
-        errdefer self.deinit();
-        if (self.wasi_ctx) |*wc| try applyWasiOptions(wc, opts);
-        return self;
+        return loadWithOptions(allocator, wasm_bytes, .{ .wasi = true, .wasi_options = opts });
     }
 
     /// Load with imports from other modules or host functions.
-    pub fn loadWithImports(allocator: Allocator, wasm_bytes: []const u8, imports: []const ImportEntry) !*WasmModule {
-        return loadCore(allocator, wasm_bytes, false, imports, null, null, null);
+    pub fn loadWithImports(allocator: Allocator, wasm_bytes: []const u8, imports: ?[]const ImportEntry) !*WasmModule {
+        return loadWithOptions(allocator, wasm_bytes, .{ .imports = imports orelse &.{} });
     }
 
     /// Load with combined WASI + import support. Used by CLI for --link + WASI fallback.
     pub fn loadWasiWithImports(allocator: Allocator, wasm_bytes: []const u8, imports: ?[]const ImportEntry, opts: WasiOptions) !*WasmModule {
-        const self = try loadCore(allocator, wasm_bytes, true, imports, null, null, null);
-        errdefer self.deinit();
-        if (self.wasi_ctx) |*wc| try applyWasiOptions(wc, opts);
-        return self;
+        return loadWithOptions(allocator, wasm_bytes, .{ .wasi = true, .wasi_options = opts, .imports = imports orelse &.{} });
     }
 
     /// Register this module's exports in its store under the given module name.
@@ -366,8 +377,9 @@ pub const WasmModule = struct {
         self.owned_wasm_bytes = null;
         self.store = rt.store_mod.Store.init(allocator);
         self.wasi_ctx = null;
-        self.fuel = null;
         self.timeout_ms = null;
+        self.fuel = null;
+        self.max_memory_bytes = null;
         self.force_interpreter = null;
 
         self.module = rt.module_mod.Module.init(allocator, wasm_bytes);
@@ -408,7 +420,7 @@ pub const WasmModule = struct {
         return .{ .module = self, .apply_error = apply_error };
     }
 
-    fn loadCore(allocator: Allocator, wasm_bytes: []const u8, wasi: bool, imports: ?[]const ImportEntry, fuel: ?u64, timeout_ms: ?u64, force_interpreter: ?bool) !*WasmModule {
+    fn loadCore(allocator: Allocator, wasm_bytes: []const u8, config: Config) !*WasmModule {
         const self = try allocator.create(WasmModule);
         errdefer allocator.destroy(self);
 
@@ -421,7 +433,7 @@ pub const WasmModule = struct {
         errdefer self.module.deinit();
         try self.module.decode();
 
-        if (wasi) {
+        if (config.wasi) {
             try rt.wasi.registerAll(&self.store, &self.module);
             self.wasi_ctx = rt.wasi.WasiContext.init(allocator);
             self.wasi_ctx.?.caps = rt.wasi.Capabilities.cli_default;
@@ -430,8 +442,14 @@ pub const WasmModule = struct {
         }
         errdefer if (self.wasi_ctx) |*wc| wc.deinit();
 
-        if (imports) |import_entries| {
-            try registerImports(&self.store, &self.module, import_entries, allocator);
+        if (self.wasi_ctx) |*wc| {
+            if (config.wasi_options) |opts| {
+                try applyWasiOptions(wc, opts);
+            }
+        }
+
+        if (config.imports.len > 0) {
+            try registerImports(&self.store, &self.module, config.imports, allocator);
         }
 
         self.instance = rt.instance_mod.Instance.init(allocator, &self.store, &self.module);
@@ -444,12 +462,16 @@ pub const WasmModule = struct {
         self.wit_funcs = &[_]wit_parser.WitFunc{};
 
         self.vm = try allocator.create(rt.vm_mod.Vm);
-
+        errdefer allocator.destroy(self.vm);
         self.vm.* = rt.vm_mod.Vm.init(allocator);
-
-        self.fuel = fuel;
-        self.timeout_ms = timeout_ms;
-        self.force_interpreter = force_interpreter;
+        self.max_memory_bytes = config.max_memory_bytes;
+        self.force_interpreter = config.force_interpreter;
+        self.timeout_ms = config.timeout_ms;
+        self.fuel = config.fuel;
+        if (self.fuel) |f| self.vm.fuel = f;
+        if (self.max_memory_bytes) |mb| self.vm.max_memory_bytes = mb;
+        if (self.force_interpreter) |fi| self.vm.force_interpreter = fi;
+        if (self.timeout_ms) |ms| self.vm.setDeadlineTimeoutMs(ms);
 
         // Execute start function if present.
         // Only apply persistent settings to the VM when explicitly set — a null
@@ -457,9 +479,11 @@ pub const WasmModule = struct {
         if (self.module.start) |start_idx| {
             self.vm.reset();
             if (self.fuel) |f| self.vm.fuel = f;
+            if (self.max_memory_bytes) |mb| self.vm.max_memory_bytes = mb;
             if (self.force_interpreter) |fi| self.vm.force_interpreter = fi;
             if (self.timeout_ms) |ms| self.vm.setDeadlineTimeoutMs(ms);
             try self.vm.invokeByIndex(&self.instance, start_idx, &.{}, &.{});
+            self.fuel = self.vm.fuel;
         }
 
         return self;
@@ -494,8 +518,10 @@ pub const WasmModule = struct {
     pub fn invoke(self: *WasmModule, name: []const u8, args: []const u64, results: []u64) !void {
         self.vm.reset();
         if (self.fuel) |f| self.vm.fuel = f;
+        if (self.max_memory_bytes) |mb| self.vm.max_memory_bytes = mb;
         if (self.force_interpreter) |fi| self.vm.force_interpreter = fi;
         if (self.timeout_ms) |ms| self.vm.setDeadlineTimeoutMs(ms);
+        defer if (self.fuel != null) { self.fuel = self.vm.fuel; };
         try self.vm.invoke(&self.instance, name, args, results);
     }
 
@@ -507,10 +533,12 @@ pub const WasmModule = struct {
     pub fn invokeInterpreterOnly(self: *WasmModule, name: []const u8, args: []const u64, results: []u64) !void {
         self.vm.reset();
         if (self.fuel) |f| self.vm.fuel = f;
+        if (self.max_memory_bytes) |mb| self.vm.max_memory_bytes = mb;
         if (self.timeout_ms) |ms| self.vm.setDeadlineTimeoutMs(ms);
         const saved_fi = self.vm.force_interpreter;
         self.vm.force_interpreter = true;
         defer self.vm.force_interpreter = saved_fi;
+        defer if (self.fuel != null) { self.fuel = self.vm.fuel; };
         try self.vm.invoke(&self.instance, name, args, results);
     }
 
@@ -1498,4 +1526,20 @@ test "fuel and timeout — persistence and caller-set preservation" {
     try wasm_mod.invoke("f", &.{}, &results);
     try testing.expect(wasm_mod.vm.deadline_ns != null);
     try testing.expectEqual(deadline_before, wasm_mod.vm.deadline_ns);
+}
+
+test "WasmModule.Config applies VM limits" {
+    const wasm_bytes = &[_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+    var wasm_mod = try WasmModule.loadWithOptions(testing.allocator, wasm_bytes, .{
+        .fuel = 12345,
+        .timeout_ms = 5000,
+        .max_memory_bytes = 1048576,
+        .force_interpreter = true,
+    });
+    defer wasm_mod.deinit();
+
+    try testing.expectEqual(@as(?u64, 12345), wasm_mod.vm.fuel);
+    try testing.expectEqual(@as(?u64, 1048576), wasm_mod.vm.max_memory_bytes);
+    try testing.expectEqual(true, wasm_mod.vm.force_interpreter);
+    try testing.expect(wasm_mod.vm.deadline_ns != null);
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -385,6 +385,7 @@ pub const WasmModule = struct {
         self.module = rt.module_mod.Module.init(allocator, wasm_bytes);
         self.module.decode() catch |err| {
             self.module.deinit();
+            self.store.deinit();
             allocator.destroy(self);
             return err;
         };
@@ -395,6 +396,7 @@ pub const WasmModule = struct {
         self.instance.instantiateBase() catch |err| {
             self.instance.deinit();
             self.module.deinit();
+            self.store.deinit();
             allocator.destroy(self);
             return err;
         };

--- a/test/c_api/test_ffi.c
+++ b/test/c_api/test_ffi.c
@@ -89,6 +89,10 @@ typedef const char *(*fn_last_error)(void);
 /* Config */
 typedef zwasm_config_t (*fn_config_new)(void);
 typedef void (*fn_config_delete)(zwasm_config_t);
+typedef void (*fn_config_set_fuel)(zwasm_config_t, uint64_t);
+typedef void (*fn_config_set_timeout)(zwasm_config_t, uint64_t);
+typedef void (*fn_config_set_max_memory)(zwasm_config_t, uint64_t);
+typedef void (*fn_config_set_force_interpreter)(zwasm_config_t, bool);
 
 /* Imports */
 typedef zwasm_imports_t (*fn_import_new)(void);
@@ -128,6 +132,10 @@ static struct {
     fn_last_error             last_error;
     fn_config_new             config_new;
     fn_config_delete          config_delete;
+    fn_config_set_fuel        config_set_fuel;
+    fn_config_set_timeout     config_set_timeout;
+    fn_config_set_max_memory  config_set_max_memory;
+    fn_config_set_force_interpreter config_set_force_interpreter;
     fn_import_new             import_new;
     fn_import_delete          import_delete;
     fn_import_add_fn          import_add_fn;
@@ -173,6 +181,10 @@ static bool load_api(const char *path) {
     LOAD_SYM(last_error,             "zwasm_last_error_message");
     LOAD_SYM(config_new,             "zwasm_config_new");
     LOAD_SYM(config_delete,          "zwasm_config_delete");
+    LOAD_SYM(config_set_fuel,        "zwasm_config_set_fuel");
+    LOAD_SYM(config_set_timeout,     "zwasm_config_set_timeout");
+    LOAD_SYM(config_set_max_memory,  "zwasm_config_set_max_memory");
+    LOAD_SYM(config_set_force_interpreter, "zwasm_config_set_force_interpreter");
     LOAD_SYM(import_new,             "zwasm_import_new");
     LOAD_SYM(import_delete,          "zwasm_import_delete");
     LOAD_SYM(import_add_fn,          "zwasm_import_add_fn");
@@ -450,6 +462,15 @@ static void test_config_lifecycle(void) {
 
     zwasm_config_t cfg = api.config_new();
     ASSERT(cfg != NULL, "config_new");
+    api.config_set_fuel(cfg, 10000);
+    api.config_set_timeout(cfg, 5000);
+    api.config_set_max_memory(cfg, 65536);
+    api.config_set_force_interpreter(cfg, true);
+
+    zwasm_module_t mod2 = api.module_new_configured(RETURN42_WASM, sizeof(RETURN42_WASM), cfg);
+    ASSERT(mod2 != NULL, "module_new_configured(cfg)");
+    if (mod2) api.module_delete(mod2);
+
     if (cfg) api.config_delete(cfg);
 
     /* Configured module (NULL config = default) */


### PR DESCRIPTION
### Summary
This PR refactors the WasmModule loading API to consolidate various loading parameters into a single Config structure, as proposed in #29. This change simplifies the API surface and ensures that all resource limits are applied consistently before module execution.

### Major Changes
- Unified Loading API: Introduced WasmModule.Config and loadWithOptions in src/types.zig. This replaces multiple specialized load functions with a single, extensible entry point.
- Pre-execution Resource Limits: VM settings such as fuel, timeout, and memory limits are now applied before the module's start function or instantiation logic runs.
- C API Expansion: Added zwasm_config_t setter functions for fuel, timeout, and memory limits, allowing C users to configure VM constraints before module creation.
- Internal Migration: Updated the CLI and internal component logic to use the new unified API.

### Rationale
The previous loading API was becoming complex as more configuration options were added. By moving parameters into a Config struct, we provide a cleaner interface for embedders and a more robust foundation for future features, such as execution cancellation.

This refactoring is a prerequisite for the cancellation mechanism currently in draft at #28.

Related Issue
Closes #29