### PR TITLE
ci: enforce versions.lock ↔ flake.nix consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
     branches: [main]
 
 jobs:
+  versions-lock-sync:
+    # Mirrors Merge Gate item #9. Fails the PR if .github/versions.lock and
+    # flake.nix disagree on a tool pin. Cheap (<1 sec) and runs in parallel
+    # with the test matrix.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/sync-versions.sh
+
   test:
     defaults:
       run:


### PR DESCRIPTION
## Summary

Adds a one-step CI job that runs \`bash scripts/sync-versions.sh\` on every PR, catching drift between \`flake.nix\` and \`.github/versions.lock\` at CI time. Mechanises Merge Gate item #9.

The job runs in parallel with the existing test matrix and finishes in under a second.

## Test plan

- [x] \`bash scripts/sync-versions.sh\` locally returns 0 (already verified after Plan A merge)
- [ ] CI green (verify after push)

Refs: D136