### PR TITLE
feat(scripts): unified gate runners + Windows installer

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,18 +81,21 @@ When in doubt, **continue**.
 
 ### Commit Gate Checklist
 
+**One-liner**: `bash scripts/gate-commit.sh` runs items 1-5 + 8 in order.
+Add `--bench` for item 6, `--only=NAME` / `--skip=NAME` to scope.
+
 0. **TDD**: Test written/updated BEFORE production code (skip for doc-only)
 1. **Tests**: `zig build test` — all pass, 0 fail, 0 leak
 2. **Spec tests**: `python3 test/spec/run_spec.py --build --summary` — fail=0, skip=0
    (Required when modifying vm.zig, predecode.zig, regalloc.zig, opcode.zig, module.zig, wasi.zig, validate.zig)
-3. **E2E tests**: `bash test/e2e/run_e2e.sh --convert --summary` — fail=0, leak=0
+3. **E2E tests**: `python3 test/e2e/run_e2e.py --convert --summary` — fail=0, leak=0
    (Required when modifying interpreter/opcodes)
-4. **Real-world compat**: `bash test/realworld/run_compat.sh` — PASS=50, FAIL=0, CRASH=0
+4. **Real-world compat**: `python3 test/realworld/run_compat.py` — PASS=50, FAIL=0, CRASH=0
    (Required when modifying vm/wasi/JIT)
 5. **FFI tests**: `bash test/c_api/run_ffi_test.sh --build` — 0 failed
    (Required when modifying c_api.zig, build.zig lib targets, or include/zwasm.h)
 6. **Benchmarks**: Required for optimization/JIT tasks.
-   - Quick check: `bash bench/run_bench.sh --quick`
+   - Quick check: `bash scripts/run-bench.sh --quick`
    - **Record**: `bash bench/record.sh --id=ID --reason="REASON"` (appends to history.yaml)
 7. **Size guard**: Binary ≤ 1.60 MB stripped (Linux ELF ~1.56 MB; Mac ~1.20 MB),
    memory ≤ 4.5 MB RSS. Originally 1.50 MB on Zig 0.15; raised to 1.80 MB
@@ -103,24 +106,24 @@ When in doubt, **continue**.
 8. **Minimal build** (when adding tests): `zig build test -Djit=false -Dcomponent=false -Dwat=false`
    Tests using WAT must guard with `if (!build_options.enable_wat) return error.SkipZigTest;`
    Tests using JIT must guard with `if (!build_options.enable_jit) return error.SkipZigTest;`
-8. **decisions.md / checklist.md / spec-support.md / memo.md**: Update as needed
+9. **decisions.md / checklist.md / spec-support.md / memo.md**: Update as needed
 
 ### Merge Gate Checklist
 
-**EVERY item on BOTH Mac AND Ubuntu x86_64.** No skipping.
+**One-liner**: `bash scripts/gate-merge.sh` runs the Commit Gate +
+items 8-9. Run on **BOTH Mac AND Ubuntu x86_64**. No skipping.
 (see `@./.dev/references/ubuntu-testing-guide.md`, setup: `@./.dev/references/setup-orbstack.md`)
 
 1. `zig build test` — all pass, 0 fail, 0 leak
 2. `python3 test/spec/run_spec.py --build --summary` — fail=0, skip=0
-3. `bash test/e2e/run_e2e.sh --convert --summary` — fail=0, leak=0
-4. `bash test/realworld/run_compat.sh` — PASS=50, FAIL=0, CRASH=0
+3. `python3 test/e2e/run_e2e.py --convert --summary` — fail=0, leak=0
+4. `python3 test/realworld/run_compat.py` — PASS=50, FAIL=0, CRASH=0
 5. `bash test/c_api/run_ffi_test.sh --build` — 0 failed
 6. `zig build test -Djit=false -Dcomponent=false -Dwat=false` — 0 fail (minimal build)
 7. Benchmarks pass (no regression)
 8. **CI green**: `gh run list --branch main --limit 1` — check after push
-9. **versions.lock ↔ flake.nix consistency** — bumped pins exist in both files
-   (Plan B will mechanise this with `scripts/sync-versions.sh`; until then,
-   review the diff manually when either file changes.)
+9. **versions.lock ↔ flake.nix consistency**: `bash scripts/sync-versions.sh`
+   exits 0. Run automatically by `gate-merge.sh`.
 
 Items 1-6 must pass on BOTH platforms before merge. Run them in parallel:
 Mac items can run locally, Ubuntu items via `orb run -m my-ubuntu-amd64`.

--- a/.dev/environment.md
+++ b/.dev/environment.md
@@ -22,9 +22,9 @@ a version string before Nix is available (e.g. `actions/setup-zig`,
 Bumping a pin requires editing both. See **D136** in `.dev/decisions.md`
 for the rationale.
 
-A future `scripts/sync-versions.sh` (Plan B) plus a Merge Gate consistency
-check will mechanise the synchronisation. Until then it is a code-review
-concern.
+`scripts/sync-versions.sh` (run by `scripts/gate-merge.sh`) mechanises
+the consistency check; the Merge Gate item #9 in `CLAUDE.md` invokes
+it automatically.
 
 ## Required Manually (per host OS)
 
@@ -69,13 +69,21 @@ There is no `nix develop --command` wrapper to remember.
 ### Daily
 
 ```bash
-zig build test                                       # Unit tests
-python test/spec/run_spec.py --build --summary       # Spec
-python test/e2e/run_e2e.py --convert --summary       # E2E
-python test/realworld/build_all.py                   # Build real-world wasm
-python test/realworld/run_compat.py                  # Compat vs wasmtime
-bash test/c_api/run_ffi_test.sh --build              # FFI dynamic
-bash bench/run_bench.sh --quick                      # Quick bench
+bash scripts/gate-commit.sh        # Commit Gate (steps 1-5 + 8)
+bash scripts/gate-commit.sh --bench # + quick bench
+bash scripts/gate-merge.sh         # Merge Gate (Commit + sync + CI check)
+bash scripts/run-bench.sh --quick  # Bench wrapper
+bash scripts/sync-versions.sh      # Manual versions.lock ↔ flake.nix check
+```
+
+Individual commands still work for ad-hoc loops:
+
+```bash
+zig build test
+python test/spec/run_spec.py --build --summary
+python test/e2e/run_e2e.py --convert --summary
+python test/realworld/build_all.py && python test/realworld/run_compat.py
+bash test/c_api/run_ffi_test.sh --build
 ```
 
 The full Commit Gate / Merge Gate checklist lives in `CLAUDE.md`.
@@ -195,24 +203,20 @@ called out in `flake.nix` as a comment.)
 
 ## CI ↔ Local Gate Mapping
 
-Today, CI installs each tool individually rather than entering a Nix
-devshell, so local and CI run "the same gates" only by convention. Plan B
-collapses this onto a shared `scripts/gate-*.sh` family of entry points
-that both contexts invoke identically.
+| Gate                                  | Local                                  | CI (current)                                   |
+|---------------------------------------|----------------------------------------|------------------------------------------------|
+| Commit Gate (CLAUDE.md items 1-5+8)   | `bash scripts/gate-commit.sh`          | `ci.yml > test` job (3 OS, runs same commands) |
+| Merge Gate (Mac + Ubuntu both clean)  | `bash scripts/gate-merge.sh` (Mac + OrbStack Ubuntu) | `ci.yml > test` (3 OS) + `size-matrix` |
+| Bench (regression + record)           | `bash scripts/run-bench.sh`            | `ci.yml > benchmark` (Ubuntu only today)       |
+| Nightly fuzz                          | `bash test/fuzz/fuzz_overnight.sh`     | `nightly.yml > fuzz`                           |
 
-| Gate                                  | Local (today)                          | CI (today)                                   | Future (Plan B)                              |
-|---------------------------------------|----------------------------------------|----------------------------------------------|----------------------------------------------|
-| Commit Gate (CLAUDE.md items 0-8)     | Hand-run individual commands           | `ci.yml > test` job                          | `bash scripts/gate-commit.sh` everywhere     |
-| Merge Gate (Mac + Ubuntu both clean)  | Manual checklist + OrbStack            | `ci.yml > test` (3 OS) + `size-matrix`       | `bash scripts/gate-merge.sh` + versions.lock check |
-| Bench (regression + record)           | `bash bench/run_bench.sh`              | `ci.yml > benchmark` (Ubuntu only)           | `bash scripts/run-bench.sh` (Linux reference + Windows record-only) |
-| Nightly fuzz                          | `bash test/fuzz/fuzz_overnight.sh`     | `nightly.yml > fuzz`                         | Same scripts; Linux/Mac under `nix develop`  |
-
-In Plan B, CI on Linux/macOS will use
+A future PR will switch CI Linux/macOS jobs to
 `DeterminateSystems/nix-installer-action` +
-`DeterminateSystems/magic-nix-cache-action`, then call the gate scripts
-under `nix develop --command`. Windows CI will run
-`scripts/windows/install-tools.ps1` (which reads `versions.lock`) and
-then call the same gate scripts under Git Bash.
+`DeterminateSystems/magic-nix-cache-action`, calling the same gate
+scripts under `nix develop --command`. Windows CI will then run
+`scripts/windows/install-tools.ps1` (reads `versions.lock`) and then
+the gate scripts under Git Bash. This ensures CI and local invoke
+the exact same commands.
 
 ## References
 

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ test/fuzz/corpus_wat/
 
 # mdBook output (generated)
 docs/book/
+
+# scripts/gate-commit.sh local cache (wasmtime misc_testsuite, etc.)
+.cache/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,40 @@
+# scripts/
+
+Unified entry points for the zwasm Commit Gate, Merge Gate, and bench
+runner. Identical commands work on macOS, Linux, and Windows under
+Git Bash. The toolchain comes from `flake.nix` on Linux/macOS (via
+direnv) and from `scripts/windows/install-tools.ps1` on Windows.
+
+## Layout
+
+```
+scripts/
+├── lib/
+│   └── versions.sh          # bash loader for .github/versions.lock
+├── sync-versions.sh         # consistency check: versions.lock ↔ flake.nix
+├── gate-commit.sh           # CLAUDE.md Commit Gate (steps 1-8)
+├── gate-merge.sh            # CLAUDE.md Merge Gate (Commit + sync + CI)
+├── run-bench.sh             # wrapper around bench/run_bench.sh
+└── windows/
+    └── install-tools.ps1    # provisions Zig/wasm-tools/wasmtime/WASI SDK
+                             # on Windows by reading versions.lock
+```
+
+## Daily use
+
+```bash
+bash scripts/gate-commit.sh             # before committing
+bash scripts/gate-merge.sh              # before merging (run on Mac AND
+                                        # Ubuntu OrbStack — see CLAUDE.md)
+bash scripts/run-bench.sh --quick       # quick bench
+bash scripts/sync-versions.sh           # confirm pin consistency
+```
+
+`gate-commit.sh --help` lists the per-step skip flags. Steps map 1:1
+to the CLAUDE.md checklist; the gate runners are intentionally thin
+so the source of truth stays in CLAUDE.md.
+
+## Rationale
+
+See `.dev/decisions.md` D136 for the unified-gate design and the
+single-source-of-truth model (flake.nix → versions.lock).

--- a/scripts/gate-commit.sh
+++ b/scripts/gate-commit.sh
@@ -65,6 +65,17 @@ if [ "$HOST_KIND" != "windows" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
     fi
 fi
 
+# Steps CI cannot run on a given host — match the `if: runner.os != X`
+# guards in .github/workflows/ci.yml so local `gate-commit.sh` lines up
+# with what CI will actually verify. Plan C tracks closing each gap.
+case "$HOST_KIND" in
+    windows)
+        # FFI test uses POSIX dlopen and assumes .so/.dylib output;
+        # see test/c_api/run_ffi_test.sh and test_ffi.c.
+        SKIP_LIST="$SKIP_LIST ffi"
+        ;;
+esac
+
 # --- Step framework ---
 
 STEPS_RUN=0

--- a/scripts/gate-commit.sh
+++ b/scripts/gate-commit.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# scripts/gate-commit.sh — single entrypoint for the Commit Gate.
+#
+# Mirrors the checklist in CLAUDE.md (`### Commit Gate Checklist`)
+# items 1-8 in order. Item 0 (TDD discipline) and item 8b (decisions
+# / checklist / spec-support / memo updates) are human-only and not
+# executed here.
+#
+# Designed to run identically on:
+#   - macOS / Linux inside the Nix devshell (direnv-managed)
+#   - Windows under Git for Windows bash, with toolchain provisioned
+#     by scripts/windows/install-tools.ps1
+#
+# Usage:
+#   bash scripts/gate-commit.sh                 # all default steps
+#   bash scripts/gate-commit.sh --skip=spec     # skip a step (repeatable)
+#   bash scripts/gate-commit.sh --only=tests    # run a single step
+#   bash scripts/gate-commit.sh --bench         # add the optional bench step
+#
+# Exit codes: 0 when every executed step passed, 1 on first failure.
+# A summary line is always printed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/versions.sh
+source "$SCRIPT_DIR/lib/versions.sh"
+
+cd "$ZWASM_REPO_ROOT"
+
+# --- Argument parsing ---
+
+SKIP_LIST=""
+ONLY=""
+RUN_BENCH=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip=*) SKIP_LIST="$SKIP_LIST ${arg#--skip=}" ;;
+        --only=*) ONLY="${arg#--only=}" ;;
+        --bench)  RUN_BENCH=1 ;;
+        --help|-h)
+            sed -n '2,17p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "gate-commit: unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# --- Devshell awareness (Linux/Mac only) ---
+
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) HOST_KIND="windows" ;;
+    Darwin)               HOST_KIND="macos"   ;;
+    Linux)                HOST_KIND="linux"   ;;
+    *)                    HOST_KIND="other"   ;;
+esac
+
+if [ "$HOST_KIND" != "windows" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
+    if command -v nix >/dev/null 2>&1 && [ -f "$ZWASM_REPO_ROOT/flake.nix" ]; then
+        echo "WARN: not in nix devshell (IN_NIX_SHELL unset). Tools may not match flake.nix pins." >&2
+        echo "      Run: direnv allow   (or)   nix develop" >&2
+    fi
+fi
+
+# --- Step framework ---
+
+STEPS_RUN=0
+STEPS_PASSED=0
+STEPS_FAILED=0
+FAILED_NAMES=""
+
+should_run() {
+    local name="$1"
+    if [ -n "$ONLY" ]; then
+        [ "$ONLY" = "$name" ]
+        return
+    fi
+    case " $SKIP_LIST " in
+        *" $name "*) return 1 ;;
+    esac
+    return 0
+}
+
+run_step() {
+    local name="$1"
+    shift
+    if ! should_run "$name"; then
+        printf '  [SKIP] %s\n' "$name"
+        return 0
+    fi
+    STEPS_RUN=$((STEPS_RUN + 1))
+    printf '\n=== [%s] %s ===\n' "$name" "$*"
+    if "$@"; then
+        STEPS_PASSED=$((STEPS_PASSED + 1))
+        printf '  [PASS] %s\n' "$name"
+    else
+        STEPS_FAILED=$((STEPS_FAILED + 1))
+        FAILED_NAMES="$FAILED_NAMES $name"
+        printf '  [FAIL] %s\n' "$name"
+    fi
+}
+
+# --- Steps (mirroring CLAUDE.md Commit Gate items 1-8) ---
+
+step_tests()        { zig build test; }
+step_spec()         { python3 test/spec/run_spec.py --build --summary; }
+step_e2e()          { python3 test/e2e/run_e2e.py --convert --summary; }
+step_realworld()    { python3 test/realworld/run_compat.py; }
+step_ffi()          { bash test/c_api/run_ffi_test.sh --build; }
+step_bench_quick()  { bash bench/run_bench.sh --quick; }
+step_minimal()      { zig build test -Djit=false -Dcomponent=false -Dwat=false; }
+
+# Steps 1-5 are unconditional, 6 is opt-in, 8 is the minimal build.
+# (Step 7 — size & memory budget — is verified in CI; checking it here
+# would require a ReleaseSafe build per invocation, which is too slow
+# for the developer loop.)
+run_step tests       step_tests
+run_step spec        step_spec
+run_step e2e         step_e2e
+run_step realworld   step_realworld
+run_step ffi         step_ffi
+if [ "$RUN_BENCH" -eq 1 ]; then
+    run_step bench   step_bench_quick
+fi
+run_step minimal     step_minimal
+
+# --- Summary ---
+
+echo
+echo "=== Commit Gate summary ==="
+printf '  ran=%d  passed=%d  failed=%d  host=%s\n' \
+    "$STEPS_RUN" "$STEPS_PASSED" "$STEPS_FAILED" "$HOST_KIND"
+if [ "$STEPS_FAILED" -gt 0 ]; then
+    printf '  failed steps:%s\n' "$FAILED_NAMES"
+    exit 1
+fi
+exit 0

--- a/scripts/gate-commit.sh
+++ b/scripts/gate-commit.sh
@@ -118,8 +118,28 @@ run_step() {
 
 step_tests()        { zig build test; }
 step_spec()         { python3 test/spec/run_spec.py --build --summary; }
-step_e2e()          { python3 test/e2e/run_e2e.py --convert --summary; }
-step_realworld()    { python3 test/realworld/run_compat.py; }
+step_e2e() {
+    # CI clones wasmtime tests/misc_testsuite per run; locally we cache
+    # it under .cache/ (gitignored) so subsequent invocations are fast.
+    local default_dir="$ZWASM_REPO_ROOT/.cache/wasmtime"
+    if [ -z "${WASMTIME_MISC_DIR:-}" ]; then
+        if [ ! -d "$default_dir/tests/misc_testsuite" ]; then
+            echo "  e2e: wasmtime misc_testsuite missing; cloning to $default_dir"
+            mkdir -p "$default_dir"
+            git clone --depth 1 --filter=blob:none --sparse \
+                https://github.com/bytecodealliance/wasmtime.git "$default_dir"
+            ( cd "$default_dir" && git sparse-checkout set tests/misc_testsuite )
+        fi
+        export WASMTIME_MISC_DIR="$default_dir/tests/misc_testsuite"
+    fi
+    python3 test/e2e/run_e2e.py --convert --summary
+}
+step_realworld() {
+    # build_all.py is idempotent (skips up-to-date wasms); chain it so
+    # run_compat.py always finds artefacts. CI runs them as separate
+    # steps because each gets its own caching/log section.
+    python3 test/realworld/build_all.py && python3 test/realworld/run_compat.py
+}
 step_ffi()          { bash test/c_api/run_ffi_test.sh --build; }
 step_bench_quick()  { bash bench/run_bench.sh --quick; }
 step_minimal()      { zig build test -Djit=false -Dcomponent=false -Dwat=false; }

--- a/scripts/gate-merge.sh
+++ b/scripts/gate-merge.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# scripts/gate-merge.sh — Merge Gate runner.
+#
+# Mirrors `### Merge Gate Checklist` in CLAUDE.md. Adds three checks
+# on top of gate-commit.sh:
+#
+#   - bench  — quick benchmark sanity (full run takes too long here;
+#              regression checking is CI's job via bench/ci_compare.sh)
+#   - sync   — versions.lock ↔ flake.nix consistency (item #9)
+#   - ci     — main-branch CI green check (item #8). Skipped locally
+#              when not on main; intended for the post-push manual run.
+#
+# Per CLAUDE.md the Merge Gate must pass on BOTH macOS AND Ubuntu
+# x86_64. This script handles one host at a time; run it once on each
+# host (Mac directly, Ubuntu via OrbStack) before merging.
+#
+# Usage:
+#   bash scripts/gate-merge.sh                  # full Merge Gate
+#   bash scripts/gate-merge.sh --skip=bench     # skip bench locally
+#   bash scripts/gate-merge.sh --skip-ci-check  # skip the gh CI lookup
+#
+# Exit codes: 0 all green, 1 first failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/versions.sh
+source "$SCRIPT_DIR/lib/versions.sh"
+
+cd "$ZWASM_REPO_ROOT"
+
+# --- Argument parsing ---
+
+SKIP_LIST=""
+SKIP_CI_CHECK=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip=*) SKIP_LIST="$SKIP_LIST ${arg#--skip=}" ;;
+        --skip-ci-check) SKIP_CI_CHECK=1 ;;
+        --help|-h)
+            sed -n '2,22p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "gate-merge: unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# --- Run Commit Gate first (items 1-6 + minimal) ---
+
+echo "=== Running Commit Gate ==="
+if ! bash "$SCRIPT_DIR/gate-commit.sh" --bench; then
+    echo "gate-merge: Commit Gate failed; not proceeding to Merge-Gate-only checks." >&2
+    exit 1
+fi
+
+# --- Merge-Gate-only steps ---
+
+STEPS_RUN=0
+STEPS_PASSED=0
+STEPS_FAILED=0
+FAILED_NAMES=""
+
+should_run() {
+    case " $SKIP_LIST " in
+        *" $1 "*) return 1 ;;
+    esac
+    return 0
+}
+
+run_step() {
+    local name="$1"
+    shift
+    if ! should_run "$name"; then
+        printf '  [SKIP] %s\n' "$name"
+        return 0
+    fi
+    STEPS_RUN=$((STEPS_RUN + 1))
+    printf '\n=== [%s] %s ===\n' "$name" "$*"
+    if "$@"; then
+        STEPS_PASSED=$((STEPS_PASSED + 1))
+        printf '  [PASS] %s\n' "$name"
+    else
+        STEPS_FAILED=$((STEPS_FAILED + 1))
+        FAILED_NAMES="$FAILED_NAMES $name"
+        printf '  [FAIL] %s\n' "$name"
+    fi
+}
+
+step_sync_versions() {
+    bash "$SCRIPT_DIR/sync-versions.sh"
+}
+
+step_ci_check() {
+    if [ "$SKIP_CI_CHECK" -eq 1 ]; then
+        echo "  ci-check skipped via --skip-ci-check"
+        return 0
+    fi
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "  gh CLI not available; skipping main-branch CI check" >&2
+        return 0
+    fi
+    local conclusion
+    conclusion="$(gh run list --branch main --limit 1 \
+        --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "")"
+    case "$conclusion" in
+        success) echo "  main CI: success"; return 0 ;;
+        ""|null) echo "  main CI: no run found (acceptable)"; return 0 ;;
+        *)       echo "  main CI: $conclusion"; return 1 ;;
+    esac
+}
+
+run_step sync     step_sync_versions
+run_step ci       step_ci_check
+
+# --- Summary ---
+
+echo
+echo "=== Merge Gate summary ==="
+printf '  merge-gate-only-steps: ran=%d passed=%d failed=%d\n' \
+    "$STEPS_RUN" "$STEPS_PASSED" "$STEPS_FAILED"
+if [ "$STEPS_FAILED" -gt 0 ]; then
+    printf '  failed steps:%s\n' "$FAILED_NAMES"
+    echo "Reminder: Merge Gate also requires Ubuntu x86_64 verification (OrbStack)." >&2
+    exit 1
+fi
+echo "Reminder: Merge Gate also requires Ubuntu x86_64 verification (OrbStack)."
+exit 0

--- a/scripts/lib/versions.sh
+++ b/scripts/lib/versions.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/lib/versions.sh — sourceable bash loader for .github/versions.lock.
+#
+# Usage from another script:
+#
+#     source "$(dirname "$0")/lib/versions.sh"
+#     echo "$ZIG_VERSION"
+#
+# The loader exports every KEY=value pair found in .github/versions.lock.
+# Comments (entire-line `#` lines) and blank lines are ignored. Inline
+# comments after a value are NOT supported in versions.lock by policy
+# (see the file header) — bash's own `source` would already strip them,
+# but the Python reader in ci.yml does not, so we keep the file simple.
+
+set -euo pipefail
+
+_zwasm_repo_root() {
+    # Walk up from this file to find the repo root (the directory holding
+    # .github/versions.lock).
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [ "$dir" != "/" ] && [ ! -f "$dir/.github/versions.lock" ]; do
+        dir="$(dirname "$dir")"
+    done
+    if [ ! -f "$dir/.github/versions.lock" ]; then
+        echo "versions.sh: cannot locate .github/versions.lock from ${BASH_SOURCE[0]}" >&2
+        return 1
+    fi
+    printf '%s' "$dir"
+}
+
+ZWASM_REPO_ROOT="$(_zwasm_repo_root)"
+export ZWASM_REPO_ROOT
+
+# `set -a` makes every subsequent assignment automatically exported, which
+# is what we want for the lock file's `KEY=value` lines. Bash skips comment
+# and blank lines when sourcing.
+set -a
+# shellcheck disable=SC1091
+source "$ZWASM_REPO_ROOT/.github/versions.lock"
+set +a
+
+# Sanity: at least the [enforced] pins must be set. Catches typos in the
+# lock file or accidental removal early.
+: "${ZIG_VERSION:?ZIG_VERSION not set in versions.lock}"
+: "${WASM_TOOLS_VERSION:?WASM_TOOLS_VERSION not set in versions.lock}"
+: "${WASMTIME_VERSION:?WASMTIME_VERSION not set in versions.lock}"
+: "${WASI_SDK_VERSION:?WASI_SDK_VERSION not set in versions.lock}"
+: "${RUST_VERSION:?RUST_VERSION not set in versions.lock}"

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# scripts/run-bench.sh — unified bench entry point.
+#
+# Thin wrapper around bench/run_bench.sh that resolves repo root via
+# scripts/lib/versions.sh and forwards all arguments through. Provided
+# so `bash scripts/run-bench.sh` works from any cwd and reads the same
+# versions.lock as the rest of the gate runners.
+#
+# Usage:
+#   bash scripts/run-bench.sh             # full bench (5 runs + 3 warmup)
+#   bash scripts/run-bench.sh --quick     # 1 run, no warmup
+#   bash scripts/run-bench.sh --bench=fib # specific benchmark
+#
+# All arguments are passed straight to bench/run_bench.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/versions.sh
+source "$SCRIPT_DIR/lib/versions.sh"
+
+cd "$ZWASM_REPO_ROOT"
+exec bash bench/run_bench.sh "$@"

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# scripts/sync-versions.sh — verify .github/versions.lock matches flake.nix.
+#
+# Two pins live in flake.nix today: Zig and WASI SDK. Other tools come
+# from nixpkgs at the flake.lock revision and do not embed an
+# explicit version literal in flake.nix, so they are checked
+# best-effort or skipped here. When Plan B's flake.nix extension lands
+# (explicit pins for wasm-tools / wasmtime / hyperfine), add them to
+# CHECKS below.
+#
+# Exit codes:
+#   0  versions.lock is consistent with flake.nix
+#   1  mismatch found (printed); manually update one side or the other
+#   2  invocation error (missing file, etc.)
+#
+# Usage:
+#   bash scripts/sync-versions.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/versions.sh
+source "$SCRIPT_DIR/lib/versions.sh"
+
+FLAKE="$ZWASM_REPO_ROOT/flake.nix"
+if [ ! -f "$FLAKE" ]; then
+    echo "sync-versions: $FLAKE not found" >&2
+    exit 2
+fi
+
+mismatches=0
+
+check() {
+    local name="$1" lock_value="$2" flake_value="$3"
+    if [ "$lock_value" = "$flake_value" ]; then
+        printf '  [OK]   %-22s %s\n' "$name" "$lock_value"
+    else
+        printf '  [MISS] %-22s versions.lock=%s flake.nix=%s\n' \
+            "$name" "$lock_value" "$flake_value"
+        mismatches=$((mismatches + 1))
+    fi
+}
+
+# Zig: every URL in flake.nix carries the version twice (path + filename).
+# Pull the first occurrence — if the four arch entries disagree, that is
+# already a separate flake.nix bug we want to surface.
+flake_zig="$(grep -oE 'ziglang\.org/download/[0-9]+\.[0-9]+\.[0-9]+/' "$FLAKE" \
+    | head -1 \
+    | sed -E 's|.*/([0-9]+\.[0-9]+\.[0-9]+)/|\1|')"
+check ZIG_VERSION "$ZIG_VERSION" "$flake_zig"
+
+# WASI SDK: URL pattern is .../wasi-sdk-<MAJOR>/wasi-sdk-<MAJOR>.0-<arch>...
+flake_wasi="$(grep -oE 'wasi-sdk/releases/download/wasi-sdk-[0-9]+' "$FLAKE" \
+    | head -1 \
+    | sed -E 's|.*wasi-sdk-||')"
+check WASI_SDK_VERSION "$WASI_SDK_VERSION" "$flake_wasi"
+
+echo
+if [ "$mismatches" -eq 0 ]; then
+    echo "sync-versions: OK"
+    exit 0
+fi
+echo "sync-versions: $mismatches mismatch(es). Fix versions.lock or flake.nix and re-run." >&2
+exit 1

--- a/scripts/windows/install-tools.ps1
+++ b/scripts/windows/install-tools.ps1
@@ -1,0 +1,237 @@
+<#
+.SYNOPSIS
+    Provisions the Windows-native toolchain pinned by .github/versions.lock.
+
+.DESCRIPTION
+    Reads the pinned versions of Zig, wasm-tools, wasmtime, and WASI SDK
+    from .github/versions.lock and installs each into a per-user
+    directory under %LOCALAPPDATA%\zwasm-tools. Adds the relevant
+    binaries to the user-scoped PATH and sets WASI_SDK_PATH.
+
+    Idempotent: an existing version-stamped directory is left in place
+    and the install step is skipped.
+
+    Requires: Windows 10/11 with built-in tar.exe (used to extract
+    .tar.gz archives), PowerShell 5.1 or PowerShell 7. Does not require
+    administrator rights.
+
+.PARAMETER Force
+    Reinstall every tool even if the version-stamped directory already
+    exists.
+
+.PARAMETER OnlyTool
+    Install just one tool. Accepts: zig, wasm-tools, wasmtime, wasi-sdk.
+
+.EXAMPLE
+    pwsh -NoLogo -File scripts\windows\install-tools.ps1
+
+.EXAMPLE
+    pwsh -NoLogo -File scripts\windows\install-tools.ps1 -OnlyTool zig -Force
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Force,
+    [ValidateSet('zig', 'wasm-tools', 'wasmtime', 'wasi-sdk', 'all')]
+    [string]$OnlyTool = 'all'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# --- Locate repo root and load versions.lock ---
+
+function Find-RepoRoot {
+    $dir = $PSScriptRoot
+    while ($dir -and -not (Test-Path (Join-Path $dir '.github\versions.lock'))) {
+        $parent = Split-Path -Parent $dir
+        if ($parent -eq $dir) { return $null }
+        $dir = $parent
+    }
+    return $dir
+}
+
+$repoRoot = Find-RepoRoot
+if (-not $repoRoot) {
+    throw "install-tools.ps1: cannot locate .github/versions.lock relative to $PSScriptRoot"
+}
+
+function Read-VersionsLock {
+    param([Parameter(Mandatory)][string]$Path)
+    $map = @{}
+    foreach ($rawLine in Get-Content -LiteralPath $Path) {
+        $line = $rawLine.Trim()
+        if (-not $line -or $line.StartsWith('#')) { continue }
+        $eq = $line.IndexOf('=')
+        if ($eq -lt 1) { continue }
+        $key = $line.Substring(0, $eq).Trim()
+        $val = $line.Substring($eq + 1)
+        # Defensive: strip a trailing inline comment in case the policy is
+        # ever violated, matching the Python reader in ci.yml.
+        $hashIdx = $val.IndexOf('#')
+        if ($hashIdx -ge 0) { $val = $val.Substring(0, $hashIdx) }
+        $map[$key] = $val.Trim().Trim('"')
+    }
+    return $map
+}
+
+$versions = Read-VersionsLock -Path (Join-Path $repoRoot '.github\versions.lock')
+foreach ($k in 'ZIG_VERSION', 'WASM_TOOLS_VERSION', 'WASMTIME_VERSION', 'WASI_SDK_VERSION') {
+    if (-not $versions.ContainsKey($k)) {
+        throw "install-tools.ps1: $k missing from versions.lock"
+    }
+}
+
+# --- Install layout ---
+
+$installRoot = Join-Path $env:LOCALAPPDATA 'zwasm-tools'
+$workDir     = Join-Path $env:LOCALAPPDATA 'zwasm-tools\.work'
+New-Item -ItemType Directory -Force -Path $installRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $workDir     | Out-Null
+
+# --- Helpers ---
+
+function Download-File {
+    param([Parameter(Mandatory)][string]$Url, [Parameter(Mandatory)][string]$Dest)
+    Write-Host "  download: $Url"
+    # Force TLS 1.2; Windows 10 ships with TLS 1.0 default in .NET 4.x.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $oldProgress = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'   # 100x faster Invoke-WebRequest
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $Dest -UseBasicParsing
+    }
+    finally {
+        $ProgressPreference = $oldProgress
+    }
+}
+
+function Extract-Zip {
+    param([Parameter(Mandatory)][string]$Archive, [Parameter(Mandatory)][string]$Dest)
+    if (Test-Path $Dest) { Remove-Item -Recurse -Force $Dest }
+    New-Item -ItemType Directory -Force -Path $Dest | Out-Null
+    Expand-Archive -LiteralPath $Archive -DestinationPath $Dest -Force
+}
+
+function Extract-TarGz {
+    param([Parameter(Mandatory)][string]$Archive, [Parameter(Mandatory)][string]$Dest)
+    if (Test-Path $Dest) { Remove-Item -Recurse -Force $Dest }
+    New-Item -ItemType Directory -Force -Path $Dest | Out-Null
+    # Built-in tar.exe (BSD tar) on Windows 10+.
+    & tar.exe -xzf $Archive -C $Dest
+    if ($LASTEXITCODE -ne 0) {
+        throw "tar.exe extraction failed for $Archive (exit $LASTEXITCODE)"
+    }
+}
+
+function Resolve-SingleSubdir {
+    param([Parameter(Mandatory)][string]$ParentDir)
+    $children = Get-ChildItem -LiteralPath $ParentDir -Directory
+    if ($children.Count -eq 1) { return $children[0].FullName }
+    return $ParentDir
+}
+
+# Install one tool. The closure receives the unpacked archive root
+# and is expected to return the directory whose contents should
+# become $stampedDir (i.e. flat layout: bin/zig.exe lives directly
+# inside or one level deep — the closure normalises that).
+function Install-Tool {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][ValidateSet('zip', 'tar.gz')][string]$Format
+    )
+    $stampedDir = Join-Path $installRoot ("{0}-{1}" -f $Name, $Version)
+    if ((Test-Path $stampedDir) -and -not $Force) {
+        Write-Host "[skip] $Name $Version (exists at $stampedDir)"
+        return $stampedDir
+    }
+    Write-Host "[install] $Name $Version"
+    $archiveExt = if ($Format -eq 'zip') { 'zip' } else { 'tar.gz' }
+    $archive = Join-Path $workDir ("{0}-{1}.{2}" -f $Name, $Version, $archiveExt)
+    Download-File -Url $Url -Dest $archive
+    $stagingDir = Join-Path $workDir ("{0}-{1}-staging" -f $Name, $Version)
+    if ($Format -eq 'zip') {
+        Extract-Zip -Archive $archive -Dest $stagingDir
+    } else {
+        Extract-TarGz -Archive $archive -Dest $stagingDir
+    }
+    $unpacked = Resolve-SingleSubdir -ParentDir $stagingDir
+    if (Test-Path $stampedDir) { Remove-Item -Recurse -Force $stampedDir }
+    Move-Item -LiteralPath $unpacked -Destination $stampedDir
+    Remove-Item -Recurse -Force $stagingDir -ErrorAction SilentlyContinue
+    Remove-Item -Force $archive -ErrorAction SilentlyContinue
+    return $stampedDir
+}
+
+# --- Install plan ---
+
+$paths = @{}
+
+if ($OnlyTool -in @('all', 'zig')) {
+    $url = "https://ziglang.org/download/$($versions.ZIG_VERSION)/zig-x86_64-windows-$($versions.ZIG_VERSION).zip"
+    $dir = Install-Tool -Name 'zig' -Version $versions.ZIG_VERSION -Url $url -Format 'zip'
+    $paths['zig'] = $dir
+}
+
+if ($OnlyTool -in @('all', 'wasm-tools')) {
+    $url = "https://github.com/bytecodealliance/wasm-tools/releases/download/v$($versions.WASM_TOOLS_VERSION)/wasm-tools-$($versions.WASM_TOOLS_VERSION)-x86_64-windows.tar.gz"
+    $dir = Install-Tool -Name 'wasm-tools' -Version $versions.WASM_TOOLS_VERSION -Url $url -Format 'tar.gz'
+    $paths['wasm-tools'] = $dir
+}
+
+if ($OnlyTool -in @('all', 'wasmtime')) {
+    $url = "https://github.com/bytecodealliance/wasmtime/releases/download/v$($versions.WASMTIME_VERSION)/wasmtime-v$($versions.WASMTIME_VERSION)-x86_64-windows.zip"
+    $dir = Install-Tool -Name 'wasmtime' -Version $versions.WASMTIME_VERSION -Url $url -Format 'zip'
+    $paths['wasmtime'] = $dir
+}
+
+if ($OnlyTool -in @('all', 'wasi-sdk')) {
+    $url = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$($versions.WASI_SDK_VERSION)/wasi-sdk-$($versions.WASI_SDK_VERSION).0-x86_64-windows.tar.gz"
+    $dir = Install-Tool -Name 'wasi-sdk' -Version $versions.WASI_SDK_VERSION -Url $url -Format 'tar.gz'
+    $paths['wasi-sdk'] = $dir
+}
+
+# --- PATH and env wiring (User scope) ---
+
+function Update-UserPath {
+    param([Parameter(Mandatory)][string[]]$Add)
+    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not $current) { $current = '' }
+    $entries = $current.Split(';') | Where-Object { $_ }
+    $changed = $false
+    foreach ($p in $Add) {
+        if (-not $p) { continue }
+        if ($entries -notcontains $p) {
+            $entries += $p
+            Write-Host "[path] +$p"
+            $changed = $true
+        }
+    }
+    if ($changed) {
+        [Environment]::SetEnvironmentVariable('Path', ($entries -join ';'), 'User')
+    }
+}
+
+$pathsToAdd = @()
+if ($paths.ContainsKey('zig'))        { $pathsToAdd += $paths['zig'] }
+if ($paths.ContainsKey('wasm-tools')) { $pathsToAdd += $paths['wasm-tools'] }
+if ($paths.ContainsKey('wasmtime'))   { $pathsToAdd += (Join-Path $paths['wasmtime'] 'bin') }
+Update-UserPath -Add $pathsToAdd
+
+if ($paths.ContainsKey('wasi-sdk')) {
+    [Environment]::SetEnvironmentVariable('WASI_SDK_PATH', $paths['wasi-sdk'], 'User')
+    Write-Host "[env] WASI_SDK_PATH=$($paths['wasi-sdk'])"
+}
+
+# Ensure Git for Windows bash is reachable so `bash scripts/gate-commit.sh`
+# works in fresh shells. Skip silently if Git is in a non-default location.
+$gitBin = 'C:\Program Files\Git\bin'
+if (Test-Path (Join-Path $gitBin 'bash.exe')) {
+    Update-UserPath -Add @($gitBin)
+}
+
+Write-Host ""
+Write-Host "Done. Open a new shell to pick up PATH/WASI_SDK_PATH changes."
+Write-Host "Verify: zig version; wasm-tools --version; wasmtime --version; bash --version"

--- a/scripts/windows/install-tools.ps1
+++ b/scripts/windows/install-tools.ps1
@@ -177,8 +177,10 @@ if ($OnlyTool -in @('all', 'zig')) {
 }
 
 if ($OnlyTool -in @('all', 'wasm-tools')) {
-    $url = "https://github.com/bytecodealliance/wasm-tools/releases/download/v$($versions.WASM_TOOLS_VERSION)/wasm-tools-$($versions.WASM_TOOLS_VERSION)-x86_64-windows.tar.gz"
-    $dir = Install-Tool -Name 'wasm-tools' -Version $versions.WASM_TOOLS_VERSION -Url $url -Format 'tar.gz'
+    # bytecodealliance ships wasm-tools as .zip for Windows (unlike Linux/macOS
+    # which use .tar.gz). Pinned by versions.lock WASM_TOOLS_VERSION.
+    $url = "https://github.com/bytecodealliance/wasm-tools/releases/download/v$($versions.WASM_TOOLS_VERSION)/wasm-tools-$($versions.WASM_TOOLS_VERSION)-x86_64-windows.zip"
+    $dir = Install-Tool -Name 'wasm-tools' -Version $versions.WASM_TOOLS_VERSION -Url $url -Format 'zip'
     $paths['wasm-tools'] = $dir
 }
 

--- a/scripts/windows/install-tools.ps1
+++ b/scripts/windows/install-tools.ps1
@@ -217,10 +217,13 @@ function Update-UserPath {
     }
 }
 
+# Each release ZIP/tar.gz unpacks with its binaries directly inside
+# the install dir — no `bin/` subdirectory on Windows for any of these
+# tools today. Add the install dir itself.
 $pathsToAdd = @()
 if ($paths.ContainsKey('zig'))        { $pathsToAdd += $paths['zig'] }
 if ($paths.ContainsKey('wasm-tools')) { $pathsToAdd += $paths['wasm-tools'] }
-if ($paths.ContainsKey('wasmtime'))   { $pathsToAdd += (Join-Path $paths['wasmtime'] 'bin') }
+if ($paths.ContainsKey('wasmtime'))   { $pathsToAdd += $paths['wasmtime'] }
 Update-UserPath -Add $pathsToAdd
 
 if ($paths.ContainsKey('wasi-sdk')) {

--- a/scripts/windows/install-tools.ps1
+++ b/scripts/windows/install-tools.ps1
@@ -89,6 +89,32 @@ $workDir     = Join-Path $env:LOCALAPPDATA 'zwasm-tools\.work'
 New-Item -ItemType Directory -Force -Path $installRoot | Out-Null
 New-Item -ItemType Directory -Force -Path $workDir     | Out-Null
 
+# --- Microsoft Visual C++ Redistributable (WASI SDK clang.exe needs it) ---
+
+function Ensure-VCRedist {
+    # WASI SDK 30 ships a clang.exe linked against MSVC's vcruntime140.dll /
+    # msvcp140.dll. Stock Windows 11 only carries the .NET-flavoured
+    # vcruntime140_clr0400.dll variants, so a fresh machine fails with
+    # STATUS_DLL_NOT_FOUND (exit 0xC0000135) before any compilation runs.
+    # The plain runtime ships in Microsoft's Visual C++ Redistributable.
+    if (Test-Path 'C:\Windows\System32\vcruntime140.dll') {
+        return
+    }
+    Write-Host "[install] Microsoft Visual C++ Redistributable (required by WASI SDK clang.exe)"
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        throw "vcruntime140.dll missing and winget unavailable. Install Microsoft.VCRedist.2015+.x64 manually."
+    }
+    & winget install --id Microsoft.VCRedist.2015+.x64 -e --silent `
+        --accept-source-agreements --accept-package-agreements
+    if ($LASTEXITCODE -ne 0) {
+        throw "winget install of Microsoft.VCRedist.2015+.x64 failed (exit $LASTEXITCODE). System-wide install needs admin; rerun in an elevated shell or install manually."
+    }
+}
+
+if ($OnlyTool -in @('all', 'wasi-sdk')) {
+    Ensure-VCRedist
+}
+
 # --- Helpers ---
 
 function Download-File {

--- a/scripts/windows/install-tools.ps1
+++ b/scripts/windows/install-tools.ps1
@@ -126,7 +126,8 @@ function Extract-TarGz {
 
 function Resolve-SingleSubdir {
     param([Parameter(Mandatory)][string]$ParentDir)
-    $children = Get-ChildItem -LiteralPath $ParentDir -Directory
+    # @(...) forces array context so a single match still has .Count.
+    $children = @(Get-ChildItem -LiteralPath $ParentDir -Directory)
     if ($children.Count -eq 1) { return $children[0].FullName }
     return $ParentDir
 }


### PR DESCRIPTION
## Summary

Plan B sub-1 + sub-2: introduce \`scripts/\` as the single invocation surface for the CLAUDE.md Commit Gate / Merge Gate, and \`scripts/windows/install-tools.ps1\` as the Windows-side toolchain provisioner that mirrors what \`flake.nix\` provides on Linux/macOS.

### What's in this PR

**Gate runners** (callable identically on Mac, Linux, Windows-bash):

- \`scripts/lib/versions.sh\` — bash loader for \`.github/versions.lock\`
- \`scripts/sync-versions.sh\` — versions.lock ↔ flake.nix consistency check (Merge Gate item #9)
- \`scripts/gate-commit.sh\` — Commit Gate runner (items 1-5 + 8); supports \`--bench\`, \`--only=NAME\`, \`--skip=NAME\`. Auto-clones \`wasmtime\` misc_testsuite to \`.cache/\` for e2e and chains \`build_all.py && run_compat.py\` for realworld so a fresh checkout works without manual setup. Auto-skips \`ffi\` on Windows to match the existing \`if: runner.os != 'Windows'\` CI guard.
- \`scripts/gate-merge.sh\` — Merge Gate runner (Commit Gate + sync + main-CI green check)
- \`scripts/run-bench.sh\` — repo-root-aware wrapper around \`bench/run_bench.sh\`
- \`scripts/README.md\` — script-level overview

**Windows installer**:

- \`scripts/windows/install-tools.ps1\` — reads \`versions.lock\` and provisions Zig 0.16.0, wasm-tools 1.246.1, wasmtime 42.0.1, WASI SDK 30 into \`%LOCALAPPDATA%\zwasm-tools\<tool>-<version>\`. Wires user-scope PATH + WASI_SDK_PATH. Auto-installs Microsoft Visual C++ Redistributable via winget when \`vcruntime140.dll\` is missing (WASI SDK clang.exe needs it). Idempotent; \`--Force\` re-extracts; \`-OnlyTool\` selects one.

**Doc updates**:

- \`CLAUDE.md\` Commit Gate / Merge Gate sections point at the new one-liners and use the .py runners that CI actually exercises (\`run_e2e.py\` / \`run_compat.py\` instead of the .sh wrappers).
- \`.dev/environment.md\` daily-flow section now leads with the gate scripts.
- \`.gitignore\` ignores \`.cache/\`.

### Verification

| Host | Commit Gate result |
|------|--------------------|
| macOS aarch64 (nix devshell) | 6/6 PASS — tests, spec, e2e, realworld (50/50), ffi, minimal |
| Windows x86_64 (install-tools.ps1 provisioned) | 5/5 PASS — tests, spec (62263/62263), e2e, realworld (25/25; Go/Rust skip — Plan C), ffi (host-skip), minimal |

The Windows realworld 25/25 is the C+C++ subset — Go/Rust/TinyGo aren't installed by install-tools.ps1 yet (Plan C extension); \`build_all.py\` skips those toolchains gracefully, so the suite reports green on what's installable today.

### Test plan

- [x] \`bash scripts/sync-versions.sh\` — clean (and verified that injecting a mismatch returns exit 1)
- [x] \`bash scripts/gate-commit.sh\` on macOS — 6/6 PASS
- [x] \`pwsh scripts/windows/install-tools.ps1\` on Windows — provisions all 4 tools + VC++ Redist
- [x] \`bash scripts/gate-commit.sh\` on Windows — 5/5 PASS
- [ ] CI matrix green (verify after push)

Refs: D136, follows #60.