### PR TITLE
docs: fix broken Zig download URL in setup-orbstack.md

### DIFF
--- a/.dev/references/setup-orbstack.md
+++ b/.dev/references/setup-orbstack.md
@@ -17,7 +17,7 @@ Run inside the VM (`orb run -m my-ubuntu-amd64 bash -lc "..."`):
 sudo apt update && sudo apt install -y build-essential python3 xz-utils curl git rsync
 
 # Zig 0.15.2
-curl -L -o /tmp/zig.tar.xz https://ziglang.org/builds/zig-x86_64-linux-0.15.2.tar.xz
+curl -L -o /tmp/zig.tar.xz https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz
 sudo mkdir -p /opt/zig && sudo tar -xf /tmp/zig.tar.xz -C /opt/zig --strip-components=1
 echo 'export PATH="/opt/zig:$PATH"' >> ~/.bashrc
 


### PR DESCRIPTION
## Summary

`ziglang.org/builds/` is the dev-snapshot path and 404s for release tags. The released 0.15.2 tarball lives under `ziglang.org/download/<version>/` (same URL used in flake.nix).

Discovered during Ubuntu VM setup on a clean-install macOS host.

```sh
$ curl -sI https://ziglang.org/builds/zig-x86_64-linux-0.15.2.tar.xz | head -1
HTTP/1.1 404 Not Found

$ curl -sI https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz | head -1
HTTP/1.1 200 OK
```

## Test plan

- [x] Verified correct URL downloads the expected Zig 0.15.2 tarball
- [x] Full merge gate (Mac+Ubuntu) on the session that revealed this already passed — this doc-only PR is trivially risk-free