### PR TITLE
perf(w48): trim release binary -83 KB Linux / -180 KB Mac

### DIFF
--- a/.dev/checklist.md
+++ b/.dev/checklist.md
@@ -19,14 +19,18 @@ Prefix: W## (to distinguish from CW's F## items).
   path — likely regalloc or memory-access pattern change. Low priority
   since 20 other benchmarks improved >10% (GC paths 40–76% faster).
 
-- [ ] W48: Linux binary size 1.65 MB → 1.50 MB. W46 Phase 2 refactor was
-  size-neutral because Linux never hit the `std.c.*` branches (comptime-
-  pruned). The 150 KB gap vs 1.50 MB target is dominated by
-  `std.debug` + `Dwarf` (~170 KB, panic-handler source-location printing),
-  `std.Io.Threaded` (~115 KB), `sort.*` (~50 KB), `std.Progress` (~18 KB).
-  Candidates: override `std.debug.panic`, trim `std.Io.Threaded` surface,
-  measure `-Doptimize=ReleaseSmall`. Non-blocking; ceiling 1.80 MB still
-  has slack.
+- [ ] W48 Phase 2: Linux binary size 1.56 MB → 1.50 MB (~62 KB more).
+  W48 Phase 1 shipped (2026-04-25): `pub const panic = std.debug.simple_panic`
+  in `src/cli.zig` + `std_options.enable_segfault_handler = false` (zwasm
+  installs its own SIGSEGV handler for JIT guard pages anyway) + changed
+  `main` from `!void` to `u8` to avoid `dumpErrorReturnTrace` pull-in.
+  Net: Linux 1.64 → 1.56 MB (-83 KB, -5%), Mac 1.38 → 1.20 MB (-180 KB).
+  Remaining contributors: `debug.*` still 81 KB (SelfInfo.Elf, Dwarf, writeTrace
+  pulled via `std.debug.lockStderr` → `std.Options.debug_io` default),
+  `std.Io.Threaded` ~115 KB, `sort.*` ~39 KB. Candidates: override
+  `std_options_debug_io` with a minimal direct-stderr Io instance; audit
+  whether `init.io` Threaded can be thinned. Non-blocking; ceiling 1.80 MB
+  still has slack.
 
 ## Resolved (summary)
 

--- a/.dev/memo.md
+++ b/.dev/memo.md
@@ -12,7 +12,7 @@ Session handover document. Read at session start.
 - FFI: 80/80 Mac+Ubuntu.
 - JIT: Register IR + ARM64/x86_64 + SIMD (NEON 253/256, SSE 244/256).
 - HOT_THRESHOLD=3 (lowered from 10 in W38).
-- Binary stripped: Mac 1.38 MB, Linux 1.65 MB (ceiling 1.80 MB). Memory: ~3.5 MB RSS.
+- Binary stripped: Mac 1.20 MB, Linux 1.56 MB (ceiling 1.80 MB; post-W48 Phase 1). Memory: ~3.5 MB RSS.
 - Platforms: macOS ARM64, Linux x86_64/ARM64, Windows x86_64.
 - **main = stable**. v1.10.0 released; post-release work on delib / W46 merged
   via PRs #47 (1a/1b pre-cursor), #48 (1b), #49 (1c/1d/1e/1f + C-API libc fix).
@@ -22,24 +22,46 @@ Session handover document. Read at session start.
 
 ## Current Task
 
-**W46 Phase 2 — DONE (2026-04-25).** Routed remaining `std.c.*` direct calls
-in `wasi.zig` (fdatasync, fcntl, ftruncate, futimens, utimensat, symlinkat,
-linkat, fstatat) through new `platform.zig` helpers. Size result was
-neutral — Linux never hit those branches (comptime-pruned), so this is a
-pure consistency/encapsulation refactor. Linux binary stays at 1.65 MB
-stripped; the 1.50 MB goal is now tracked as **W48** with specific size
-contributors identified (std.debug+Dwarf ~170 KB, std.Io.Threaded ~115 KB,
-sort.* ~50 KB, std.Progress ~18 KB). Next candidate work:
+**W48 Phase 1 — DONE (2026-04-25).** Trimmed Linux binary from 1.64 → 1.56 MB
+(-83 KB, -5%) and Mac binary from 1.38 → 1.20 MB (-180 KB, -13%) via three
+changes in `src/cli.zig`:
+
+1. `pub const panic = std.debug.simple_panic;` — skips `FullPanic`'s
+   formatted safety-panic messages + the `defaultPanic` /
+   `writeCurrentStackTrace` DWARF pull-in.
+2. `pub const std_options: std.Options = .{ .enable_segfault_handler = false };`
+   — zwasm already installs its own SIGSEGV handler in
+   `guard_mod.installSignalHandler()` for JIT guard-page OOB, so the std
+   default handler is always replaced at runtime anyway. Disabling it at
+   comptime elides `std.debug.handleSegfaultPosix` and the transitive
+   pull-in of `SelfInfo.Elf.*`.
+3. `pub fn main(init) u8 { return runCli(init) catch |err| { ... } }` —
+   `main` no longer returns an error union, so `start.zig`'s `wrapMain`
+   inlines the `u8` arm and never emits the call to
+   `std.debug.dumpErrorReturnTrace`.
+
+Remaining ~62 KB to target 1.50 MB (still well under 1.80 MB ceiling):
+`debug.*` ~81 KB (SelfInfo.Elf / Dwarf / writeTrace still reachable via
+`std.debug.lockStderr` → `std.Options.debug_io`), `std.Io.Threaded` ~115 KB.
+Tracked as W48 Phase 2 — next lever is `std_options_debug_io` override
+with a minimal direct-stderr Io instance. Non-blocking.
+
+Next candidate work:
 
 - **W47**: `tgo_strops_cached` +24% regression investigation (single-benchmark,
   low priority). See checklist.
 - **W45**: SIMD loop persistence — skip Q-cache eviction at loop headers
   (requires back-edge detection in `scanBranchTargets`).
-- **W48**: Linux binary size 1.65 → 1.50 MB. Candidates: custom panic
-  handler (dropping source-location printing), trim std.Io.Threaded
-  surface, measure ReleaseSmall. Non-blocking; 1.80 MB ceiling has slack.
+- **W48 Phase 2**: remaining 62 KB to reach 1.50 MB Linux. Non-blocking.
 
 ## Previous Task
+
+**W46 Phase 2 — DONE (2026-04-25 via PR #52).** Routed remaining `std.c.*`
+direct calls in `wasi.zig` through `platform.zig` helpers. Size-neutral on
+Linux because the `std.c.*` sites were already inside comptime-pruned
+`else` arms; pure consistency refactor.
+
+### W46 earlier phases
 
 **W46 Phase 1c/1d/1e/1f — DONE (2026-04-25 via PR #49).**
 

--- a/bench/history.yaml
+++ b/bench/history.yaml
@@ -3949,3 +3949,67 @@ entries:
       rw_cpp_string_cached: {time_ms: 4.8}
       rw_cpp_sort: {time_ms: 3.4}
       rw_cpp_sort_cached: {time_ms: 3.8}
+  - id: "v1.11-w48"
+    date: "2026-04-25"
+    reason: "W48: panic handler trim + segfault disable + u8 main return"
+    commit: "68a7067"
+    build: ReleaseSafe
+    results:
+      fib: {time_ms: 45.2}
+      fib_cached: {time_ms: 47.2}
+      tak: {time_ms: 5.1}
+      tak_cached: {time_ms: 5.1}
+      sieve: {time_ms: 5.2}
+      sieve_cached: {time_ms: 4.9}
+      nbody: {time_ms: 24.6}
+      nbody_cached: {time_ms: 22.4}
+      nqueens: {time_ms: 2.5}
+      nqueens_cached: {time_ms: 3.3}
+      tgo_fib: {time_ms: 33.7}
+      tgo_fib_cached: {time_ms: 34.2}
+      tgo_tak: {time_ms: 5.5}
+      tgo_tak_cached: {time_ms: 3.7}
+      tgo_arith: {time_ms: 2.4}
+      tgo_arith_cached: {time_ms: 1.9}
+      tgo_sieve: {time_ms: 1.4}
+      tgo_sieve_cached: {time_ms: 3.6}
+      tgo_fib_loop: {time_ms: 2.4}
+      tgo_fib_loop_cached: {time_ms: 1.8}
+      tgo_gcd: {time_ms: 2.8}
+      tgo_gcd_cached: {time_ms: 2.5}
+      tgo_nqueens: {time_ms: 55.1}
+      tgo_nqueens_cached: {time_ms: 59.5}
+      tgo_mfr: {time_ms: 46.9}
+      tgo_mfr_cached: {time_ms: 48.3}
+      tgo_list: {time_ms: 57.5}
+      tgo_list_cached: {time_ms: 58.5}
+      tgo_rwork: {time_ms: 6.4}
+      tgo_rwork_cached: {time_ms: 11.8}
+      tgo_strops: {time_ms: 67.9}
+      tgo_strops_cached: {time_ms: 66.0}
+      st_fib2: {time_ms: 847.8}
+      st_fib2_cached: {time_ms: 864.5}
+      st_sieve: {time_ms: 176.3}
+      st_sieve_cached: {time_ms: 175.8}
+      st_nestedloop: {time_ms: 2.6}
+      st_nestedloop_cached: {time_ms: 2.6}
+      st_ackermann: {time_ms: 5.6}
+      st_ackermann_cached: {time_ms: 3.7}
+      st_matrix: {time_ms: 278.8}
+      st_matrix_cached: {time_ms: 280.9}
+      gc_alloc: {time_ms: 5.2}
+      gc_alloc_cached: {time_ms: 3.9}
+      gc_tree: {time_ms: 16.5}
+      gc_tree_cached: {time_ms: 17.7}
+      rw_rust_fib: {time_ms: 41.6}
+      rw_rust_fib_cached: {time_ms: 40.6}
+      rw_c_matrix: {time_ms: 2.9}
+      rw_c_matrix_cached: {time_ms: 4.0}
+      rw_c_math: {time_ms: 19.7}
+      rw_c_math_cached: {time_ms: 19.5}
+      rw_c_string: {time_ms: 44.8}
+      rw_c_string_cached: {time_ms: 43.5}
+      rw_cpp_string: {time_ms: 5.6}
+      rw_cpp_string_cached: {time_ms: 5.6}
+      rw_cpp_sort: {time_ms: 3.2}
+      rw_cpp_sort_cached: {time_ms: 2.8}

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -12,6 +12,23 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const types = @import("types.zig");
+
+/// Minimal panic namespace: prints the message and traps, without
+/// pulling in DWARF parsing / source-location printing via the default
+/// `FullPanic` / `debug.defaultPanic` path. Saves ~30 KB on Linux,
+/// ~150 KB on Mac (W48). Tests still use the default handler because
+/// the test root is `src/types.zig`, not `src/cli.zig`.
+pub const panic = std.debug.simple_panic;
+
+/// Disable the std default segfault handler. zwasm already installs its
+/// own SIGSEGV handler in `guard_mod.installSignalHandler()` for JIT
+/// guard-page OOB traps, so the std handler would just be replaced at
+/// runtime anyway. Declaring this elides the default handler and its
+/// transitive pull-in of `debug.writeCurrentStackTrace` /
+/// `debug.SelfInfo.Elf.*` / DWARF parsing from the release binary.
+pub const std_options: std.Options = .{
+    .enable_segfault_handler = false,
+};
 const module_mod = @import("module.zig");
 const opcode = @import("opcode.zig");
 const vm_mod = @import("vm.zig");
@@ -33,7 +50,21 @@ const platform = @import("platform.zig");
 /// `io` through explicit parameters rather than relying on this global.
 var cli_io: std.Io = undefined;
 
-pub fn main(init: std.process.Init) !void {
+/// Entry point. Returns `u8` (not `!void`) so the start.zig wrapper does
+/// not emit a call to `std.debug.dumpErrorReturnTrace` — that pull-in
+/// drags DWARF / ELF parsing into the binary (~80 KB on Linux). We catch
+/// errors here and print them ourselves (W48).
+pub fn main(init: std.process.Init) u8 {
+    return runCli(init) catch |err| {
+        var buf: [256]u8 = undefined;
+        var w = std.Io.File.stderr().writer(init.io, &buf);
+        w.interface.print("error: {t}\n", .{err}) catch {};
+        w.interface.flush() catch {};
+        return 1;
+    };
+}
+
+fn runCli(init: std.process.Init) !u8 {
     // Install signal handler for JIT guard page OOB traps
     if (comptime jit_mod.jitSupported()) {
         guard_mod.installSignalHandler();
@@ -70,25 +101,26 @@ pub fn main(init: std.process.Init) !void {
     if (args.len < 2) {
         printUsage(stdout);
         try stdout.flush();
-        return;
+        return 0;
     }
 
     const command = args[1];
+    var exit_code: u8 = 0;
 
     if (std.mem.eql(u8, command, "run")) {
         const ok = try cmdRun(allocator, args[2..], stdout, stderr);
         try stdout.flush();
-        if (!ok) std.process.exit(1);
+        if (!ok) exit_code = 1;
     } else if (std.mem.eql(u8, command, "inspect")) {
         try cmdInspect(allocator, args[2..], stdout, stderr);
     } else if (std.mem.eql(u8, command, "validate")) {
         const ok = try cmdValidate(allocator, args[2..], stdout, stderr);
         try stdout.flush();
-        if (!ok) std.process.exit(1);
+        if (!ok) exit_code = 1;
     } else if (std.mem.eql(u8, command, "compile")) {
         const ok = try cmdCompile(allocator, args[2..], stdout, stderr);
         try stdout.flush();
-        if (!ok) std.process.exit(1);
+        if (!ok) exit_code = 1;
     } else if (std.mem.eql(u8, command, "features")) {
         cmdFeatures(args[2..], stdout, stderr);
     } else if (std.mem.eql(u8, command, "help") or std.mem.eql(u8, command, "--help") or std.mem.eql(u8, command, "-h")) {
@@ -99,13 +131,14 @@ pub fn main(init: std.process.Init) !void {
         // zwasm file.wasm ... → shorthand for zwasm run file.wasm ...
         const ok = try cmdRun(allocator, args[1..], stdout, stderr);
         try stdout.flush();
-        if (!ok) std.process.exit(1);
+        if (!ok) exit_code = 1;
     } else {
         try stderr.print("error: unknown command '{s}'\n", .{command});
         try stderr.flush();
         printUsage(stdout);
     }
     try stdout.flush();
+    return exit_code;
 }
 
 fn printUsage(w: *std.Io.Writer) void {


### PR DESCRIPTION
## Summary

Three small changes in `src/cli.zig` (CLI root only — library/test/example roots untouched) to reduce the stripped ReleaseSafe binary:

1. `pub const panic = std.debug.simple_panic;` — skips the FullPanic formatted messages and DWARF-backed source-location printing.
2. `pub const std_options: std.Options = .{ .enable_segfault_handler = false };` — zwasm already installs its own SIGSEGV handler in `guard_mod.installSignalHandler()` for JIT guard-page OOB, so the std default handler was always being clobbered anyway. Disabling it at comptime elides `SelfInfo.Elf.*` / stack unwinder.
3. `pub fn main(init) u8` (was `!void`). `start.zig`'s `wrapMain` is inline; with a `u8` return type it comptime-resolves to `return result` only, so `std.debug.dumpErrorReturnTrace` becomes dead code. CLI errors are now caught and reported via a direct stderr print.

## Size result (stripped, ReleaseSafe)

| Target | Before | After | Delta |
| --- | --- | --- | --- |
| Linux x86_64 | 1,722,328 B (1.64 MB) | 1,636,792 B (1.56 MB) | **-83 KB (-5%)** |
| Mac aarch64 | 1,442,896 B (1.38 MB) | 1,260,992 B (1.20 MB) | **-180 KB (-13%)** |

Target 1.50 MB Linux still ~62 KB away — tracked as W48 Phase 2 (`std_options_debug_io` override). Non-blocking; 1.80 MB ceiling has ample slack.

## Test plan

- [x] `zig build test` — 399/399 pass
- [x] Minimal build (`-Djit=false -Dcomponent=false -Dwat=false`) — 268 / 15 skip / 0 fail
- [x] `python3 test/spec/run_spec.py --build --summary` — 62263/62263, 0 skip
- [x] `bash test/e2e/run_e2e.sh --convert --summary` — 796/796
- [x] `bash test/realworld/run_compat.sh` — 50/50
- [x] `bash test/c_api/run_ffi_test.sh --build` — 80/80
- [x] Cross-compile: Linux x86_64 + Mac aarch64 clean
- [x] `bash bench/ci_compare.sh --runs=5 --threshold=20` vs `origin/main` — no regression (gc_alloc_cached +11% is within noise)
- [x] Bench recorded as `v1.11-w48` in `bench/history.yaml`
- [x] CLI smoke-tested: `version`, `help`, `run fib 10` (= 55), invalid commands return correct exit codes
- [ ] CI green on Ubuntu + Windows + size-matrix runners (will check after push)