### PR TITLE
fix(types): plug export_fns/cached_fns leak when start function traps (#42)

### DIFF
--- a/bench/history.yaml
+++ b/bench/history.yaml
@@ -4013,3 +4013,67 @@ entries:
       rw_cpp_string_cached: {time_ms: 5.6}
       rw_cpp_sort: {time_ms: 3.2}
       rw_cpp_sort_cached: {time_ms: 2.8}
+  - id: "issue-42-fix"
+    date: "2026-04-26"
+    reason: "loadCore errdefer for export_fns/cached_fns (issue #42)"
+    commit: "dd7b43a"
+    build: ReleaseSafe
+    results:
+      fib: {time_ms: 44.9}
+      fib_cached: {time_ms: 43.9}
+      tak: {time_ms: 6.4}
+      tak_cached: {time_ms: 6.5}
+      sieve: {time_ms: 4.7}
+      sieve_cached: {time_ms: 6.3}
+      nbody: {time_ms: 22.6}
+      nbody_cached: {time_ms: 23.9}
+      nqueens: {time_ms: 2.1}
+      nqueens_cached: {time_ms: 2.7}
+      tgo_fib: {time_ms: 33.3}
+      tgo_fib_cached: {time_ms: 33.5}
+      tgo_tak: {time_ms: 6.2}
+      tgo_tak_cached: {time_ms: 6.4}
+      tgo_arith: {time_ms: 1.6}
+      tgo_arith_cached: {time_ms: 2.0}
+      tgo_sieve: {time_ms: 3.2}
+      tgo_sieve_cached: {time_ms: 0.2}
+      tgo_fib_loop: {time_ms: 1.9}
+      tgo_fib_loop_cached: {time_ms: 2.5}
+      tgo_gcd: {time_ms: 1.9}
+      tgo_gcd_cached: {time_ms: 2.5}
+      tgo_nqueens: {time_ms: 55.3}
+      tgo_nqueens_cached: {time_ms: 53.2}
+      tgo_mfr: {time_ms: 47.5}
+      tgo_mfr_cached: {time_ms: 47.3}
+      tgo_list: {time_ms: 56.2}
+      tgo_list_cached: {time_ms: 56.7}
+      tgo_rwork: {time_ms: 6.3}
+      tgo_rwork_cached: {time_ms: 6.3}
+      tgo_strops: {time_ms: 66.5}
+      tgo_strops_cached: {time_ms: 82.0}
+      st_fib2: {time_ms: 840.3}
+      st_fib2_cached: {time_ms: 852.9}
+      st_sieve: {time_ms: 173.1}
+      st_sieve_cached: {time_ms: 173.3}
+      st_nestedloop: {time_ms: 2.2}
+      st_nestedloop_cached: {time_ms: 2.6}
+      st_ackermann: {time_ms: 4.5}
+      st_ackermann_cached: {time_ms: 4.6}
+      st_matrix: {time_ms: 275.6}
+      st_matrix_cached: {time_ms: 277.9}
+      gc_alloc: {time_ms: 3.6}
+      gc_alloc_cached: {time_ms: 4.0}
+      gc_tree: {time_ms: 16.5}
+      gc_tree_cached: {time_ms: 15.8}
+      rw_rust_fib: {time_ms: 34.3}
+      rw_rust_fib_cached: {time_ms: 35.5}
+      rw_c_matrix: {time_ms: 3.0}
+      rw_c_matrix_cached: {time_ms: 3.0}
+      rw_c_math: {time_ms: 19.3}
+      rw_c_math_cached: {time_ms: 19.2}
+      rw_c_string: {time_ms: 42.8}
+      rw_c_string_cached: {time_ms: 43.0}
+      rw_cpp_string: {time_ms: 4.8}
+      rw_cpp_string_cached: {time_ms: 5.2}
+      rw_cpp_sort: {time_ms: 3.8}
+      rw_cpp_sort_cached: {time_ms: 3.2}

--- a/src/types.zig
+++ b/src/types.zig
@@ -506,7 +506,15 @@ pub const WasmModule = struct {
         try self.instance.instantiate();
 
         self.export_fns = buildExportInfo(allocator, &self.module) catch &[_]ExportInfo{};
+        errdefer {
+            for (self.export_fns) |ei| {
+                allocator.free(ei.param_types);
+                allocator.free(ei.result_types);
+            }
+            if (self.export_fns.len > 0) allocator.free(self.export_fns);
+        }
         self.cached_fns = buildCachedFns(allocator, self) catch &[_]WasmFn{};
+        errdefer if (self.cached_fns.len > 0) allocator.free(self.cached_fns);
         self.wit_funcs = &[_]wit_parser.WitFunc{};
 
         self.vm = try allocator.create(rt.vm_mod.Vm);
@@ -1624,6 +1632,21 @@ test "WasmModule.Config applies VM limits" {
     try testing.expectEqual(@as(?u64, 1048576), wasm_mod.vm.?.max_memory_bytes);
     try testing.expectEqual(true, wasm_mod.vm.?.force_interpreter);
     try testing.expect(wasm_mod.vm.?.deadline_ns != null);
+}
+
+test "loadFromWat: trapping start function does not leak export_fns/cached_fns (issue #42)" {
+    if (!@import("build_options").enable_wat) return error.SkipZigTest;
+    const wat =
+        \\(module
+        \\  (func $start unreachable)
+        \\  (func (export "dummy") (result i32) i32.const 0)
+        \\  (start $start)
+        \\)
+    ;
+    try testing.expectError(
+        error.Unreachable,
+        WasmModule.loadFromWat(testing.allocator, wat),
+    );
 }
 
 test "loadLinked OOM after phase 1: invoke returns ModuleNotFullyLoaded" {


### PR DESCRIPTION
## Summary

Closes #42.

`WasmModule.loadCore` allocates `export_fns` and `cached_fns` before invoking the Wasm `start` function. If the start function traps (e.g. `unreachable`), the existing `errdefer` chain unwinds `vm`/`instance`/`wasi_ctx`/`module`/`store`/`self` but never frees the export caches — leaking both slices and the inner `param_types`/`result_types` arrays.

This PR adds `errdefer` entries that mirror the `deinit` order so the failure path is symmetric with normal teardown. The `errdefer` is zero-overhead on the happy path (Zig registers cleanup at compile time, no runtime check) and only fires when the start function or a later allocation returns an error.

A regression test is added under `loadFromWat` (guarded with `enable_wat`) that loads a module with `unreachable` start + a non-empty export and asserts no leaks via `testing.allocator`.

## Test plan

Local Mac (aarch64) gates:

- [x] `zig build test` — 400/400 pass, 0 leak (Red 確認: 3 leaks → Green: 0 leak)
- [x] `python3 test/spec/run_spec.py --build --summary` — 62263/62263 pass
- [x] `bash test/e2e/run_e2e.sh --convert --summary` — 796/796 pass, 0 leak
- [x] `bash test/realworld/run_compat.sh` — PASS=50 FAIL=0 CRASH=0
- [x] `bash test/c_api/run_ffi_test.sh --build` — 80/80 pass
- [x] `zig build test -Djit=false -Dcomponent=false -Dwat=false` — 268 pass, 16 skip, 0 fail
- [x] Size guard — 1.14 MB stripped (≤ 1.60 MB ceiling)
- [x] Full benchmark recorded as `issue-42-fix` in `bench/history.yaml` — large benches stable / improved; small (<10ms) benches show hyperfine noise floor variance only (errdefer change cannot physically affect hot path)

CI will validate Ubuntu x86_64.