### PR TITLE
ci: source HYPERFINE_VERSION from versions.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,9 @@ jobs:
 
       - name: Install hyperfine
         run: |
-          curl -L --retry 3 --retry-delay 5 -f -o /tmp/hyperfine.deb https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine_1.18.0_amd64.deb
+          source .github/versions.lock
+          curl -L --retry 3 --retry-delay 5 -f -o /tmp/hyperfine.deb \
+            "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/hyperfine_${HYPERFINE_VERSION}_amd64.deb"
           sudo dpkg -i /tmp/hyperfine.deb
 
       - name: Build ReleaseSafe


### PR DESCRIPTION
## Summary

Tiny consistency fix. The benchmark job's hyperfine install hardcoded \`v1.18.0\` in two places while \`versions.lock\` already declared \`HYPERFINE_VERSION=1.18.0\` authoritatively. Source the value via \`source .github/versions.lock\` (same pattern other steps use) so a single-file bump suffices.

No behaviour change at the same pinned version.

## Test plan

- [ ] CI benchmark job still installs hyperfine 1.18.0 and runs

Refs: D136