### PR TITLE
refactor(delib-1b): wasi path-based ops use Linux direct syscalls

### DIFF
--- a/src/platform.zig
+++ b/src/platform.zig
@@ -131,6 +131,15 @@ fn linuxResultAsIsize(rc: usize) isize {
     return @bitCast(rc);
 }
 
+fn linuxResultAsI32(rc: usize) i32 {
+    const e = std.os.linux.errno(rc);
+    if (e != .SUCCESS) {
+        std.c._errno().* = @intFromEnum(e);
+        return -1;
+    }
+    return 0;
+}
+
 fn linuxResultAsI64(rc: usize) i64 {
     const e = std.os.linux.errno(rc);
     if (e != .SUCCESS) {
@@ -238,6 +247,63 @@ pub fn pfdClose(handle: std.posix.fd_t) void {
         .windows => _ = CloseHandle(handle),
         .linux => _ = std.os.linux.close(handle),
         else => _ = std.c.close(handle),
+    }
+}
+
+// Path-based helpers. All POSIX-only (callers of these helpers already
+// branch to a `std.Io.Dir` path on Windows before reaching here). The
+// `.windows` arms return -1 so compilation succeeds on Windows builds;
+// the helpers themselves are never reached at runtime on Windows.
+pub fn pfdMkdirAt(dirfd: std.posix.fd_t, path: [*:0]const u8, mode: u32) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => return linuxResultAsI32(std.os.linux.mkdirat(dirfd, path, mode)),
+        else => return @intCast(std.c.mkdirat(dirfd, path, @intCast(mode))),
+    }
+}
+
+pub fn pfdUnlinkAt(dirfd: std.posix.fd_t, path: [*:0]const u8, flags: u32) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => return linuxResultAsI32(std.os.linux.unlinkat(dirfd, path, flags)),
+        else => return @intCast(std.c.unlinkat(dirfd, path, @intCast(flags))),
+    }
+}
+
+pub fn pfdRenameAt(
+    old_dirfd: std.posix.fd_t,
+    old_path: [*:0]const u8,
+    new_dirfd: std.posix.fd_t,
+    new_path: [*:0]const u8,
+) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => return linuxResultAsI32(std.os.linux.renameat(old_dirfd, old_path, new_dirfd, new_path)),
+        else => return @intCast(std.c.renameat(old_dirfd, old_path, new_dirfd, new_path)),
+    }
+}
+
+pub fn pfdReadlinkAt(dirfd: std.posix.fd_t, path: [*:0]const u8, buf: []u8) isize {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => return linuxResultAsIsize(std.os.linux.readlinkat(dirfd, path, buf.ptr, buf.len)),
+        else => return std.c.readlinkat(dirfd, path, buf.ptr, buf.len),
+    }
+}
+
+pub fn pfdDup(fd: std.posix.fd_t) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => {
+            const rc = std.os.linux.dup(fd);
+            const e = std.os.linux.errno(rc);
+            if (e != .SUCCESS) {
+                std.c._errno().* = @intFromEnum(e);
+                return -1;
+            }
+            return @intCast(rc);
+        },
+        else => return @intCast(std.c.dup(fd)),
     }
 }
 

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -1652,7 +1652,7 @@ pub fn path_create_directory(ctx: *anyopaque, _: usize) anyerror!void {
         try pushErrno(vm, .NAMETOOLONG);
         return;
     };
-    if (std.c.mkdirat(host_fd, path_z.ptr, 0o777) != 0) {
+    if (platform.pfdMkdirAt(host_fd, path_z.ptr, 0o777) != 0) {
         try pushErrno(vm, cErrnoToWasi());
         return;
     }
@@ -1697,7 +1697,7 @@ pub fn path_remove_directory(ctx: *anyopaque, _: usize) anyerror!void {
         try pushErrno(vm, .NAMETOOLONG);
         return;
     };
-    if (std.c.unlinkat(host_fd, path_z.ptr, @intCast(posix.AT.REMOVEDIR)) != 0) {
+    if (platform.pfdUnlinkAt(host_fd, path_z.ptr, @intCast(posix.AT.REMOVEDIR)) != 0) {
         try pushErrno(vm, cErrnoToWasi());
         return;
     }
@@ -1742,7 +1742,7 @@ pub fn path_unlink_file(ctx: *anyopaque, _: usize) anyerror!void {
         try pushErrno(vm, .NAMETOOLONG);
         return;
     };
-    if (std.c.unlinkat(host_fd, path_z.ptr, 0) != 0) {
+    if (platform.pfdUnlinkAt(host_fd, path_z.ptr, 0) != 0) {
         try pushErrno(vm, cErrnoToWasi());
         return;
     }
@@ -1802,7 +1802,7 @@ pub fn path_rename(ctx: *anyopaque, _: usize) anyerror!void {
         try pushErrno(vm, .NAMETOOLONG);
         return;
     };
-    if (std.c.renameat(old_host_fd, old_z.ptr, new_host_fd, new_z.ptr) != 0) {
+    if (platform.pfdRenameAt(old_host_fd, old_z.ptr, new_host_fd, new_z.ptr) != 0) {
         try pushErrno(vm, cErrnoToWasi());
         return;
     }
@@ -2053,7 +2053,17 @@ pub fn fd_filestat_set_times(ctx: *anyopaque, _: usize) anyerror!void {
     };
 
     const times = wasiTimesToTimespec(fst_flags, atim_ns, mtim_ns);
-    if (std.c.futimens(host_fd, &times) != 0) {
+    const failed = switch (comptime builtin.os.tag) {
+        .linux => blk: {
+            // utimensat(fd, NULL, times, 0) == futimens(fd, times)
+            const rc = std.os.linux.utimensat(host_fd, null, &times, 0);
+            const e = std.os.linux.errno(rc);
+            if (e != .SUCCESS) std.c._errno().* = @intFromEnum(e);
+            break :blk e != .SUCCESS;
+        },
+        else => std.c.futimens(host_fd, &times) != 0,
+    };
+    if (failed) {
         try pushErrno(vm, cErrnoToWasi());
         return;
     }
@@ -2301,7 +2311,7 @@ pub fn fd_renumber(ctx: *anyopaque, _: usize) anyerror!void {
     // Dup host fd and assign to fd_to slot
     const new_host = blk: {
         if (builtin.os.tag == .windows) unreachable;
-        const rc = std.c.dup(from_host);
+        const rc = platform.pfdDup(from_host);
         if (rc < 0) {
             try pushErrno(vm, cErrnoToWasi());
             return;
@@ -2486,7 +2496,7 @@ pub fn path_readlink(ctx: *anyopaque, _: usize) anyerror!void {
         try pushErrno(vm, .NAMETOOLONG);
         return;
     };
-    const rc = std.c.readlinkat(host_fd, path_z.ptr, buf.ptr, buf.len);
+    const rc = platform.pfdReadlinkAt(host_fd, path_z.ptr, buf);
     if (rc < 0) {
         try pushErrno(vm, cErrnoToWasi());
         return;


### PR DESCRIPTION
## Summary

Second step of the W46 un-link-libc migration, building on #47.

- Add `pfdMkdirAt`, `pfdUnlinkAt`, `pfdRenameAt`, `pfdReadlinkAt`, `pfdDup` to `src/platform.zig`. Each uses `std.os.linux.*` direct syscalls on Linux, `std.c.*` on Mac/BSD, returns -1 on Windows (never reached — callers already branch to `std.Io.Dir` first).
- Update `src/wasi.zig` path-based ops: `path_create_directory`, `path_remove_directory`, `path_unlink_file`, `path_rename`, `path_readlink`, `fd_renumber`.
- Inline `switch (comptime builtin.os.tag)` for `fd_filestat_set_times` — Linux uses `utimensat(fd, null, &times, 0)` which is equivalent to `futimens(fd, &times)`.

Behavior unchanged: existing `cErrnoToWasi` callers still work because the Linux branch mirrors the syscall errno into `std.c._errno().*` before returning.

## Still not ready to flip `link_libc = false`

Remaining `std.c.*` references that will block un-linking:

- `src/platform.zig:331,352` — `std.c.getenv(...)` (app-cache dir / env lookup)
- `src/trace.zig:71` — `std.c.write(stderr_fd, ...)` (should be `platform.pfdWrite`)
- `src/wasi.zig:525` — `std.c._errno().*` in `cErrnoToWasi` (need an alt errno source)
- `src/wasi.zig` path_filestat_set_times already uses `std.c.utimensat` on non-Linux (OK for Mac)

Those are W46 Phase 1c-1e, intentionally out of scope here.

## Test plan

- [x] `zig build test` (Mac aarch64) — all pass.
- [x] `zig build -Dtarget=x86_64-linux-gnu` — clean.
- [x] `zig build -Dtarget=x86_64-windows-gnu` — clean.
- [x] `bash test/realworld/run_compat.sh` (Mac ReleaseSafe) — PASS: 50 / FAIL: 0.
- [ ] Full CI — Mac + Ubuntu + Windows green (46/46 real-world compat on Windows).

Tracks: W46 in `.dev/checklist.md`.