### PR TITLE
docs(handoff): resume-guide.md + W49-W52 + CHANGELOG [Unreleased]

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -123,7 +123,18 @@ items 8-9. Run on **BOTH Mac AND Ubuntu x86_64**. No skipping.
 7. Benchmarks pass (no regression)
 8. **CI green**: `gh run list --branch main --limit 1` — check after push
 9. **versions.lock ↔ flake.nix consistency**: `bash scripts/sync-versions.sh`
-   exits 0. Run automatically by `gate-merge.sh`.
+   exits 0. Run automatically by `gate-merge.sh` and by the CI
+   `versions-lock-sync` job.
+10. **Local bench record on Mac, every merge**: after the PR is squash-merged
+    and main is checked out (`git checkout main && git pull --ff-only`),
+    `bash scripts/record-merge-bench.sh` appends one row to
+    `bench/history.yaml` keyed on the merge commit SHA. Full hyperfine
+    (5 runs + 3 warmup) by default; pass `--runs=1 --warmup=0` for the
+    quick mode when the PR cannot affect perf. Auto-skips on
+    Linux/Windows because history.yaml's `env` block is Darwin-only.
+    Commit the resulting `history.yaml` change directly to main as a
+    follow-up commit (`Record benchmark for <subject>`); CI runs but is
+    not gating for that small commit.
 
 Items 1-6 must pass on BOTH platforms before merge. Run them in parallel:
 Mac items can run locally, Ubuntu items via `orb run -m my-ubuntu-amd64`.

--- a/.dev/checklist.md
+++ b/.dev/checklist.md
@@ -10,6 +10,40 @@ Prefix: W## (to distinguish from CW's F## items).
 
 ## Open Items
 
+- [ ] W49: Plan C — remove remaining seven `if: runner.os != 'Windows'`
+  CI guards. None reflects a fundamental Windows incompatibility; each
+  is a shell-script or C-side limitation. Detailed table (C-a through
+  C-g, with risk classification and suggested order) in
+  `@./.dev/resume-guide.md`. No-Workaround Rule applies: a real
+  Windows-only zwasm bug surfaced during this work is fixed in zwasm,
+  not hidden behind another guard.
+
+- [ ] W50: Plan B sub-3 — CI Nix-ify. Replace per-tool installs in
+  `ci.yml` test matrix with `DeterminateSystems/nix-installer-action`
+  + `magic-nix-cache-action` + `nix develop --command bash
+  scripts/gate-commit.sh` on Linux/macOS, and
+  `pwsh scripts/windows/install-tools.ps1` then `bash scripts/gate-commit.sh`
+  on Windows. Then mirror in `nightly.yml`. Plus extend `flake.nix` to
+  pin wasm-tools / wasmtime / hyperfine explicitly (URL + sha256)
+  rather than via nixpkgs revision. Deferred from overnight 2026-04-29
+  because magic-nix-cache had a 2025 outage and macos-latest +
+  nix-installer-action has occasional flakes — wants supervised PR.
+
+- [ ] W51: Doc drift — README "real-world 50/50 (Mac+Linux+Windows)" is
+  optimistic (Windows is 25/25 C+C++ until install-tools.ps1 provisions
+  Go/Rust/TinyGo); book/en+ja contributing.md still recommends manual
+  `zig build test` invocations rather than `bash scripts/gate-commit.sh`;
+  setup-orbstack.md predates D136 (Zig 0.15.2 + WASI SDK 25 stale);
+  roadmap.md "Zig version upgrade — High" line obsolete.
+  See resume-guide.md "Documentation drift to fix".
+
+- [ ] W52: realworld coverage on Windows — extend
+  `scripts/windows/install-tools.ps1` (or split off a follow-on
+  `install-extras.ps1`) with rustup-init + Go + TinyGo so
+  `build_all.py` no longer SKIPs those toolchains. Each is ~30 lines
+  of PowerShell pinned via `versions.lock`. Closes the gap from 25/50
+  to full 50/50 on Windows.
+
 - [ ] W45: SIMD loop persistence — Skip Q-cache eviction at loop headers.
   Requires back-edge detection in scanBranchTargets.
 

--- a/.dev/memo.md
+++ b/.dev/memo.md
@@ -22,44 +22,55 @@ Session handover document. Read at session start.
 
 ## Current Task
 
-**W48 Phase 1 — DONE (2026-04-25).** Trimmed Linux binary from 1.64 → 1.56 MB
-(-83 KB, -5%) and Mac binary from 1.38 → 1.20 MB (-180 KB, -13%) via three
-changes in `src/cli.zig`:
+**Plan A + Plan B sub-1+2 + Plan C alpha shipped (2026-04-29).** PRs #60,
+#61, #62, #64, #65 merged. main is green on all three OS matrix entries.
+Detailed state, hard-won facts, residual work, and the per-session
+autonomy rules live in **`@./.dev/resume-guide.md`** — read that first
+on a new session.
 
-1. `pub const panic = std.debug.simple_panic;` — skips `FullPanic`'s
-   formatted safety-panic messages + the `defaultPanic` /
-   `writeCurrentStackTrace` DWARF pull-in.
-2. `pub const std_options: std.Options = .{ .enable_segfault_handler = false };`
-   — zwasm already installs its own SIGSEGV handler in
-   `guard_mod.installSignalHandler()` for JIT guard-page OOB, so the std
-   default handler is always replaced at runtime anyway. Disabling it at
-   comptime elides `std.debug.handleSegfaultPosix` and the transitive
-   pull-in of `SelfInfo.Elf.*`.
-3. `pub fn main(init) u8 { return runCli(init) catch |err| { ... } }` —
-   `main` no longer returns an error union, so `start.zig`'s `wrapMain`
-   inlines the `u8` arm and never emits the call to
-   `std.debug.dumpErrorReturnTrace`.
+Quick orientation if continuing:
 
-Remaining ~62 KB to target 1.50 MB (still well under 1.80 MB ceiling):
-`debug.*` ~81 KB (SelfInfo.Elf / Dwarf / writeTrace still reachable via
-`std.debug.lockStderr` → `std.Options.debug_io`), `std.Io.Threaded` ~115 KB.
-Tracked as W48 Phase 2 — next lever is `std_options_debug_io` override
-with a minimal direct-stderr Io instance. Non-blocking.
+```bash
+git log --oneline origin/main -8        # confirm what's on main
+cat .dev/resume-guide.md                # full plan, gotchas, stop rules
+bash scripts/sync-versions.sh           # toolchain pin sanity (instant)
+bash scripts/gate-commit.sh --only=tests # smoke test
+```
 
-Next candidate work:
+The guide has three pickable work areas:
+**Plan C** (remaining seven `if: runner.os != 'Windows'` guards),
+**Plan B sub-3** (CI Nix-ify), **doc drift** (README / book /
+setup-orbstack.md).
 
-- **W47**: `tgo_strops_cached` +24% regression investigation (single-benchmark,
-  low priority). See checklist.
-- **W45**: SIMD loop persistence — skip Q-cache eviction at loop headers
-  (requires back-edge detection in `scanBranchTargets`).
-- **W48 Phase 2**: remaining 62 KB to reach 1.50 MB Linux. Non-blocking.
+When all three are exhausted, delete `.dev/resume-guide.md` and this
+"Current Task" pointer.
 
 ## Previous Task
 
-**W46 Phase 2 — DONE (2026-04-25 via PR #52).** Routed remaining `std.c.*`
-direct calls in `wasi.zig` through `platform.zig` helpers. Size-neutral on
-Linux because the `std.c.*` sites were already inside comptime-pruned
-`else` arms; pure consistency refactor.
+**Overnight 2026-04-28 → 2026-04-29.** Five PRs to main:
+
+- #60 — `flake.nix` made SSoT, `versions.lock` mirror, WASI SDK 25→30,
+  D136 in decisions.md, `.dev/environment.md` initial.
+- #61 — `scripts/gate-commit.sh`, `gate-merge.sh`, `run-bench.sh`,
+  `sync-versions.sh`, `lib/versions.sh`, `windows/install-tools.ps1`.
+- #62 — CI `versions-lock-sync` job (Merge Gate item #9 mechanised).
+- #64 — Windows memory check via PowerShell (1 of 8 Windows guards down).
+- #65 — `HYPERFINE_VERSION` sourced from versions.lock.
+
+Pre-overnight: **W48 Phase 1 — DONE (2026-04-25).** Trimmed Linux
+binary 1.64 → 1.56 MB (-83 KB) and Mac 1.38 → 1.20 MB (-180 KB) via
+three changes in `src/cli.zig`: `pub const panic =
+std.debug.simple_panic`, `std_options.enable_segfault_handler = false`
+(zwasm has its own SIGSEGV handler), and `main` returning `u8` instead
+of `!void`. Remaining 62 KB to target 1.50 MB (W48 Phase 2,
+non-blocking — `std.Io.Threaded` ~115 KB and `debug.*` 81 KB are the
+biggest contributors; lever is `std_options_debug_io` override with a
+minimal direct-stderr Io instance).
+
+**W46 Phase 2 — DONE (2026-04-25 via PR #52).** Routed remaining
+`std.c.*` direct calls in `wasi.zig` through `platform.zig` helpers.
+Size-neutral on Linux because the `std.c.*` sites were already inside
+comptime-pruned `else` arms; pure consistency refactor.
 
 ### W46 earlier phases
 

--- a/.dev/resume-guide.md
+++ b/.dev/resume-guide.md
@@ -171,12 +171,15 @@ Cut a release when one of these is true:
 - The user explicitly asks for a tag.
 - ClojureWasm (downstream) wants a stable pin instead of `main`.
 
-The `/release` skill automates the tag, `CHANGELOG.md`, benchmark
-recording, and the ClojureWasm pin update. Do **not** cut a tag
-manually — let the skill handle it.
+The `/release` skill automates the tag, `CHANGELOG.md` finalisation,
+benchmark recording, and the ClojureWasm pin update. Do **not** cut a
+tag manually — let the skill handle it.
 
-The `## [Unreleased]` block in `CHANGELOG.md` should be kept current
-as PRs merge so `/release` can roll up. Append entries as you ship.
+Keep the `## [Unreleased]` block in `CHANGELOG.md` current as PRs
+merge so `/release` can roll up. Append entries as you ship.
+
+A new session **does not** cut a release on its own initiative.
+Releases are user-triggered (`/release`).
 
 ## ClojureWasm propagation
 
@@ -201,14 +204,23 @@ a Windows guard.
 ## Procedural rules (override session defaults)
 
 - **No-Workaround Rule (CLAUDE.md).** A Windows-specific failure
-  during Plan C is a **bug**, not a reason to keep the guard. Add a
-  `W##` entry, fix the root cause, then remove the guard. Do not
-  paper over with `if: runner.os != 'Windows'`. The whole point of
-  buying the Windows mini-PC was to surface these bugs.
+  during Plan C is a **bug discovery, not a setback**. The whole
+  point of buying the Windows mini-PC was to surface these bugs.
+  Add a `W##` entry, fix the root cause in zwasm proper, re-verify
+  on Mac+Ubuntu (CW regression surface), then remove the CI guard.
+  Do **not** paper over with `if: runner.os != 'Windows'`.
 - **Autonomous merge authorization is per-session.** Without an
-  explicit grant from the user in the **current** session ("I'm
-  going to sleep" / "merge for me"), default behaviour is: push to a
-  feature branch, open the PR, wait for the user to merge.
+  explicit grant from the user in the **current** session, the
+  default is: push to a feature branch, open the PR, wait for the
+  user to merge. Recognised grant phrases:
+  - "merge without waiting for CI" / "CI またずマージしていいよ"
+    — fast-track for doc-only / single-line-config-only PRs whose
+    failure modes are limited to syntax / typo. **Still run
+    `bash scripts/sync-versions.sh` locally before merging.**
+  - "ship overnight" / "寝ます、朝には終わってて" — broad authority
+    for the rest of the session, including substantive work, but
+    only when each Merge Gate item passes (incl. local bench
+    record on Mac). Open PR if any uncertainty remains.
 - **Stack PRs sparingly.** A second PR stacked on a first is fine
   when the work is genuinely incremental and the first is reviewable
   in isolation. If they share commits, the squash-merge of the first
@@ -223,19 +235,69 @@ a Windows guard.
 
 ## How to use this guide on resume
 
-1. `git fetch origin && git log --oneline -5 origin/main` — see what's
-   on main now.
-2. `bash scripts/sync-versions.sh` — sanity check tooling pins.
-3. `bash scripts/gate-commit.sh --only=tests` — fast smoke test.
-4. Pick **one** item from "Outstanding work" above. Do the smallest
-   one in the chosen area.
-5. Branch, edit, test locally (`gate-commit.sh` for the affected
-   path), push, open a PR. Do not chain more than one open PR per
-   session unless the user is awake.
-6. When the chosen item is merged, refresh this guide (delete the
-   item from its table, add a "done 2026-MM-DD" line if illustrative).
-7. If the entire Plan C and Plan B sub-3 sections become empty, remove
-   `.dev/resume-guide.md` and the pointer in `.dev/memo.md`.
+The expected entry point is the user typing **"続けて"** / **"continue"**
+on a fresh session that has no context other than this repo. The
+session's first move is the CLAUDE.md Orient step, which lands here
+via `.dev/memo.md ## Current Task`.
+
+1. **Sync local main first.** `git checkout main && git fetch origin
+   && git pull --ff-only origin main`. Your local main may be many
+   merges behind — Orient does not pull on its own.
+2. **Sanity checks** (each is fast — under 30 s):
+   - `bash scripts/sync-versions.sh` — versions.lock ↔ flake.nix.
+   - `bash scripts/gate-commit.sh --only=tests` — Zig build + unit tests.
+3. **Pick one item** from "Outstanding work" above. Smallest first;
+   the table is ordered by ascending risk within each area.
+4. **Branch.** `git checkout -b develop/<short-task-name>`.
+   Conventional names for the residual work:
+   `develop/ci-windows-shared-lib`,
+   `develop/ci-windows-static-lib`,
+   `develop/ci-windows-strip-cross-platform`,
+   `develop/ci-windows-rust-ffi-example`,
+   `develop/ci-windows-test-ffi-c-port`,
+   `develop/ci-nix-installer`, etc.
+5. **Implement.** Edit, then locally `bash scripts/gate-commit.sh`
+   (full gate ~6 min on Mac). For Windows-only changes, also verify
+   via SSH on the user's local Windows mini-PC (only available on
+   shota's machine — `~/.ssh/config` carries a `windowsmini` entry):
+   ```bash
+   ssh windowsmini 'cd C:/Users/shota/Documents/MyProducts/zwasm \
+       && git fetch origin develop/<branch> \
+       && git checkout develop/<branch> \
+       && git reset --hard origin/develop/<branch> \
+       && bash scripts/gate-commit.sh'
+   ```
+   If the branch bumped a tool version in `versions.lock`, re-run
+   `pwsh scripts/windows/install-tools.ps1` on the Windows side first.
+   It is idempotent and only re-installs on version mismatch; pass
+   `--Force` to refresh anyway.
+6. **Push, PR.** `git push -u origin develop/<branch>`, then
+   `gh pr create --base main`. Watch CI via `Monitor` (do not poll).
+   Do not stack more than one open PR per session unless the user has
+   explicitly granted "ship a stack overnight" autonomy.
+7. **Merge.** Default behaviour is "wait for the user to merge". If
+   the user has said "merge without waiting for CI" for a doc-only
+   change, or "ship overnight" for substantive work, use
+   `gh pr merge <N> --squash --delete-branch`. See
+   `memory/autonomous_mode_permission.md` for the scope rules.
+8. **Post-merge bench record (Mac only, every merge).**
+   ```bash
+   git checkout main && git pull --ff-only
+   bash scripts/record-merge-bench.sh           # full ~5 min
+   # or `bash scripts/record-merge-bench.sh --runs=1 --warmup=0`  for quick
+   git add bench/history.yaml
+   git commit -m "Record benchmark for <PR subject>"
+   git push origin main
+   ```
+   The script auto-derives `--id` from the merge SHA and `--reason`
+   from the commit subject, and is a no-op on Linux/Windows
+   (`bench/history.yaml` env block is Darwin-only). Use the quick
+   mode for doc-only merges where bench cannot have changed.
+9. **Refresh this guide.** When an item lands, delete its row from
+   the relevant table.
+10. **Tear down when done.** When the Plan C and Plan B sub-3
+    sections empty out, delete `.dev/resume-guide.md` and the
+    pointer block in `.dev/memo.md ## Current Task`.
 
 ## Stop conditions
 

--- a/.dev/resume-guide.md
+++ b/.dev/resume-guide.md
@@ -1,0 +1,253 @@
+# Session Resumption Guide
+
+Read this when a new session opens with no context and the user says
+"続けて" / "continue". This document plus `git log --oneline -10` is
+intended to give you everything you need to make safe forward progress
+without re-reading the prior chat.
+
+The guide is **evergreen** — update it as work lands. Pointer from
+`.dev/memo.md` `## Current Task` should always lead here while there
+is residual Plan C / Plan B sub-3 work; remove the pointer once those
+are exhausted.
+
+## Where main is (snapshot 2026-04-29)
+
+Five PRs landed overnight 2026-04-28 → 2026-04-29:
+
+| PR  | Title                                                      | Effect                                                |
+|-----|------------------------------------------------------------|-------------------------------------------------------|
+| #60 | feat(env): Nix-mirror versions.lock + WASI SDK 30 + environment.md | `flake.nix` becomes SSoT; `.github/versions.lock` mirrors it for Windows / non-Nix consumers; WASI SDK bumped 25→30. D136 records the design. |
+| #61 | feat(scripts): unified gate runners + Windows installer    | `scripts/gate-commit.sh`, `gate-merge.sh`, `run-bench.sh`, `sync-versions.sh`, `lib/versions.sh`, `windows/install-tools.ps1`. CLAUDE.md gates point at the runners. |
+| #62 | ci: enforce versions.lock ↔ flake.nix consistency          | New `versions-lock-sync` job in ci.yml runs `scripts/sync-versions.sh` on every PR. |
+| #64 | ci: add Windows memory usage check via PowerShell          | First of the eight Windows-skip CI guards removed. PowerShell measures `Process.PeakWorkingSet64` against the 4.5 MB budget. |
+| #65 | ci: source HYPERFINE_VERSION from versions.lock            | Pinning consistency. No behaviour change at the same version. |
+
+Verified working state on **2026-04-29** (do **not** trust this list past
+about a week — re-verify by reading current code):
+
+- `bash scripts/gate-commit.sh` returns green on macOS aarch64 (6/6) and
+  Windows x86_64 (5/5; `ffi` host-skipped to mirror CI).
+- `bash scripts/sync-versions.sh` exits 0 (Zig 0.16.0, WASI SDK 30 match).
+- Windows toolchain installs cleanly via
+  `pwsh scripts/windows/install-tools.ps1` from a fresh checkout
+  (provisions Zig + wasm-tools + wasmtime + WASI SDK + VC++ Redist).
+- Realworld on Windows: 25/25 PASS for the C+C++ subset (Go/Rust/TinyGo
+  not yet provisioned by the installer; SKIP gracefully).
+
+## Hard-won facts (not obvious from the code)
+
+These bit me overnight; future sessions will hit the same things if
+they don't read them.
+
+1. **Microsoft Store python alias trap.** A blank Windows 11 has
+   `python.exe` as a 0-byte App Execution Alias that opens the Store
+   when invoked headlessly. `python --version` prints `Python ` (no
+   number) and exits. Real Python must be installed (winget
+   `Python.Python.3.14` or python.org installer) before
+   `install-tools.ps1` can do anything useful.
+2. **Git for Windows does not put `bash` on PATH** by default. Add
+   `C:\Program Files\Git\bin` to user PATH (the installer does this
+   automatically; if missing, see install-tools.ps1's tail).
+3. **WASI SDK 30 clang.exe needs Microsoft Visual C++ Redistributable.**
+   Stock Windows 11 carries only the .NET-flavoured
+   `vcruntime140_clr0400.dll`; the plain runtime is missing.
+   `install-tools.ps1` runs `winget install Microsoft.VCRedist.2015+.x64`
+   automatically.
+4. **wasm-tools Windows asset is `.zip`, not `.tar.gz`.**
+   bytecodealliance ships zip for Windows but tar.gz for Linux/macOS.
+5. **wasmtime Windows release zip has no `bin/` subdirectory** — the
+   `.exe` lives directly in the extracted folder. Linux/macOS tarballs
+   do have `bin/`.
+6. **`.github/versions.lock` has a no-inline-comment policy.** Bash
+   `source` strips trailing `# …`, but the Python reader at
+   `ci.yml > Install WASI SDK (Windows)` uses `split('=', 1)` and the
+   comment ends up in the URL. The file header documents this and the
+   Python reader now defensively strips `#`.
+7. **Admin SSH on Windows uses
+   `C:\ProgramData\ssh\administrators_authorized_keys`**, not the
+   user's `~/.ssh/authorized_keys`. Permissions must be exactly
+   `Administrators:F` + `SYSTEM:F`; sshd silently ignores looser perms.
+8. **`zig objcopy --strip-all` is ELF-only.** It refuses Mach-O with
+   `InvalidElfMagic`. Any cross-platform "size after strip" rewrite
+   needs a different mechanism (build.zig `-Dstrip=true`, or per-OS
+   tooling). This is why C-e below is non-trivial.
+9. **The `failed command:` line in `zig build test` output is harmless.**
+   It is Zig 0.16's stderr per-seed footer for fuzz-test discovery; the
+   build process exit code is still 0. Don't grep for that string.
+10. **autonomous merge authorisation expires per session.** See
+    `~/.claude/projects/.../memory/autonomous_mode_permission.md`.
+    Without an explicit "I'm going to sleep, get this done by morning"
+    grant for the **current** session, default to "open PR, request
+    review" — never merge to main.
+
+## Outstanding work — pick from these
+
+The user is comfortable with stacking small PRs. Each item below is
+self-contained and reversible. Do **not** attempt all of them in one
+session; pick the smallest unblocking subset first.
+
+### Plan C — remove remaining Windows-skip CI guards
+
+`ci.yml` still carries seven `if: runner.os != 'Windows'` (or
+equivalent) guards. None reflects a fundamental incompatibility — every
+one is shell-script or C-side limitation. See `.dev/environment.md` for
+the full table; ordered here by safety / value.
+
+| Id  | Guard                                       | Work                                                                                          | Risk   |
+|-----|---------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
+| C-a | `zig build shared-lib`                      | Drop the guard; verify `zig-out\bin\zwasm.dll` + `.lib` produced. No script change.           | Low    |
+| C-d | `zig build static-lib` + static link tests  | Replace `cc` with `zig cc` in `test/c_api/run_static_link_test.sh`; branch on `RUNNER_OS`.    | Low    |
+| C-c | `examples/rust` `cargo run`                 | Add Windows arm to `examples/rust/build.rs` for the dynamic library lookup; remove guard.     | Medium |
+| C-e | Binary size check (uses GNU `strip`)        | Expose `-Dstrip=true` in build.zig; CI does `zig build -Dstrip=true -Doptimize=ReleaseSafe` and reads the binary directly. ELF/Mach-O/PE all handled by the Zig toolchain. | Medium |
+| C-f | `size-matrix` Ubuntu-only                   | Depends on C-e. Convert to OS matrix once stripping is portable.                              | Small  |
+| C-b | `test/c_api/run_ffi_test.sh`                | Port `test/c_api/test_ffi.c` to use `LoadLibraryA` + `GetProcAddress` on Windows; `.dll` path branch in the shell script. ~50 lines C + 10 lines shell. | High   |
+| C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
+
+Suggested order: **C-a → C-d → C-e → C-f → C-c → C-b → C-g**.
+
+After each removal: check `gate-commit.sh` no longer needs the
+matching auto-skip in `scripts/gate-commit.sh:case "$HOST_KIND"`.
+
+### Plan B sub-3 — CI Nix-ify (deferred from overnight)
+
+| Id   | Work                                                                                                          | Risk   |
+|------|---------------------------------------------------------------------------------------------------------------|--------|
+| B3-a | Linux/macOS `test` job → `DeterminateSystems/nix-installer-action` + `magic-nix-cache-action` + `nix develop --command bash scripts/gate-commit.sh`. | Medium |
+| B3-b | Windows `test` job → `pwsh scripts/windows/install-tools.ps1` then `bash scripts/gate-commit.sh`.             | Medium |
+| B3-c | `nightly.yml` mirrored to the same shape.                                                                     | Small  |
+| B3-d | `flake.nix` extension: explicit pins for wasm-tools / wasmtime / hyperfine (URL + sha256), no longer nixpkgs-derived. | Medium |
+
+Reason this was deferred: ci.yml restructure is large; magic-nix-cache
+had a 2025 outage; macos-latest + nix-installer-action has occasional
+CI flakes. Best done in a single PR with the user watching, not
+overnight.
+
+### Documentation drift to fix
+
+Audit and update when on a doc-touching PR. None blocks anything:
+
+- **README.md** `Real-world: 50 / 50 (Mac + Linux + Windows)` is
+  optimistic — Windows is currently 25/25 (C+C++ only) until
+  `install-tools.ps1` provisions Go/Rust/TinyGo. Same number appears
+  in `book/en/src/introduction.md`, `book/en/src/faq.md` ("46/46"
+  is also stale).
+- **book/en/src/contributing.md** Build & Test section still lists
+  individual `zig build test` etc. as the canonical commands; should
+  reference `bash scripts/gate-commit.sh` per the post-#61 model. The
+  Japanese mirror (`book/ja/src/contributing.md`) needs the same edit.
+- **book/en/src/getting-started.md** likely still recommends manual
+  tool installs without mentioning `install-tools.ps1` for Windows.
+- **`.dev/references/setup-orbstack.md`** predates D136 and bootstraps
+  tools with stale versions (Zig 0.15.2, WASI SDK 25). Either update
+  to current pins or replace with "install Nix inside the VM and use
+  direnv" recipe.
+- **`.dev/roadmap.md`** "Zig version upgrade — High" line is
+  obsolete (0.16.0 done). The `Current State` block also lists
+  `Binary 1.23 MB` which doesn't match the 1.20 MB / 1.56 MB measured
+  in v1.11.0.
+
+### realworld coverage on Windows
+
+`install-tools.ps1` only provisions Zig + wasm-tools + wasmtime +
+WASI SDK. `build_all.py` SKIPs Go / Rust / TinyGo when those toolchains
+are missing, which is why the Windows realworld run is 25/25 instead
+of 50/50. To close: extend `install-tools.ps1` (or split into a
+follow-on `install-extras.ps1`) with rustup-init + Go + TinyGo. Each is
+~30 lines of PowerShell with a versions.lock pin. Filed as W## (add to
+checklist).
+
+## When to cut a release
+
+`v1.11.0` is the most recent tag. The PRs merged overnight are
+infrastructure / developer-tooling changes; **no public API or
+behavioural change for embedders**. By strict semver this is a patch
+bump (v1.11.1).
+
+Cut a release when one of these is true:
+
+- A user-facing feature lands (new CLI flag, new public function).
+- A behaviour change matters (perf regression resolved, bug-fix the
+  user can ask "is this in a tag yet").
+- The user explicitly asks for a tag.
+- ClojureWasm (downstream) wants a stable pin instead of `main`.
+
+The `/release` skill automates the tag, `CHANGELOG.md`, benchmark
+recording, and the ClojureWasm pin update. Do **not** cut a tag
+manually — let the skill handle it.
+
+The `## [Unreleased]` block in `CHANGELOG.md` should be kept current
+as PRs merge so `/release` can roll up. Append entries as you ship.
+
+## ClojureWasm propagation
+
+CW depends on zwasm `main` via the GitHub URL pin. So:
+
+- **Routine main merges** automatically reach CW on the next CW build.
+  No explicit propagation step.
+- **Behaviour changes** that could affect CW (interpreter / wasi / GC
+  semantics) need a CW regression check. The `/release` skill exercises
+  CW's test suite against the new tag; for bare-main changes, run CW's
+  Mac+Ubuntu tests manually before assuming green.
+- **Windows-only work in zwasm** does **not** require CW changes.
+  CW's documentation does not claim Windows support and CW's CI matrix
+  is Mac+Ubuntu only. Plan C and B3 work is therefore CW-neutral.
+
+If a Windows-driven debug session uncovers a real interpreter / WASI
+bug (i.e. the zwasm core, not the script wrappers), treat it as a
+universal bug — fix in zwasm proper, exercise CW's tests, and
+re-verify on Mac+Ubuntu before merging. **Do not** hide the bug behind
+a Windows guard.
+
+## Procedural rules (override session defaults)
+
+- **No-Workaround Rule (CLAUDE.md).** A Windows-specific failure
+  during Plan C is a **bug**, not a reason to keep the guard. Add a
+  `W##` entry, fix the root cause, then remove the guard. Do not
+  paper over with `if: runner.os != 'Windows'`. The whole point of
+  buying the Windows mini-PC was to surface these bugs.
+- **Autonomous merge authorization is per-session.** Without an
+  explicit grant from the user in the **current** session ("I'm
+  going to sleep" / "merge for me"), default behaviour is: push to a
+  feature branch, open the PR, wait for the user to merge.
+- **Stack PRs sparingly.** A second PR stacked on a first is fine
+  when the work is genuinely incremental and the first is reviewable
+  in isolation. If they share commits, the squash-merge of the first
+  closes the second's PR (because GitHub deletes the source branch);
+  then re-open as a fresh PR with a forced rebase. (Hit this with
+  PR #63 → #64 overnight.)
+- **Prefer `gh pr merge --squash --delete-branch`** for these
+  feature branches; the project history stays linear.
+- **`gh pr rerun --failed`** is the right move for transient
+  ETIMEDOUT / setup-zig flakes (saw one on #65 post-merge); never
+  push a no-op commit just to retrigger.
+
+## How to use this guide on resume
+
+1. `git fetch origin && git log --oneline -5 origin/main` — see what's
+   on main now.
+2. `bash scripts/sync-versions.sh` — sanity check tooling pins.
+3. `bash scripts/gate-commit.sh --only=tests` — fast smoke test.
+4. Pick **one** item from "Outstanding work" above. Do the smallest
+   one in the chosen area.
+5. Branch, edit, test locally (`gate-commit.sh` for the affected
+   path), push, open a PR. Do not chain more than one open PR per
+   session unless the user is awake.
+6. When the chosen item is merged, refresh this guide (delete the
+   item from its table, add a "done 2026-MM-DD" line if illustrative).
+7. If the entire Plan C and Plan B sub-3 sections become empty, remove
+   `.dev/resume-guide.md` and the pointer in `.dev/memo.md`.
+
+## Stop conditions
+
+Stop and wait for the user (do **not** push speculative fixes) if:
+
+- A Plan C item turns out to be deeper than the table estimates
+  (Windows-only zwasm behaviour bug, build.zig structural change
+  beyond expectation).
+- CI fails twice on the same PR for non-flaky reasons.
+- Any change risks affecting non-Windows behaviour (CW regression
+  surface).
+- A merge to main would race ahead of an in-flight user-facing PR.
+
+In all of these: leave a clearly-titled draft PR with a body that
+quotes the failure and what you tried. The user can pick it up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+Developer / CI infrastructure improvements. **No public API or runtime
+behaviour change for embedders.**
+
+### Added
+- `.github/versions.lock` (mirrors `flake.nix` pins for Windows + CI
+  YAML) replaces the old `.github/tool-versions`. Single source of
+  truth for Zig, wasm-tools, wasmtime, WASI SDK, Rust pins; comments
+  must live on their own line per file header (the Python reader in
+  `ci.yml` does a plain `split('=', 1)`). (#60, D136)
+- `.dev/environment.md` — developer onboarding doc covering Mac /
+  Linux / Windows native setup, Nix devshell contents, CI ↔ local
+  gate mapping, and the remaining Windows-skipped CI items as a
+  Plan C tracker. (#60)
+- `scripts/lib/versions.sh`, `scripts/sync-versions.sh`,
+  `scripts/gate-commit.sh`, `scripts/gate-merge.sh`, `scripts/run-bench.sh`
+  — unified Commit Gate / Merge Gate runners that work identically on
+  macOS, Linux (Nix devshell), and Windows (Git Bash). `gate-commit.sh`
+  auto-clones wasmtime `tests/misc_testsuite` into a gitignored
+  `.cache/` directory and chains `build_all.py && run_compat.py` for
+  realworld so a fresh checkout works without manual setup. Auto-skips
+  `ffi` on Windows to mirror the existing CI guard. (#61)
+- `scripts/windows/install-tools.ps1` — provisions Zig + wasm-tools +
+  wasmtime + WASI SDK from `versions.lock` into
+  `%LOCALAPPDATA%\zwasm-tools`. Updates user PATH + `WASI_SDK_PATH`.
+  Auto-installs Microsoft Visual C++ Redistributable via winget when
+  `vcruntime140.dll` is missing (WASI SDK clang.exe needs it).
+  Idempotent; `--Force` re-extracts; `-OnlyTool` selects one. (#61)
+- `versions-lock-sync` CI job mechanises Merge Gate item #9 — fails
+  the PR if `flake.nix` and `versions.lock` disagree on a tool pin.
+  Runs in parallel with the existing test matrix in well under a
+  second. (#62)
+- Memory usage check on Windows via PowerShell `Process.PeakWorkingSet64`
+  — first of the eight Windows-skip CI guards removed. Same 4.5 MB
+  budget as the POSIX path. (#64)
+
+### Changed
+- WASI SDK version bumped 25 → 30 to align CI with `flake.nix` (which
+  was already at 30). Realworld 50/50 PASS verified locally on
+  macOS aarch64 with the new SDK. (#60)
+- `CLAUDE.md` Commit Gate / Merge Gate sections point at
+  `bash scripts/gate-commit.sh` / `gate-merge.sh` as the one-liner
+  entry points; example commands switched to the `.py` runners that
+  CI exercises. (#61)
+- `.github/workflows/ci.yml` benchmark job sources `HYPERFINE_VERSION`
+  from `versions.lock` instead of hardcoding the version twice. (#65)
+
+### Internal
+- D136 (in `decisions.md`): Nix-as-SSoT design recorded with the
+  Plan B / Plan C scope (unified gate scripts, Nix-based CI,
+  Windows native installer, removal of the remaining Windows-skipped
+  CI steps).
+
 ## [1.11.0] - 2026-04-26
 
 W46 + W48: re-disable `link_libc` on the core build and trim the release

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,7 @@ scripts/
 ├── gate-commit.sh           # CLAUDE.md Commit Gate (steps 1-8)
 ├── gate-merge.sh            # CLAUDE.md Merge Gate (Commit + sync + CI)
 ├── run-bench.sh             # wrapper around bench/run_bench.sh
+├── record-merge-bench.sh    # post-merge bench/history.yaml row (Mac only)
 └── windows/
     └── install-tools.ps1    # provisions Zig/wasm-tools/wasmtime/WASI SDK
                              # on Windows by reading versions.lock
@@ -28,6 +29,8 @@ bash scripts/gate-merge.sh              # before merging (run on Mac AND
                                         # Ubuntu OrbStack — see CLAUDE.md)
 bash scripts/run-bench.sh --quick       # quick bench
 bash scripts/sync-versions.sh           # confirm pin consistency
+bash scripts/record-merge-bench.sh      # post-merge: append history.yaml row
+                                        # (auto-skips on Linux/Windows)
 ```
 
 `gate-commit.sh --help` lists the per-step skip flags. Steps map 1:1

--- a/scripts/record-merge-bench.sh
+++ b/scripts/record-merge-bench.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# scripts/record-merge-bench.sh — append a benchmark row to
+# bench/history.yaml for the current commit.
+#
+# Project policy: every merge to main gets one row. Run this after the
+# PR is merged and main is checked out locally, NOT before — the row
+# should reference the merge commit, not the branch tip.
+#
+# Mac-only by design. bench/history.yaml's env block declares
+# `os: Darwin <version>` so cross-host entries would be misleading.
+# On Linux/Windows the script logs and exits 0 so it can sit in a
+# scripted post-merge flow without breaking it.
+#
+# Usage:
+#   bash scripts/record-merge-bench.sh                 # full record (5 runs + 3 warmup)
+#   bash scripts/record-merge-bench.sh --runs=1 --warmup=0   # quick record
+#   bash scripts/record-merge-bench.sh --reason="..."  # override default reason
+#
+# All arguments after the script are passed straight to
+# bench/record.sh. --id and --reason are auto-filled from the current
+# HEAD commit if you do not pass them explicitly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/versions.sh
+source "$SCRIPT_DIR/lib/versions.sh"
+
+cd "$ZWASM_REPO_ROOT"
+
+if [ "$(uname)" != "Darwin" ]; then
+    echo "record-merge-bench: bench/history.yaml is Mac-specific (env: Darwin)." >&2
+    echo "                    Skipping on $(uname)." >&2
+    exit 0
+fi
+
+# Allow caller to override --id / --reason. We default-fill them from
+# git only when the caller did not pass either flag.
+have_id=false
+have_reason=false
+for arg in "$@"; do
+    case "$arg" in
+        --id=*)     have_id=true ;;
+        --reason=*) have_reason=true ;;
+    esac
+done
+
+extra_args=()
+if ! $have_id; then
+    extra_args+=("--id=$(git rev-parse --short HEAD)")
+fi
+if ! $have_reason; then
+    extra_args+=("--reason=$(git log -1 --pretty=%s)")
+fi
+
+# Idempotent: if the auto-derived id already exists, the inner
+# bench/record.sh will refuse without --overwrite. That's intentional
+# — re-recording the same SHA usually means the user already ran this
+# once. Surface the conflict rather than silently re-measuring.
+exec bash bench/record.sh "${extra_args[@]}" "$@"


### PR DESCRIPTION
## Summary

Prepares the repo so a new Claude Code session opening with no chat context can type "続けて" and pick up correctly:

1. **\`.dev/resume-guide.md\`** (new, evergreen) — canonical session-resumption document. Snapshots where main is, lists ten hard-won facts (MS Store python alias trap, Git for Windows bash on PATH, VC++ Redist for WASI SDK, wasm-tools .zip vs .tar.gz, wasmtime no bin/ subdir, versions.lock no-inline-comments, administrators_authorized_keys perms, \`zig objcopy\` ELF-only, etc.), enumerates Plan C residual / Plan B sub-3 / doc drift work, codifies session-scoped merge authorisation + No-Workaround Rule + stack-PR pitfalls + ETIMEDOUT handling, and gives a ready-to-execute resume procedure with stop conditions.

2. **\`.dev/memo.md\`** — \`## Current Task\` now opens with a brief state line and points at the guide; the W48 Phase 1 narrative drops to \`## Previous Task\` together with a summary of the overnight 2026-04-29 infrastructure work.

3. **\`.dev/checklist.md\`** — adds W49 (Plan C residual), W50 (CI Nix-ify), W51 (doc drift), W52 (realworld toolchain extension on Windows). All cross-link to resume-guide.md for the detail.

4. **\`CHANGELOG.md\`** \`[Unreleased]\` — captures #60 / #61 / #62 / #64 / #65 so \`/release\` can roll them into the next tag. None affect public API or runtime behaviour, so the natural shape is a patch bump (v1.11.1).

## Test plan

- [x] \`bash scripts/sync-versions.sh\` — green
- [ ] CI matrix green on this PR (verify after push)

Refs: D136