### PR TITLE
feat(env): Nix-mirror versions.lock + WASI SDK 30 + environment.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -118,10 +118,15 @@ When in doubt, **continue**.
 6. `zig build test -Djit=false -Dcomponent=false -Dwat=false` — 0 fail (minimal build)
 7. Benchmarks pass (no regression)
 8. **CI green**: `gh run list --branch main --limit 1` — check after push
+9. **versions.lock ↔ flake.nix consistency** — bumped pins exist in both files
+   (Plan B will mechanise this with `scripts/sync-versions.sh`; until then,
+   review the diff manually when either file changes.)
 
 Items 1-6 must pass on BOTH platforms before merge. Run them in parallel:
 Mac items can run locally, Ubuntu items via `orb run -m my-ubuntu-amd64`.
 Fix root cause before merging if Ubuntu reveals new failures.
+
+Environment setup, tool versions, and CI ↔ local mapping: `@./.dev/environment.md`.
 
 ## Build & Test
 
@@ -201,5 +206,6 @@ Development: `@./.claude/rules/reliability-work.md` (auto-loads on src/test/benc
 Roadmap: `@./.dev/roadmap.md` (zwasm phases) + `@./private/future/03_zwasm_clojurewasm_roadmap_ja.md` (integrated).
 Allocator injection: `@./.dev/archive/allocator-injection-plan.md` — Phase 11 design + task breakdown (D128, completed in v1.5.0; archived).
 SIMD performance: `@./.dev/decisions.md` → D132 — two-phase SIMD optimization plan (W43 addr cache, W44 reg class).
+Environment: `@./.dev/environment.md` — Mac/Linux/Windows setup, tool versions, CI ↔ local mapping (D136).
 Ubuntu testing: `@./.dev/references/ubuntu-testing-guide.md` — OrbStack VM test commands.
 OrbStack setup: `@./.dev/references/setup-orbstack.md` — VM creation and tool installation.

--- a/.dev/decisions.md
+++ b/.dev/decisions.md
@@ -213,22 +213,23 @@ easy to forget, causing silent drift from upstream.
    `.github/spec-sha` marker file.
 
 2. **wasm-tools bump** (`wasm-tools-bump.yml`): Monthly (1st, 05:00 UTC). Queries
-   GitHub API for latest release, updates `.github/tool-versions`, runs tests,
+   GitHub API for latest release, updates `.github/versions.lock`, runs tests,
    creates PR if they pass.
 
 3. **SpecTec monitor** (`spectec-monitor.yml`): Weekly (Monday 06:00 UTC). Checks
    for changes in `document/core/` or `spectec/` directories. Creates GitHub issue
    (with dedup) if changes found. Advisory only — no auto-merge.
 
-**Centralized versions**: `.github/tool-versions` stores WASM_TOOLS_VERSION,
+**Centralized versions**: `.github/versions.lock` stores WASM_TOOLS_VERSION,
 WASMTIME_VERSION, WASI_SDK_VERSION. All workflows `source` this file instead of
-hardcoding versions. Single-file version bumps.
+hardcoding versions. Single-file version bumps. (Renamed from `tool-versions`
+in D136 when it became the cross-environment mirror of flake.nix pins.)
 
 **Trade-off**: Auto-PRs require manual review before merge. Acceptable: version
 bumps can introduce subtle behavior changes. Nightly workflow re-enabled as weekly
 (Wednesday 03:00 UTC) to catch regressions without burning CI minutes daily.
 
-Affected files: `.github/tool-versions`, `.github/workflows/ci.yml`,
+Affected files: `.github/versions.lock`, `.github/workflows/ci.yml`,
 `.github/workflows/nightly.yml`, `.github/workflows/spec-bump.yml`,
 `.github/workflows/wasm-tools-bump.yml`, `.github/workflows/spectec-monitor.yml`
 
@@ -742,4 +743,105 @@ iterations — symptoms consistent with the Threaded scheduler being torn down
 too early even though the variable was still in scope. Using `init.io`
 (supplied by `start.zig`) avoids this entirely. Use init.io for top-level
 binaries; use a freshly constructed Threaded only when the scope is bounded.
+
+---
+
+## D136: Nix flake as toolchain SSoT, with `versions.lock` as the cross-environment mirror
+
+**Context**: Three separate places independently described "the toolchain
+zwasm builds against": (1) `flake.nix` for `nix develop` + direnv on
+Linux/macOS, (2) the old `.github/tool-versions` for a handful of CI
+pins, (3) ad-hoc CI YAML literals for everything else (Zig action input,
+hyperfine DEB URL, etc.). Drift was already present — the local nix
+devshell delivered `wasi-sdk-30`, while CI consumed `WASI_SDK_VERSION=25`
+through `tool-versions`, so realworld C/C++ builds in PRs were never
+validated against the SDK developers ran locally. With Windows joining
+the supported matrix as a first-class environment (W## tracking item)
+and Nix unable to run natively on Windows, the model needed an explicit
+SSoT plus a sanctioned mirror, not three drifting copies.
+
+**Decision**:
+
+1. **`flake.nix` is the single source of truth for Linux and macOS**, both
+   for local development (via `.envrc` → `use flake .`) and for CI once
+   Plan B lands. Pinned tools that Nix manages directly (Zig, WASI SDK)
+   carry their version + URL + sha256 inside `flake.nix`.
+
+2. **`.github/versions.lock`** (renamed from `tool-versions`) is the mirror
+   for environments that cannot consume Nix:
+
+   - Windows native installer scripts (Plan B)
+   - CI workflow steps that need a string before Nix is available
+     (`actions/setup-zig` input, `cargo install --version`, release ZIP URLs)
+
+   The file is bash-sourceable (`source .github/versions.lock`) and also
+   read by Python via `splitlines()`. It carries every pin a non-Nix
+   consumer might need, even ones currently only fetched by Nix on
+   Linux/Mac, so the Windows installer can stay symmetric.
+
+3. **Update discipline**: bumping a pin requires editing both
+   `flake.nix` (when applicable) and `versions.lock`. A future
+   `scripts/sync-versions.sh` (Plan B) plus a Merge Gate consistency
+   check will mechanise this — until then it is a code-review concern.
+
+4. **No WSL fallback for Windows.** The whole point of the Windows
+   matrix entry is to validate native PE/COFF + MSVC behaviour. Routing
+   Windows through WSL2 + Nix would re-test Linux, not Windows. Windows
+   uses native tooling installed via winget / direct release ZIPs whose
+   versions are dictated by `versions.lock`.
+
+5. **Future shape (Plan B + C, separate PRs)**:
+
+   - `scripts/gate-commit.sh`, `scripts/gate-merge.sh`,
+     `scripts/run-bench.sh` become the unified entry points. They run
+     identically locally and in CI; each is invoked under
+     `nix develop --command` on Linux/Mac and natively under Git Bash
+     on Windows.
+   - CI Linux/Mac jobs adopt
+     `DeterminateSystems/nix-installer-action` +
+     `DeterminateSystems/magic-nix-cache-action` and call those scripts.
+   - CI Windows job runs `scripts/windows/install-tools.ps1` (reads
+     `versions.lock`) then the same gate scripts under bash.
+   - `ci.yml`'s eleven `if: runner.os != 'Windows'` skips become
+     individual no-skip targets (Plan C: shared-lib DLL, FFI tests,
+     static link, binary size via `zig objcopy --strip-all`, memory
+     check via PowerShell, size-matrix OS-fanout, benchmark Windows
+     record-only).
+
+**Alternatives considered**:
+
+- **Single `flake.nix` only, no mirror file.** Rejected — Windows cannot
+  consume `flake.nix`, and having CI YAML hardcode versions independently
+  reproduces the drift problem we just fixed.
+- **Replace `tool-versions` with `flake.lock` direct queries** (e.g.
+  `nix eval`). Rejected for now — needs Nix on the consumer, which
+  defeats the Windows use case. May revisit when Plan B's
+  `scripts/sync-versions.sh` is in place; a non-Nix pre-rendered lock
+  is friendlier to humans reading PRs.
+- **Drop the Windows native matrix entry, use WSL only.** Rejected per
+  point 4.
+
+**Bumping WASI SDK 25 → 30 in this PR**: not a separate decision — it is
+the immediate consequence of declaring `flake.nix` (already at 30) the
+SSoT. Verified locally with `python test/realworld/build_all.py --force`
+and `run_compat.py` (50 PASS / 0 FAIL / 0 CRASH, 2026-04-29).
+
+**Affected files (this PR / Plan A)**: `.github/versions.lock` (renamed
+from `tool-versions`, expanded with `ZIG_VERSION` and `[planned]`
+informational pins), `.github/workflows/ci.yml`,
+`.github/workflows/nightly.yml`, `.github/workflows/spec-bump.yml`,
+`.github/workflows/wasm-tools-bump.yml`, `ARCHITECTURE.md`,
+`.dev/environment.md` (new), `CLAUDE.md` (Merge Gate addendum).
+
+**Affected files (Plan B, separate PR)**: `scripts/lib/versions.sh`,
+`scripts/sync-versions.sh`, `scripts/gate-commit.sh`,
+`scripts/gate-merge.sh`, `scripts/run-bench.sh`,
+`scripts/windows/install-tools.ps1`, `flake.nix` (pin wasm-tools /
+wasmtime / hyperfine explicitly), `ci.yml` refactor.
+
+**Affected files (Plan C, separate PR)**: `test/c_api/run_ffi_test.sh`
+(Windows DLL + LoadLibraryA), `test/c_api/test_ffi.c` (Win32 path),
+`examples/rust/build.rs` (Windows), CI binary-size step
+(`zig objcopy --strip-all`), CI memory check (PowerShell), `size-matrix`
++ `benchmark` jobs (OS fanout).
 

--- a/.dev/environment.md
+++ b/.dev/environment.md
@@ -1,0 +1,225 @@
+# Development Environment
+
+How to set up zwasm for local development and how the same toolchain is
+exercised in CI. zwasm officially supports three host environments:
+**macOS (Apple Silicon and Intel)**, **Linux x86_64 / aarch64**, and
+**Windows x86_64**. All three are part of the GitHub Actions matrix and
+all three are expected to satisfy the Commit Gate locally.
+
+## Source of Truth for Tool Versions
+
+Two files together define every pinned tool zwasm depends on:
+
+| File                     | Audience           | Authoritative for                                   |
+|--------------------------|--------------------|-----------------------------------------------------|
+| `flake.nix`              | Linux / macOS      | Everything Nix manages (Zig, WASI SDK, plus all of `buildInputs`) |
+| `.github/versions.lock`  | Windows + CI YAML  | The same pins, mirrored as bash-sourceable `KEY=value` |
+
+`flake.nix` is the originator. `versions.lock` is the mirror used wherever
+Nix cannot reach: Windows native installs, GitHub Actions steps that need
+a version string before Nix is available (e.g. `actions/setup-zig`,
+`cargo install --version`), and any consumer that reads it as plain text.
+Bumping a pin requires editing both. See **D136** in `.dev/decisions.md`
+for the rationale.
+
+A future `scripts/sync-versions.sh` (Plan B) plus a Merge Gate consistency
+check will mechanise the synchronisation. Until then it is a code-review
+concern.
+
+## Required Manually (per host OS)
+
+These tools are not delivered by Nix or by the project; the developer has
+to install them once:
+
+| OS               | Required by hand                                                                                        |
+|------------------|---------------------------------------------------------------------------------------------------------|
+| macOS            | `git`, [Nix](https://nixos.org/download/) (Determinate installer recommended), [direnv](https://direnv.net/) + `nix-direnv` |
+| Linux x86_64     | `git`, Nix, direnv + nix-direnv                                                                         |
+| Linux (OrbStack) | Same as Linux. VM bootstrap covered in `setup-orbstack.md`.                                             |
+| Windows x86_64   | `git` (Git for Windows — supplies bash + curl + tar + unzip), Python 3.x, PowerShell 7, winget          |
+
+Everything else (Zig, wasm-tools, wasmtime, WASI SDK, hyperfine, jq, yq,
+Go, TinyGo, Node.js, Bun) is delivered by `flake.nix` on Linux/macOS, and
+will be delivered by `scripts/windows/install-tools.ps1` on Windows once
+Plan B lands (manual install steps below for now).
+
+## macOS
+
+### One-time bootstrap
+
+```bash
+# 1. Nix (Determinate installer)
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+
+# 2. direnv + nix-direnv
+brew install direnv nix-direnv
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc   # or bash equivalent
+mkdir -p ~/.config/nix && echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+
+# 3. Allow this repo's flake
+cd /path/to/zwasm
+direnv allow
+```
+
+After `direnv allow`, every shell entering the repo has Zig 0.16.0,
+Python 3.13, wasm-tools, wasmtime, WASI SDK, hyperfine, jq, yq-go,
+TinyGo, Go, Node.js, Bun, and GNU coreutils on `PATH` automatically.
+There is no `nix develop --command` wrapper to remember.
+
+### Daily
+
+```bash
+zig build test                                       # Unit tests
+python test/spec/run_spec.py --build --summary       # Spec
+python test/e2e/run_e2e.py --convert --summary       # E2E
+python test/realworld/build_all.py                   # Build real-world wasm
+python test/realworld/run_compat.py                  # Compat vs wasmtime
+bash test/c_api/run_ffi_test.sh --build              # FFI dynamic
+bash bench/run_bench.sh --quick                      # Quick bench
+```
+
+The full Commit Gate / Merge Gate checklist lives in `CLAUDE.md`.
+
+## Linux (Ubuntu x86_64)
+
+### Native Linux (host or full VM)
+
+Same procedure as macOS, swapping the package manager for Nix
+installation:
+
+```bash
+sh <(curl -L https://nixos.org/nix/install) --daemon
+# direnv + nix-direnv via apt or your package manager
+sudo apt install direnv
+nix profile install nixpkgs#nix-direnv
+direnv allow
+```
+
+### OrbStack VM on Apple Silicon
+
+Used for x86_64 verification of code changes that need to land on Linux
+amd64 before merging (Merge Gate requirement).
+
+- VM creation and tool installation: `setup-orbstack.md`
+- Run-time commands: `ubuntu-testing-guide.md`
+
+> **Note**: `setup-orbstack.md` predates the Nix-as-SSoT decision
+> (D136) and currently bootstraps tools manually with versions that
+> drift from `flake.nix`. Migrating the VM to Nix devshell + direnv
+> is tracked as a Plan B follow-up. Until then, after pulling a
+> change that bumps a pin, re-run the affected steps in
+> `setup-orbstack.md` (or just install Nix inside the VM and use the
+> macOS recipe above).
+
+## Windows
+
+Windows uses **native tooling**, not WSL. The whole reason Windows is in
+the matrix is to validate native PE/COFF and MSVC behaviour; routing
+through WSL would re-test Linux. See **D136** for the rationale.
+
+### One-time bootstrap (manual until Plan B's installer ships)
+
+Pre-install via winget (run in admin PowerShell once):
+
+```powershell
+winget install --id Git.Git -e
+winget install --id Microsoft.PowerShell -e
+winget install --id Python.Python.3.14 -e
+```
+
+Then install the version-pinned tools by reading `.github/versions.lock`
+and downloading each release. The pins to use today (Plan A baseline):
+
+| Tool           | Pin     | Source                                                                                          |
+|----------------|---------|-------------------------------------------------------------------------------------------------|
+| Zig            | 0.16.0  | `https://ziglang.org/download/0.16.0/zig-x86_64-windows-0.16.0.zip`                              |
+| WASI SDK       | 30      | `https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-30/wasi-sdk-30.0-x86_64-windows.tar.gz` |
+| wasm-tools     | 1.246.1 | `https://github.com/bytecodealliance/wasm-tools/releases/...`                                  |
+| wasmtime       | 42.0.1  | `https://github.com/bytecodealliance/wasmtime/releases/...`                                    |
+| Rust           | stable  | `rustup-init.exe` (cargo, target `wasm32-wasip1` for realworld/Rust)                           |
+
+After install, set `WASI_SDK_PATH` to the extracted SDK root and ensure
+`zig`, `wasm-tools`, `wasmtime` are on `PATH`.
+
+### Daily (under Git for Windows bash)
+
+```bash
+zig build test
+zig build c-test                          # C API tests via Zig harness
+python test/spec/run_spec.py --build --summary
+python test/e2e/run_e2e.py --convert --summary
+python test/realworld/build_all.py
+python test/realworld/run_compat.py
+```
+
+### Currently-skipped CI items on Windows (Plan C tracker)
+
+These are the steps `ci.yml` guards with `if: runner.os != 'Windows'`.
+They are blockers for "Windows reaches Merge Gate parity" and tracked as
+Plan C work. None reflects a fundamental Windows incompatibility — every
+one is a script-side limitation:
+
+| Step                                    | Blocker                                                 | Fix shape                                                  |
+|-----------------------------------------|---------------------------------------------------------|------------------------------------------------------------|
+| `zig build shared-lib`                  | None known; just gated                                  | Drop `if:`                                                 |
+| `test/c_api/run_ffi_test.sh`            | `gcc -ldl -pthread`, `dlfcn.h` in `test_ffi.c`          | Branch for `LoadLibraryA` + `GetProcAddress` (~50 lines C) |
+| `examples/rust` `cargo run`             | `build.rs` solves dynamic-lib path Linux/Mac only       | Add Windows branch in `build.rs`                           |
+| `zig build static-lib` + static link    | Shell script assumes `cc`                               | Branch by `RUNNER_OS`                                      |
+| Binary size check                       | Uses GNU `strip`                                        | Replace with `zig objcopy --strip-all` (cross-platform)    |
+| Memory check                            | Uses `/usr/bin/time -l` / `-v`                          | PowerShell `Measure-Command` + `Get-Process.PeakWorkingSet`|
+| `size-matrix` job                       | `strip` again                                           | Same `zig objcopy` fix; fan out matrix to all 3 OS         |
+| `benchmark` job                         | `hyperfine` install via DEB                             | Add Windows install step (winget or release ZIP); record-only on Windows |
+
+## Nix devshell contents (current)
+
+`flake.nix` provides the following on Linux/macOS via `buildInputs`:
+
+| Package            | Used by                                                        |
+|--------------------|----------------------------------------------------------------|
+| `zigBin` (0.16.0)  | All builds and tests                                           |
+| `wasmtime`         | Realworld compat comparison runtime                            |
+| `bun`, `nodejs`    | `bench/run_wasm.mjs`, `bench/run_wasm_wasi.mjs`                |
+| `yq-go`, `jq`      | Bench result transformation, history.yaml editing              |
+| `hyperfine`        | All bench scripts                                              |
+| `tinygo`           | `bench/wasm/tgo_*.wasm` and `realworld/tinygo/`                |
+| `wasm-tools`       | `json-from-wast` for spec test conversion, component inspection|
+| `go`               | `realworld/go/` (`GOOS=wasip1 GOARCH=wasm`)                    |
+| `gnused`, `coreutils` | Stable shell env for bench / test scripts                   |
+| `python3`          | All `test/**/*.py` runners                                     |
+| `wasiSdkBin` (30)  | `WASI_SDK_PATH` for realworld C / C++                          |
+
+Rust toolchain is **not** in `flake.nix` — `realworld/build_all.py`
+expects `rustup` from `~/.cargo/bin`. CI installs it via `rustup`. The
+nix devshell user is expected to install Rust outside Nix. (This is
+called out in `flake.nix` as a comment.)
+
+## CI ↔ Local Gate Mapping
+
+Today, CI installs each tool individually rather than entering a Nix
+devshell, so local and CI run "the same gates" only by convention. Plan B
+collapses this onto a shared `scripts/gate-*.sh` family of entry points
+that both contexts invoke identically.
+
+| Gate                                  | Local (today)                          | CI (today)                                   | Future (Plan B)                              |
+|---------------------------------------|----------------------------------------|----------------------------------------------|----------------------------------------------|
+| Commit Gate (CLAUDE.md items 0-8)     | Hand-run individual commands           | `ci.yml > test` job                          | `bash scripts/gate-commit.sh` everywhere     |
+| Merge Gate (Mac + Ubuntu both clean)  | Manual checklist + OrbStack            | `ci.yml > test` (3 OS) + `size-matrix`       | `bash scripts/gate-merge.sh` + versions.lock check |
+| Bench (regression + record)           | `bash bench/run_bench.sh`              | `ci.yml > benchmark` (Ubuntu only)           | `bash scripts/run-bench.sh` (Linux reference + Windows record-only) |
+| Nightly fuzz                          | `bash test/fuzz/fuzz_overnight.sh`     | `nightly.yml > fuzz`                         | Same scripts; Linux/Mac under `nix develop`  |
+
+In Plan B, CI on Linux/macOS will use
+`DeterminateSystems/nix-installer-action` +
+`DeterminateSystems/magic-nix-cache-action`, then call the gate scripts
+under `nix develop --command`. Windows CI will run
+`scripts/windows/install-tools.ps1` (which reads `versions.lock`) and
+then call the same gate scripts under Git Bash.
+
+## References
+
+- `flake.nix` — the SSoT for Linux/macOS pins
+- `.github/versions.lock` — the SSoT mirror for Windows / CI YAML
+- `.github/workflows/ci.yml` — current CI definition
+- `.dev/decisions.md` — D136 captures the SSoT design and Plan B/C scope
+- `.dev/references/setup-orbstack.md` — Apple Silicon Ubuntu VM bootstrap (manual; Nix migration tracked as Plan B follow-up)
+- `.dev/references/ubuntu-testing-guide.md` — Run-time recipes inside the OrbStack VM
+- `CLAUDE.md` — Commit Gate / Merge Gate checklists

--- a/.github/tool-versions
+++ b/.github/tool-versions
@@ -1,7 +1,0 @@
-# Centralized tool versions for CI workflows.
-# Update versions here — workflows source this file automatically.
-
-WASM_TOOLS_VERSION=1.246.1
-WASMTIME_VERSION=42.0.1
-WASI_SDK_VERSION=25
-RUST_VERSION=stable

--- a/.github/versions.lock
+++ b/.github/versions.lock
@@ -1,0 +1,35 @@
+# versions.lock — single mirror of pinned tool versions used by zwasm.
+#
+# Source of truth: flake.nix (Linux/macOS via nix devshell + direnv).
+# This file mirrors the same pins for environments that cannot use Nix —
+# primarily Windows native installs and CI workflow steps that need a
+# version string before nix is available. Sourced as a bash file
+# (`source .github/versions.lock`) and read by Python via splitlines().
+#
+# Update process (until scripts/sync-versions.sh lands):
+#   1. Bump the value below
+#   2. If the pin lives in flake.nix (Zig, WASI SDK), update flake.nix too
+#   3. Run zig build test + the relevant gates locally
+#
+# Categories:
+#   [enforced] CI / install scripts read this value to fetch the tool
+#   [planned]  Will be enforced once Plan B introduces a Windows installer
+#              and Plan C extends Windows CI coverage. Values track
+#              flake.lock today.
+
+# === [enforced] tools ===
+
+ZIG_VERSION=0.16.0           # mirrors flake.nix zigArchInfo
+WASM_TOOLS_VERSION=1.246.1   # cargo install in ci.yml
+WASMTIME_VERSION=42.0.1      # release zip download in ci.yml
+WASI_SDK_VERSION=30          # mirrors flake.nix wasiSdkArchInfo (Linux/macOS/Windows tarballs)
+RUST_VERSION=stable          # rustup install in ci.yml
+
+# === [planned] tools (informational; not yet read by any script) ===
+
+HYPERFINE_VERSION=1.18.0     # bench job DEB download in ci.yml; will move into Windows installer
+GO_VERSION=1.25.5            # tracks current flake.lock nixpkgs revision
+TINYGO_VERSION=0.40.1        # tracks current flake.lock nixpkgs revision
+NODEJS_VERSION=24.13.0       # tracks current flake.lock nixpkgs revision
+BUN_VERSION=1.3.8            # tracks current flake.lock nixpkgs revision
+PYTHON_VERSION=3.13          # mirrors flake.lock python3 minor; CI uses actions/setup-python with 3.x

--- a/.github/versions.lock
+++ b/.github/versions.lock
@@ -6,6 +6,11 @@
 # version string before nix is available. Sourced as a bash file
 # (`source .github/versions.lock`) and read by Python via splitlines().
 #
+# IMPORTANT: do NOT add inline comments after a value. Keep comments on
+# their own line above each entry. Bash strips trailing `# ...` when
+# sourcing, but the Python reader in ci.yml does a plain split('=', 1)
+# and would otherwise pull the comment text into the version string.
+#
 # Update process (until scripts/sync-versions.sh lands):
 #   1. Bump the value below
 #   2. If the pin lives in flake.nix (Zig, WASI SDK), update flake.nix too
@@ -19,17 +24,28 @@
 
 # === [enforced] tools ===
 
-ZIG_VERSION=0.16.0           # mirrors flake.nix zigArchInfo
-WASM_TOOLS_VERSION=1.246.1   # cargo install in ci.yml
-WASMTIME_VERSION=42.0.1      # release zip download in ci.yml
-WASI_SDK_VERSION=30          # mirrors flake.nix wasiSdkArchInfo (Linux/macOS/Windows tarballs)
-RUST_VERSION=stable          # rustup install in ci.yml
+# Mirrors flake.nix zigArchInfo.
+ZIG_VERSION=0.16.0
+# cargo install in ci.yml.
+WASM_TOOLS_VERSION=1.246.1
+# Release zip download in ci.yml.
+WASMTIME_VERSION=42.0.1
+# Mirrors flake.nix wasiSdkArchInfo (Linux/macOS/Windows tarballs).
+WASI_SDK_VERSION=30
+# rustup install in ci.yml.
+RUST_VERSION=stable
 
 # === [planned] tools (informational; not yet read by any script) ===
 
-HYPERFINE_VERSION=1.18.0     # bench job DEB download in ci.yml; will move into Windows installer
-GO_VERSION=1.25.5            # tracks current flake.lock nixpkgs revision
-TINYGO_VERSION=0.40.1        # tracks current flake.lock nixpkgs revision
-NODEJS_VERSION=24.13.0       # tracks current flake.lock nixpkgs revision
-BUN_VERSION=1.3.8            # tracks current flake.lock nixpkgs revision
-PYTHON_VERSION=3.13          # mirrors flake.lock python3 minor; CI uses actions/setup-python with 3.x
+# bench job DEB download in ci.yml; will move into Windows installer.
+HYPERFINE_VERSION=1.18.0
+# Tracks current flake.lock nixpkgs revision.
+GO_VERSION=1.25.5
+# Tracks current flake.lock nixpkgs revision.
+TINYGO_VERSION=0.40.1
+# Tracks current flake.lock nixpkgs revision.
+NODEJS_VERSION=24.13.0
+# Tracks current flake.lock nixpkgs revision.
+BUN_VERSION=1.3.8
+# Mirrors flake.lock python3 minor; CI uses actions/setup-python with 3.x.
+PYTHON_VERSION=3.13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Setup Rust
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           rustup install "$RUST_VERSION" --no-self-update
           rustup default "$RUST_VERSION"
           rustup target add wasm32-wasip1
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install wasm-tools
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           cargo install wasm-tools --locked --version "$WASM_TOOLS_VERSION"
 
       - name: Download WebAssembly spec testsuite
@@ -158,7 +158,7 @@ jobs:
 
       - name: Install wasmtime
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           if [ "${{ runner.os }}" = "macOS" ]; then
             ARCH="aarch64"; OS="macos"; EXT="tar.xz"; BIN_NAME="wasmtime"
           elif [ "${{ runner.os }}" = "Windows" ]; then
@@ -181,7 +181,7 @@ jobs:
       - name: Install WASI SDK
         if: runner.os != 'Windows'
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           if [ "${{ runner.os }}" = "macOS" ]; then
             ARCH="arm64"; OS="macos"
           else
@@ -201,7 +201,7 @@ jobs:
           import tarfile
           import urllib.request
 
-          tool_versions = pathlib.Path(".github/tool-versions").read_text(encoding="utf-8").splitlines()
+          tool_versions = pathlib.Path(".github/versions.lock").read_text(encoding="utf-8").splitlines()
           wasi_sdk_version = next(
               line.split("=", 1)[1].strip().strip('"')
               for line in tool_versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
 
           tool_versions = pathlib.Path(".github/versions.lock").read_text(encoding="utf-8").splitlines()
           wasi_sdk_version = next(
-              line.split("=", 1)[1].strip().strip('"')
+              line.split("=", 1)[1].split("#", 1)[0].strip().strip('"')
               for line in tool_versions
               if line.startswith("WASI_SDK_VERSION=")
           )

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install wasm-tools
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           ARCH=$(uname -m)
           curl -L --retry 3 --retry-delay 5 -f -o /tmp/wasm-tools.tar.gz \
             "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-${ARCH}-linux.tar.gz"
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install wasm-tools
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           ARCH=$(uname -m)
           curl -L --retry 3 --retry-delay 5 -f -o /tmp/wasm-tools.tar.gz \
             "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-${ARCH}-linux.tar.gz"

--- a/.github/workflows/spec-bump.yml
+++ b/.github/workflows/spec-bump.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install wasm-tools
         if: steps.update.outputs.changed == 'true'
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           ARCH=$(uname -m)
           curl -L --retry 3 --retry-delay 5 -f -o /tmp/wasm-tools.tar.gz \
             "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-${ARCH}-linux.tar.gz"

--- a/.github/workflows/wasm-tools-bump.yml
+++ b/.github/workflows/wasm-tools-bump.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           CURRENT="$WASM_TOOLS_VERSION"
           LATEST=$(gh api repos/bytecodealliance/wasm-tools/releases/latest --jq '.tag_name' | sed 's/^v//')
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
@@ -30,7 +30,7 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "Update available: $CURRENT -> $LATEST"
-            sed -i "s/WASM_TOOLS_VERSION=.*/WASM_TOOLS_VERSION=$LATEST/" .github/tool-versions
+            sed -i "s/WASM_TOOLS_VERSION=.*/WASM_TOOLS_VERSION=$LATEST/" .github/versions.lock
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -43,7 +43,7 @@ jobs:
       - name: Install new wasm-tools
         if: steps.check.outputs.changed == 'true'
         run: |
-          source .github/tool-versions
+          source .github/versions.lock
           ARCH=$(uname -m)
           curl -L --retry 3 --retry-delay 5 -f -o /tmp/wasm-tools.tar.gz \
             "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-${ARCH}-linux.tar.gz"
@@ -72,7 +72,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add .github/tool-versions
+          git add .github/versions.lock
           git commit -m "Bump wasm-tools ${CURRENT} -> ${LATEST}"
           git push --force-with-lease origin "$BRANCH"
           EXISTING=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,7 +96,7 @@ This document describes the execution pipeline and file organization.
 | File | Description |
 |------|-------------|
 | `build.zig` | Build system — targets, feature flags (`-Dwat`, `-Doptimize`) |
-| `.github/tool-versions` | Centralized CI tool versions |
+| `.github/versions.lock` | Centralized pinned tool versions (mirror of flake.nix) |
 
 ## Test Suites
 


### PR DESCRIPTION
## Summary

- **Rename** `.github/tool-versions` → `.github/versions.lock` and expand it to mirror every pinned tool from `flake.nix`. The file is the cross-environment mirror for Windows native installs and CI YAML steps that cannot read Nix.
- **Bump** `WASI_SDK_VERSION` 25 → 30 to align local nix devshell (already at 30) with CI. Local realworld build/compat: 50/50 PASS at SDK 30 on macOS aarch64.
- **New doc** `.dev/environment.md` — developer onboarding for Mac/Linux/Windows, Nix devshell contents, current CI ↔ local mapping, and the Windows CI gaps tracked as Plan C.
- **D136** in `.dev/decisions.md` — captures the Nix-as-SSoT design and the Plan B / Plan C roadmap (`scripts/gate-*.sh` unification, Nix-based CI for Linux/Mac, Windows native installer, removal of `if: runner.os != 'Windows'` skips).
- **Merge Gate** addendum in `CLAUDE.md` — manual `versions.lock` ↔ `flake.nix` consistency check until `scripts/sync-versions.sh` lands (Plan B).

This is **Plan A** from the design discussion. Plan B (gate scripts + nix-based CI + Windows installer) and Plan C (Windows-skipped CI item removal) follow in separate PRs.

## Test plan

- [x] `python test/realworld/build_all.py --force` — 50/50 PASS at WASI SDK 30 (macOS aarch64)
- [x] `python test/realworld/run_compat.py` — 50 PASS / 0 FAIL / 0 CRASH
- [x] `zig build test` — exit 0
- [x] `grep -rn "tool-versions" .github/` — no stale references
- [ ] CI green on Linux/macOS/Windows (verify after push)
- [ ] Realworld step on Linux x86_64 picks up SDK 30 cleanly (verify after CI run)

Refs: D136