### PR TITLE
ci(windows): drop shared-lib guard — Plan C-a

### DIFF
--- a/.dev/environment.md
+++ b/.dev/environment.md
@@ -188,7 +188,6 @@ incompatibility — every one is a script-side limitation:
 
 | Step                                    | Blocker                                                 | Fix shape                                                  |
 |-----------------------------------------|---------------------------------------------------------|------------------------------------------------------------|
-| `zig build shared-lib`                  | None known; just gated                                  | Drop `if:`                                                 |
 | `test/c_api/run_ffi_test.sh`            | `gcc -ldl -pthread`, `dlfcn.h` in `test_ffi.c`          | Branch for `LoadLibraryA` + `GetProcAddress` (~50 lines C) |
 | `examples/rust` `cargo run`             | `build.rs` solves dynamic-lib path Linux/Mac only       | Add Windows branch in `build.rs`                           |
 | `zig build static-lib` + static link    | Shell script assumes `cc`                               | Branch by `RUNNER_OS`                                      |
@@ -197,7 +196,10 @@ incompatibility — every one is a script-side limitation:
 | `benchmark` job                         | `hyperfine` install via DEB; `bench/ci_compare.sh` GNU dependencies | Add Windows install step + audit ci_compare.sh portability |
 
 (Memory check is no longer in this table — PR #64 added a PowerShell
-`Process.PeakWorkingSet64` branch for the Windows runner.)
+`Process.PeakWorkingSet64` branch for the Windows runner. `zig build
+shared-lib` is no longer in this table — the guard was a no-op since
+Zig produces `zwasm.dll` + `zwasm.lib` natively from
+`addLibrary({.linkage = .dynamic})`.)
 
 ## Nix devshell contents (current)
 

--- a/.dev/resume-guide.md
+++ b/.dev/resume-guide.md
@@ -99,7 +99,6 @@ the full table; ordered here by safety / value.
 
 | Id  | Guard                                       | Work                                                                                          | Risk   |
 |-----|---------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
-| C-a | `zig build shared-lib`                      | Drop the guard; verify `zig-out\bin\zwasm.dll` + `.lib` produced. No script change.           | Low    |
 | C-d | `zig build static-lib` + static link tests  | Replace `cc` with `zig cc` in `test/c_api/run_static_link_test.sh`; branch on `RUNNER_OS`.    | Low    |
 | C-c | `examples/rust` `cargo run`                 | Add Windows arm to `examples/rust/build.rs` for the dynamic library lookup; remove guard.     | Medium |
 | C-e | Binary size check (uses GNU `strip`)        | Expose `-Dstrip=true` in build.zig; CI does `zig build -Dstrip=true -Doptimize=ReleaseSafe` and reads the binary directly. ELF/Mach-O/PE all handled by the Zig toolchain. | Medium |
@@ -107,7 +106,10 @@ the full table; ordered here by safety / value.
 | C-b | `test/c_api/run_ffi_test.sh`                | Port `test/c_api/test_ffi.c` to use `LoadLibraryA` + `GetProcAddress` on Windows; `.dll` path branch in the shell script. ~50 lines C + 10 lines shell. | High   |
 | C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
 
-Suggested order: **C-a → C-d → C-e → C-f → C-c → C-b → C-g**.
+Suggested order: **C-d → C-e → C-f → C-c → C-b → C-g**. (C-a landed
+post-2026-04-29 — `zig build shared-lib` on Windows produces
+`zwasm.dll` + `zwasm.lib` natively from
+`addLibrary({.linkage = .dynamic})`; guard was a no-op.)
 
 After each removal: check `gate-commit.sh` no longer needs the
 matching auto-skip in `scripts/gate-commit.sh:case "$HOST_KIND"`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
         run: zig build c-test
 
       - name: Build shared library
-        if: runner.os != 'Windows'
         run: zig build shared-lib
 
       - name: Run FFI tests (shared library)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ behaviour change for embedders.**
 - Memory usage check on Windows via PowerShell `Process.PeakWorkingSet64`
   — first of the eight Windows-skip CI guards removed. Same 4.5 MB
   budget as the POSIX path. (#64)
+- `zig build shared-lib` now runs on Windows in CI. Zig produces
+  `zwasm.dll` + `zwasm.lib` natively from
+  `addLibrary({.linkage = .dynamic})` — the old guard was a no-op.
+  Plan C-a.
 
 ### Changed
 - WASI SDK version bumped 25 → 30 to align CI with `flake.nix` (which


### PR DESCRIPTION
## Summary

- Drops the `if: runner.os != 'Windows'` guard on the CI \`Build shared library\` step.
- Zig produces \`zwasm.dll\` + \`zwasm.lib\` natively on Windows from \`addLibrary({.linkage = .dynamic})\`; the guard was a no-op.
- Removes C-a from the Plan C tracker in \`.dev/environment.md\` / \`.dev/resume-guide.md\` and notes it in CHANGELOG \`[Unreleased]\`.

This is the second of the eight original Windows-skip CI guards to come down (after PR #64 covered the memory check). Six remaining: C-b, C-c, C-d, C-e, C-f, C-g.

## Test plan

- [ ] CI: \`test (windows-latest)\` succeeds on the new \`Build shared library\` step (artifact: \`zig-out\\bin\\zwasm.dll\` + \`zig-out\\lib\\zwasm.lib\`).
- [ ] CI: Mac/Ubuntu \`test\` jobs unchanged (no behavioural diff for them).
- [ ] CI: \`versions-lock-sync\` green (no version touch in this PR).
- [ ] No local change required for shota — \`bash scripts/gate-commit.sh\` already builds shared-lib on Mac.