### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ examples/rust/Cargo.lock
 *.swp
 *~
 
+# Claude Code runtime state
+.claude/scheduled_tasks.lock
+
 # Spec tests: tracked in git (avoids wabt version dependency across platforms)
 
 # E2E tests (generated from wasmtime misc_testsuite)


### PR DESCRIPTION
## Summary
- Adds \`.claude/scheduled_tasks.lock\` to \`.gitignore\`. This file is written by Claude Code's scheduled-task executor and otherwise shows up as untracked on every \`git status\`.

## Test plan
- [x] \`git status\` no longer lists the lock file