### PR TITLE
refactor(w46-phase2): route std.c.* WASI calls through platform helpers

### DIFF
--- a/.dev/checklist.md
+++ b/.dev/checklist.md
@@ -19,6 +19,15 @@ Prefix: W## (to distinguish from CW's F## items).
   path — likely regalloc or memory-access pattern change. Low priority
   since 20 other benchmarks improved >10% (GC paths 40–76% faster).
 
+- [ ] W48: Linux binary size 1.65 MB → 1.50 MB. W46 Phase 2 refactor was
+  size-neutral because Linux never hit the `std.c.*` branches (comptime-
+  pruned). The 150 KB gap vs 1.50 MB target is dominated by
+  `std.debug` + `Dwarf` (~170 KB, panic-handler source-location printing),
+  `std.Io.Threaded` (~115 KB), `sort.*` (~50 KB), `std.Progress` (~18 KB).
+  Candidates: override `std.debug.panic`, trim `std.Io.Threaded` surface,
+  measure `-Doptimize=ReleaseSmall`. Non-blocking; ceiling 1.80 MB still
+  has slack.
+
 ## Resolved (summary)
 
 W37: Contiguous v128 storage. W39: Multi-value return JIT (guard removed).
@@ -43,8 +52,14 @@ W46: Un-link libc — Phase 1 complete (delib 1a–1f, merged 2026-04-24/25).
      `src/c_api.zig` uses `std.heap.c_allocator`. Platform helpers added:
      pfdWrite, pfdRead, pfdClose, pfdDup, pfdDup2, pfdPipe, pfdSleepNs, pfdErrno,
      pfdFsync, pfdReadlinkAt (Linux=direct syscalls, Mac=libSystem auto-link,
-     Windows=kernel32/Win32). Payoff measured: Mac 1.38 MB, Linux 1.65 MB
-     stripped (vs 1.80 MB ceiling). The 1.50 MB target is deferred to the
-     std.Io migration (tracked separately if it resurfaces).
+     Windows=kernel32/Win32).
+     Phase 2 complete (2026-04-25): remaining wasi.zig direct `std.c.*` call
+     sites (fdatasync, fcntl, ftruncate, futimens, utimensat, symlinkat,
+     linkat, fstatat) routed through new platform helpers (pfdFdatasync,
+     pfdFcntlSetfl, pfdFtruncate, pfdFutimens, pfdUtimensat, pfdSymlinkat,
+     pfdLinkat, pfdFstatatDarwin). Linux was already libc-free through
+     comptime-pruned switches; Phase 2 is a pure refactor with zero
+     binary-size delta. Size payoff measured: Mac 1.38 MB, Linux 1.65 MB
+     stripped (vs 1.80 MB ceiling). The 1.50 MB target is tracked under W48.
 
 W2-W36: See git history. All resolved through Stages 0-47 and Phases 1-19.

--- a/.dev/memo.md
+++ b/.dev/memo.md
@@ -22,16 +22,22 @@ Session handover document. Read at session start.
 
 ## Current Task
 
-**W46 Phase 1 — DONE (2026-04-25).** PR #49 merged (`30a3680`). See
-`.dev/checklist.md` Resolved section for details. Next candidate work:
+**W46 Phase 2 — DONE (2026-04-25).** Routed remaining `std.c.*` direct calls
+in `wasi.zig` (fdatasync, fcntl, ftruncate, futimens, utimensat, symlinkat,
+linkat, fstatat) through new `platform.zig` helpers. Size result was
+neutral — Linux never hit those branches (comptime-pruned), so this is a
+pure consistency/encapsulation refactor. Linux binary stays at 1.65 MB
+stripped; the 1.50 MB goal is now tracked as **W48** with specific size
+contributors identified (std.debug+Dwarf ~170 KB, std.Io.Threaded ~115 KB,
+sort.* ~50 KB, std.Progress ~18 KB). Next candidate work:
 
 - **W47**: `tgo_strops_cached` +24% regression investigation (single-benchmark,
   low priority). See checklist.
 - **W45**: SIMD loop persistence — skip Q-cache eviction at loop headers
   (requires back-edge detection in `scanBranchTargets`).
-- **W46 Phase 2 (optional)**: migrate `fd_read`/`fd_write` onto `std.Io`.
-  Not blocking. Would help return binary size to 1.50 MB target and improve
-  Windows I/O correctness further; pick up when `std.Io` stdlib APIs stabilize.
+- **W48**: Linux binary size 1.65 → 1.50 MB. Candidates: custom panic
+  handler (dropping source-location printing), trim std.Io.Threaded
+  surface, measure ReleaseSmall. Non-blocking; 1.80 MB ceiling has slack.
 
 ## Previous Task
 
@@ -61,6 +67,12 @@ C-API targets after the first push revealed `std.heap.c_allocator` needs libc.
   and `-Dtarget=x86_64-windows-gnu` compile cleanly on Mac even though the
   test binaries can't execute — the compile success alone catches link-time
   symbol-resolution issues before pushing to CI.
+- **Linux is already libc-free even when `std.c.*` appears in source.**
+  Inside a `switch (comptime builtin.os.tag)`, the `.linux =>` and
+  `else =>` arms are comptime-pruned; the Linux build never references
+  `std.c.*` bindings even if they appear textually. This is why W46 Phase 2
+  was size-neutral on Linux — the refactor only cleans up Mac/BSD code
+  paths.
 
 ## References
 

--- a/bench/history.yaml
+++ b/bench/history.yaml
@@ -3885,3 +3885,67 @@ entries:
       rw_cpp_string_cached: {time_ms: 5.0}
       rw_cpp_sort: {time_ms: 2.7}
       rw_cpp_sort_cached: {time_ms: 3.0}
+  - id: "v1.10-w46p2"
+    date: "2026-04-25"
+    reason: "W46 Phase 2: route std.c.* through platform helpers"
+    commit: "b168570"
+    build: ReleaseSafe
+    results:
+      fib: {time_ms: 48.7}
+      fib_cached: {time_ms: 46.3}
+      tak: {time_ms: 6.1}
+      tak_cached: {time_ms: 6.6}
+      sieve: {time_ms: 6.9}
+      sieve_cached: {time_ms: 5.4}
+      nbody: {time_ms: 23.2}
+      nbody_cached: {time_ms: 21.9}
+      nqueens: {time_ms: 2.7}
+      nqueens_cached: {time_ms: 3.0}
+      tgo_fib: {time_ms: 34.2}
+      tgo_fib_cached: {time_ms: 34.2}
+      tgo_tak: {time_ms: 6.0}
+      tgo_tak_cached: {time_ms: 6.1}
+      tgo_arith: {time_ms: 1.4}
+      tgo_arith_cached: {time_ms: 2.4}
+      tgo_sieve: {time_ms: 2.8}
+      tgo_sieve_cached: {time_ms: 2.5}
+      tgo_fib_loop: {time_ms: 2.7}
+      tgo_fib_loop_cached: {time_ms: 1.8}
+      tgo_gcd: {time_ms: 1.8}
+      tgo_gcd_cached: {time_ms: 2.7}
+      tgo_nqueens: {time_ms: 55.6}
+      tgo_nqueens_cached: {time_ms: 55.1}
+      tgo_mfr: {time_ms: 48.8}
+      tgo_mfr_cached: {time_ms: 49.2}
+      tgo_list: {time_ms: 58.0}
+      tgo_list_cached: {time_ms: 58.9}
+      tgo_rwork: {time_ms: 5.7}
+      tgo_rwork_cached: {time_ms: 6.9}
+      tgo_strops: {time_ms: 74.9}
+      tgo_strops_cached: {time_ms: 66.9}
+      st_fib2: {time_ms: 860.5}
+      st_fib2_cached: {time_ms: 860.8}
+      st_sieve: {time_ms: 175.2}
+      st_sieve_cached: {time_ms: 176.5}
+      st_nestedloop: {time_ms: 2.9}
+      st_nestedloop_cached: {time_ms: 2.4}
+      st_ackermann: {time_ms: 4.8}
+      st_ackermann_cached: {time_ms: 4.8}
+      st_matrix: {time_ms: 282.7}
+      st_matrix_cached: {time_ms: 281.4}
+      gc_alloc: {time_ms: 4.2}
+      gc_alloc_cached: {time_ms: 4.1}
+      gc_tree: {time_ms: 17.6}
+      gc_tree_cached: {time_ms: 16.8}
+      rw_rust_fib: {time_ms: 35.5}
+      rw_rust_fib_cached: {time_ms: 36.3}
+      rw_c_matrix: {time_ms: 2.8}
+      rw_c_matrix_cached: {time_ms: 0.2}
+      rw_c_math: {time_ms: 18.2}
+      rw_c_math_cached: {time_ms: 20.5}
+      rw_c_string: {time_ms: 45.4}
+      rw_c_string_cached: {time_ms: 43.6}
+      rw_cpp_string: {time_ms: 3.9}
+      rw_cpp_string_cached: {time_ms: 4.8}
+      rw_cpp_sort: {time_ms: 3.4}
+      rw_cpp_sort_cached: {time_ms: 3.8}

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -386,6 +386,102 @@ pub fn pfdPipe(fds: *[2]std.posix.fd_t) i32 {
     }
 }
 
+pub fn pfdFdatasync(handle: std.posix.fd_t) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => {
+            if (FlushFileBuffers(handle) == windows.BOOL.FALSE) {
+                pfd_last_errno = .IO;
+                return -1;
+            }
+            return 0;
+        },
+        .linux => return linuxResultAsI32(std.os.linux.fdatasync(handle)),
+        else => return cResultAsI32(std.c.fdatasync(handle)),
+    }
+}
+
+/// `fcntl(fd, F_SETFL, flags)`. Returns 0 on success, -1 on error.
+pub fn pfdFcntlSetfl(handle: std.posix.fd_t, flags: u32) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return 0, // fcntl is not meaningful on Windows; treat as no-op success
+        .linux => {
+            const linux = std.os.linux;
+            const rc = linux.fcntl(handle, linux.F.SETFL, @as(usize, flags));
+            return linuxResultAsI32(rc);
+        },
+        else => return cResultAsI32(std.c.fcntl(handle, std.c.F.SETFL, flags)),
+    }
+}
+
+pub fn pfdFtruncate(handle: std.posix.fd_t, length: i64) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1, // callers use std.Io.File.setLength on Windows
+        .linux => return linuxResultAsI32(std.os.linux.ftruncate(handle, length)),
+        else => return cResultAsI32(std.c.ftruncate(handle, @bitCast(length))),
+    }
+}
+
+pub fn pfdFutimens(handle: std.posix.fd_t, times: *const [2]std.posix.timespec) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => return linuxResultAsI32(std.os.linux.utimensat(handle, null, times, 0)),
+        else => return cResultAsI32(std.c.futimens(handle, times)),
+    }
+}
+
+pub fn pfdUtimensat(
+    dirfd: std.posix.fd_t,
+    path: [*:0]const u8,
+    times: *const [2]std.posix.timespec,
+    flags: u32,
+) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => return linuxResultAsI32(std.os.linux.utimensat(dirfd, path, times, flags)),
+        else => return cResultAsI32(std.c.utimensat(dirfd, path, times, flags)),
+    }
+}
+
+pub fn pfdSymlinkat(
+    target: [*:0]const u8,
+    newdirfd: std.posix.fd_t,
+    linkpath: [*:0]const u8,
+) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => return linuxResultAsI32(std.os.linux.symlinkat(target, newdirfd, linkpath)),
+        else => return cResultAsI32(std.c.symlinkat(target, newdirfd, linkpath)),
+    }
+}
+
+pub fn pfdLinkat(
+    olddirfd: std.posix.fd_t,
+    oldpath: [*:0]const u8,
+    newdirfd: std.posix.fd_t,
+    newpath: [*:0]const u8,
+    flags: u32,
+) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows => return -1,
+        .linux => return linuxResultAsI32(std.os.linux.linkat(olddirfd, oldpath, newdirfd, newpath, flags)),
+        else => return cResultAsI32(std.c.linkat(olddirfd, oldpath, newdirfd, newpath, flags)),
+    }
+}
+
+/// Darwin/BSD-only `fstatat` helper. Linux callers go through `statx` instead
+/// (see `fstatatToFileStat`). Returns 0 on success, -1 on error.
+pub fn pfdFstatatDarwin(
+    dirfd: std.posix.fd_t,
+    path: [*:0]const u8,
+    stat_out: *std.c.Stat,
+    flags: u32,
+) i32 {
+    switch (comptime builtin.os.tag) {
+        .windows, .linux => return -1,
+        else => return cResultAsI32(std.c.fstatat(dirfd, path, stat_out, flags)),
+    }
+}
+
 /// Sleep for the given number of nanoseconds. Best-effort — short-sleep
 /// tests use this to give other threads time to start.
 pub fn pfdSleepNs(ns: u64) void {

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -617,9 +617,9 @@ fn fstatatToFileStat(dirfd: posix.fd_t, path_z: [*:0]const u8, nofollow: u32) !F
             .ctim_ns = @as(i128, sx.ctime.sec) * 1_000_000_000 + sx.ctime.nsec,
         };
     }
-    // Darwin/BSD: std.c.fstatat + system.Stat.
+    // Darwin/BSD: fstatat + system.Stat.
     var st: std.c.Stat = undefined;
-    if (std.c.fstatat(dirfd, path_z, &st, nofollow) != 0) return error.Stat;
+    if (platform.pfdFstatatDarwin(dirfd, path_z, &st, nofollow) != 0) return error.Stat;
     const S = posix.S;
     const filetype: u8 = if (S.ISDIR(st.mode))
         @intFromEnum(Filetype.DIRECTORY)
@@ -1564,21 +1564,7 @@ pub fn fd_datasync(ctx: *anyopaque, _: usize) anyerror!void {
                 return;
             }
         } else {
-            const failed = switch (comptime builtin.os.tag) {
-                .linux => blk: {
-                    const rc = std.os.linux.fdatasync(host_fd);
-                    const e = std.os.linux.errno(rc);
-                    if (e != .SUCCESS) platform.pfd_last_errno = e;
-                    break :blk e != .SUCCESS;
-                },
-                .windows => unreachable,
-                else => blk: {
-                    const rc = std.c.fdatasync(host_fd);
-                    if (rc != 0) platform.syncErrnoFromLibC();
-                    break :blk rc != 0;
-                },
-            };
-            if (failed) {
+            if (platform.pfdFdatasync(host_fd) != 0) {
                 try pushErrno(vm, cErrnoToWasi());
                 return;
             }
@@ -1949,19 +1935,7 @@ pub fn fd_fdstat_set_flags(ctx: *anyopaque, _: usize) anyerror!void {
     if (fdflags & 0x04 != 0) os_flags |= @as(u32, @bitCast(posix.O{ .NONBLOCK = true }));
     if (fdflags & 0x10 != 0) os_flags |= @as(u32, @bitCast(posix.O{ .SYNC = true }));
 
-    const failed = switch (comptime builtin.os.tag) {
-        .linux => blk: {
-            const linux = std.os.linux;
-            const rc = linux.fcntl(host_fd, linux.F.SETFL, @as(usize, os_flags));
-            break :blk posix.errno(rc) != .SUCCESS;
-        },
-        .windows => false, // fcntl not meaningful on Windows; treat as success
-        else => blk: {
-            const rc = std.c.fcntl(host_fd, std.c.F.SETFL, os_flags);
-            break :blk rc < 0;
-        },
-    };
-    if (failed) {
+    if (platform.pfdFcntlSetfl(host_fd, os_flags) != 0) {
         try pushErrno(vm, .IO);
         return;
     }
@@ -2004,21 +1978,7 @@ pub fn fd_filestat_set_size(ctx: *anyopaque, _: usize) anyerror!void {
     };
 
     if (wasi.getHostFd(fd)) |host_fd| {
-        const failed = switch (comptime builtin.os.tag) {
-            .linux => blk: {
-                const rc = std.os.linux.ftruncate(host_fd, @bitCast(size));
-                const e = std.os.linux.errno(rc);
-                if (e != .SUCCESS) platform.pfd_last_errno = e;
-                break :blk e != .SUCCESS;
-            },
-            .windows => unreachable,
-            else => blk: {
-                const rc = std.c.ftruncate(host_fd, @bitCast(size));
-                if (rc != 0) platform.syncErrnoFromLibC();
-                break :blk rc != 0;
-            },
-        };
-        if (failed) {
+        if (platform.pfdFtruncate(host_fd, size) != 0) {
             try pushErrno(vm, cErrnoToWasi());
             return;
         }
@@ -2072,21 +2032,7 @@ pub fn fd_filestat_set_times(ctx: *anyopaque, _: usize) anyerror!void {
     };
 
     const times = wasiTimesToTimespec(fst_flags, atim_ns, mtim_ns);
-    const failed = switch (comptime builtin.os.tag) {
-        .linux => blk: {
-            // utimensat(fd, NULL, times, 0) == futimens(fd, times)
-            const rc = std.os.linux.utimensat(host_fd, null, &times, 0);
-            const e = std.os.linux.errno(rc);
-            if (e != .SUCCESS) platform.pfd_last_errno = e;
-            break :blk e != .SUCCESS;
-        },
-        else => blk: {
-            const rc = std.c.futimens(host_fd, &times);
-            if (rc != 0) platform.syncErrnoFromLibC();
-            break :blk rc != 0;
-        },
-    };
-    if (failed) {
+    if (platform.pfdFutimens(host_fd, &times) != 0) {
         try pushErrno(vm, cErrnoToWasi());
         return;
     }
@@ -2458,19 +2404,9 @@ pub fn path_filestat_set_times(ctx: *anyopaque, _: usize) anyerror!void {
     @memcpy(path_buf[0..path_len], path);
     path_buf[path_len] = 0;
 
-    if (comptime builtin.os.tag == .linux) {
-        const linux = std.os.linux;
-        const rc = linux.utimensat(host_fd, &path_buf, &times, nofollow);
-        if (posix.errno(rc) != .SUCCESS) {
-            try pushErrno(vm, .IO);
-            return;
-        }
-    } else {
-        const rc = std.c.utimensat(host_fd, &path_buf, &times, nofollow);
-        if (rc < 0) {
-            try pushErrno(vm, .IO);
-            return;
-        }
+    if (platform.pfdUtimensat(host_fd, &path_buf, &times, nofollow) != 0) {
+        try pushErrno(vm, .IO);
+        return;
     }
     try pushErrno(vm, .SUCCESS);
 }
@@ -2573,21 +2509,7 @@ pub fn path_symlink(ctx: *anyopaque, _: usize) anyerror!void {
             try pushErrno(vm, .NAMETOOLONG);
             return;
         };
-        const failed = switch (comptime builtin.os.tag) {
-            .linux => blk: {
-                const rc = std.os.linux.symlinkat(old_z.ptr, host_fd, new_z.ptr);
-                const e = std.os.linux.errno(rc);
-                if (e != .SUCCESS) platform.pfd_last_errno = e;
-                break :blk e != .SUCCESS;
-            },
-            .windows => unreachable,
-            else => blk: {
-                const rc = std.c.symlinkat(old_z.ptr, host_fd, new_z.ptr);
-                if (rc != 0) platform.syncErrnoFromLibC();
-                break :blk rc != 0;
-            },
-        };
-        if (failed) {
+        if (platform.pfdSymlinkat(old_z.ptr, host_fd, new_z.ptr) != 0) {
             try pushErrno(vm, cErrnoToWasi());
             return;
         }
@@ -2643,21 +2565,7 @@ pub fn path_link(ctx: *anyopaque, _: usize) anyerror!void {
             try pushErrno(vm, .NAMETOOLONG);
             return;
         };
-        const failed = switch (comptime builtin.os.tag) {
-            .linux => blk: {
-                const rc = std.os.linux.linkat(old_host_fd, old_z.ptr, new_host_fd, new_z.ptr, 0);
-                const e = std.os.linux.errno(rc);
-                if (e != .SUCCESS) platform.pfd_last_errno = e;
-                break :blk e != .SUCCESS;
-            },
-            .windows => unreachable,
-            else => blk: {
-                const rc = std.c.linkat(old_host_fd, old_z.ptr, new_host_fd, new_z.ptr, 0);
-                if (rc != 0) platform.syncErrnoFromLibC();
-                break :blk rc != 0;
-            },
-        };
-        if (failed) {
+        if (platform.pfdLinkat(old_host_fd, old_z.ptr, new_host_fd, new_z.ptr, 0) != 0) {
             try pushErrno(vm, cErrnoToWasi());
             return;
         }


### PR DESCRIPTION
## Summary

- Adds eight new `pfd*` helpers to `src/platform.zig` (`pfdFdatasync`, `pfdFcntlSetfl`, `pfdFtruncate`, `pfdFutimens`, `pfdUtimensat`, `pfdSymlinkat`, `pfdLinkat`, `pfdFstatatDarwin`) so all WASI I/O now dispatches through one platform module.
- Converts the eight surviving direct `std.c.*` call sites in `src/wasi.zig` to use them. Linux was already libc-free at these sites — the `std.c.*` calls lived inside comptime-pruned `else =>` arms — so this is a pure consistency refactor, not a link-time change.
- Updates `.dev/checklist.md` + `.dev/memo.md`: W46 Phase 2 → resolved, W48 opened to track the remaining 150 KB gap to the 1.50 MB Linux target.

## Size result

Linux x86_64 stripped (ReleaseSafe): 1,722,264 B → 1,722,328 B (+64 B, within noise). Mac stripped stays at ~1.38 MB. Phase 2 is size-neutral by construction; W48 investigates the actual size contributors (std.debug+Dwarf ~170 KB, std.Io.Threaded ~115 KB, sort.* ~50 KB, std.Progress ~18 KB).

## Test plan

- [x] `zig build test` — 399/399 pass locally
- [x] Minimal build (`-Djit=false -Dcomponent=false -Dwat=false`) — 268 pass / 15 skip / 0 fail
- [x] `python3 test/spec/run_spec.py --build --summary` — 62263/62263 pass, 0 skip
- [x] `bash test/e2e/run_e2e.sh --convert --summary` — 796/796 pass
- [x] `bash test/realworld/run_compat.sh` — 50/50 pass (first run hit one flaky DIFF `tinygo_json` → PASS on retry)
- [x] `bash test/c_api/run_ffi_test.sh --build` — 80/80 pass
- [x] Cross-compile sanity: `zig build -Dtarget=x86_64-linux-gnu` + `-Dtarget=x86_64-windows-gnu` — both clean
- [x] Benchmarks recorded as `v1.10-w46p2` in `bench/history.yaml`
- [x] `bash bench/ci_compare.sh --runs=5 --threshold=20` vs `origin/main` — no regression
- [ ] CI green on Ubuntu + Windows + size-matrix runners (will check after push)