### PR TITLE
ci(windows): drop static-lib + static-link guards — Plan C-d

### DIFF
--- a/.dev/environment.md
+++ b/.dev/environment.md
@@ -190,7 +190,6 @@ incompatibility — every one is a script-side limitation:
 |-----------------------------------------|---------------------------------------------------------|------------------------------------------------------------|
 | `test/c_api/run_ffi_test.sh`            | `gcc -ldl -pthread`, `dlfcn.h` in `test_ffi.c`          | Branch for `LoadLibraryA` + `GetProcAddress` (~50 lines C) |
 | `examples/rust` `cargo run`             | `build.rs` solves dynamic-lib path Linux/Mac only       | Add Windows branch in `build.rs`                           |
-| `zig build static-lib` + static link    | Shell script assumes `cc`                               | Branch by `RUNNER_OS`                                      |
 | Binary size check                       | Uses GNU `strip`                                        | Expose `-Dstrip=true` in build.zig and measure directly (Mach-O / ELF / PE all handled by Zig) |
 | `size-matrix` job                       | `strip` again                                           | Same fix as binary size check; fan out to OS matrix        |
 | `benchmark` job                         | `hyperfine` install via DEB; `bench/ci_compare.sh` GNU dependencies | Add Windows install step + audit ci_compare.sh portability |
@@ -199,7 +198,11 @@ incompatibility — every one is a script-side limitation:
 `Process.PeakWorkingSet64` branch for the Windows runner. `zig build
 shared-lib` is no longer in this table — the guard was a no-op since
 Zig produces `zwasm.dll` + `zwasm.lib` natively from
-`addLibrary({.linkage = .dynamic})`.)
+`addLibrary({.linkage = .dynamic})`. `zig build static-lib` + static
+link tests are no longer in this table — the script now uses `zig cc`
+in place of system `cc`, which is portable; PIE coverage is preserved
+on Linux; Rust static-link skips on Windows pending the C-c
+`examples/rust/build.rs` POSIX-isms fix.)
 
 ## Nix devshell contents (current)
 

--- a/.dev/resume-guide.md
+++ b/.dev/resume-guide.md
@@ -99,17 +99,19 @@ the full table; ordered here by safety / value.
 
 | Id  | Guard                                       | Work                                                                                          | Risk   |
 |-----|---------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
-| C-d | `zig build static-lib` + static link tests  | Replace `cc` with `zig cc` in `test/c_api/run_static_link_test.sh`; branch on `RUNNER_OS`.    | Low    |
 | C-c | `examples/rust` `cargo run`                 | Add Windows arm to `examples/rust/build.rs` for the dynamic library lookup; remove guard.     | Medium |
 | C-e | Binary size check (uses GNU `strip`)        | Expose `-Dstrip=true` in build.zig; CI does `zig build -Dstrip=true -Doptimize=ReleaseSafe` and reads the binary directly. ELF/Mach-O/PE all handled by the Zig toolchain. | Medium |
 | C-f | `size-matrix` Ubuntu-only                   | Depends on C-e. Convert to OS matrix once stripping is portable.                              | Small  |
 | C-b | `test/c_api/run_ffi_test.sh`                | Port `test/c_api/test_ffi.c` to use `LoadLibraryA` + `GetProcAddress` on Windows; `.dll` path branch in the shell script. ~50 lines C + 10 lines shell. | High   |
 | C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
 
-Suggested order: **C-d → C-e → C-f → C-c → C-b → C-g**. (C-a landed
+Suggested order: **C-e → C-f → C-c → C-b → C-g**. (C-a landed
 post-2026-04-29 — `zig build shared-lib` on Windows produces
 `zwasm.dll` + `zwasm.lib` natively from
-`addLibrary({.linkage = .dynamic})`; guard was a no-op.)
+`addLibrary({.linkage = .dynamic})`; guard was a no-op. C-d landed
+post-2026-04-29 — `test/c_api/run_static_link_test.sh` now uses
+`zig cc` everywhere; PIE preserved on Linux; Rust skipped on Windows
+until C-c lands.)
 
 After each removal: check `gate-commit.sh` no longer needs the
 matching auto-skip in `scripts/gate-commit.sh:case "$HOST_KIND"`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,9 @@ jobs:
         run: cd examples/rust && cargo run
 
       - name: Build static library (PIC + compiler_rt)
-        if: runner.os != 'Windows'
         run: zig build static-lib -Dpic=true -Dcompiler-rt=true
 
       - name: Run static link tests
-        if: runner.os != 'Windows'
         run: bash test/c_api/run_static_link_test.sh
 
       - name: Install wasm-tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ behaviour change for embedders.**
   `zwasm.dll` + `zwasm.lib` natively from
   `addLibrary({.linkage = .dynamic})` — the old guard was a no-op.
   Plan C-a.
+- `zig build static-lib -Dpic=true -Dcompiler-rt=true` and
+  `test/c_api/run_static_link_test.sh` now run on Windows in CI.
+  The C link tests use `zig cc` (portable across Mac/Linux/Windows)
+  instead of system `cc`. PIE coverage is preserved on Linux. Rust
+  static-link still skips on Windows because
+  `examples/rust/build.rs` is POSIX-only (Plan C-c). Plan C-d.
 
 ### Changed
 - WASI SDK version bumped 25 → 30 to align CI with `flake.nix` (which

--- a/test/c_api/run_static_link_test.sh
+++ b/test/c_api/run_static_link_test.sh
@@ -2,7 +2,12 @@
 # run_static_link_test.sh — Test linking libzwasm.a from non-Zig toolchains
 #
 # Simulates real-world usage: build static lib with PIC + compiler_rt,
-# then link with system cc and cargo (Rust) directly.
+# then link via `zig cc` (portable across Mac/Linux/Windows; replaces
+# the previous platform-specific `cc`). On Linux we additionally cover
+# the `-pie` path. The Rust static-link test runs everywhere a working
+# cargo + rustc are available; on Windows MSVC ABI it is skipped because
+# `examples/rust/build.rs` still uses `cargo:rustc-link-lib=c|m` /
+# `-Wl,-rpath`, which are POSIX-only (tracked as Plan C-c).
 #
 # Usage:
 #   bash test/c_api/run_static_link_test.sh [--build]
@@ -25,6 +30,22 @@ PASS=0
 FAIL=0
 TOTAL=0
 
+UNAME_S=$(uname -s 2>/dev/null || echo unknown)
+case "$UNAME_S" in
+    MINGW*|MSYS*|CYGWIN*) HOST_OS=Windows ;;
+    Darwin)               HOST_OS=Darwin  ;;
+    Linux)                HOST_OS=Linux   ;;
+    *)                    HOST_OS=Other   ;;
+esac
+
+if [ "$HOST_OS" = "Windows" ]; then
+    BIN_EXT=".exe"
+    TMP_DIR="${TEMP:-/tmp}"
+else
+    BIN_EXT=""
+    TMP_DIR="/tmp"
+fi
+
 pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"; }
 
@@ -35,46 +56,51 @@ if $BUILD || [ ! -f "$LIB" ]; then
 fi
 
 echo ""
-echo "=== Static Link Tests ==="
+echo "=== Static Link Tests (host=$HOST_OS) ==="
 echo ""
 
-# --- Test 1: C direct link with system cc ---
-echo "[1/3] C direct link (cc)"
-TMPBIN=$(mktemp /tmp/zwasm_static_XXXXXX)
-if cc -o "$TMPBIN" examples/c/hello.c -Iinclude "$LIB" -lc -lm 2>/tmp/zwasm_cc_err.txt; then
+# --- Test 1: C direct link with `zig cc` ---
+echo "[1/3] C direct link (zig cc)"
+TMPBIN="${TMP_DIR}/zwasm_static_${RANDOM}${BIN_EXT}"
+rm -f "$TMPBIN"
+if zig cc -o "$TMPBIN" examples/c/hello.c -Iinclude "$LIB" 2>/tmp/zwasm_cc_err.txt; then
     OUTPUT=$("$TMPBIN" 2>&1)
     if [ "$OUTPUT" = "f() = 42" ]; then
-        pass "cc link + run"
+        pass "zig cc link + run"
     else
-        fail "cc link ok but output='$OUTPUT' (expected 'f() = 42')"
+        fail "zig cc link ok but output='$OUTPUT' (expected 'f() = 42')"
     fi
 else
-    fail "cc link failed: $(cat /tmp/zwasm_cc_err.txt)"
+    fail "zig cc link failed: $(cat /tmp/zwasm_cc_err.txt)"
 fi
 rm -f "$TMPBIN" /tmp/zwasm_cc_err.txt
 
-# --- Test 2: C direct link with system cc (PIE) ---
-echo "[2/3] C direct link (cc -pie)"
-TMPBIN=$(mktemp /tmp/zwasm_static_XXXXXX)
-PIE_FLAG=""
-if [[ "$(uname)" != "Darwin" ]]; then
-    PIE_FLAG="-pie"
-fi
-if cc $PIE_FLAG -o "$TMPBIN" examples/c/hello.c -Iinclude "$LIB" -lc -lm 2>/tmp/zwasm_cc_pie_err.txt; then
-    OUTPUT=$("$TMPBIN" 2>&1)
-    if [ "$OUTPUT" = "f() = 42" ]; then
-        pass "cc PIE link + run"
+# --- Test 2: C direct link with `zig cc -pie` (Linux only) ---
+if [ "$HOST_OS" = "Linux" ]; then
+    echo "[2/3] C direct link (zig cc -pie)"
+    TMPBIN="${TMP_DIR}/zwasm_static_pie_${RANDOM}${BIN_EXT}"
+    rm -f "$TMPBIN"
+    if zig cc -pie -o "$TMPBIN" examples/c/hello.c -Iinclude "$LIB" 2>/tmp/zwasm_cc_pie_err.txt; then
+        OUTPUT=$("$TMPBIN" 2>&1)
+        if [ "$OUTPUT" = "f() = 42" ]; then
+            pass "zig cc PIE link + run"
+        else
+            fail "zig cc PIE link ok but output='$OUTPUT' (expected 'f() = 42')"
+        fi
     else
-        fail "cc PIE link ok but output='$OUTPUT' (expected 'f() = 42')"
+        fail "zig cc PIE link failed: $(cat /tmp/zwasm_cc_pie_err.txt)"
     fi
+    rm -f "$TMPBIN" /tmp/zwasm_cc_pie_err.txt
 else
-    fail "cc PIE link failed: $(cat /tmp/zwasm_cc_pie_err.txt)"
+    echo "[2/3] C direct link (zig cc -pie)"
+    echo "  SKIP: PIE only exercised on Linux"
 fi
-rm -f "$TMPBIN" /tmp/zwasm_cc_pie_err.txt
 
 # --- Test 3: Rust static link (cargo) ---
 echo "[3/3] Rust static link (cargo)"
-if command -v cargo >/dev/null 2>&1; then
+if [ "$HOST_OS" = "Windows" ]; then
+    echo "  SKIP: Rust example build.rs is POSIX-only (Plan C-c will fix)"
+elif command -v cargo >/dev/null 2>&1; then
     # Clean to avoid stale cached dylib-linked binary
     cargo clean --manifest-path examples/rust/Cargo.toml 2>/dev/null || true
     if ZWASM_STATIC=1 cargo build --manifest-path examples/rust/Cargo.toml 2>/tmp/zwasm_cargo_err.txt; then

--- a/test/c_api/run_static_link_test.sh
+++ b/test/c_api/run_static_link_test.sh
@@ -25,7 +25,6 @@ for arg in "$@"; do
     esac
 done
 
-LIB="zig-out/lib/libzwasm.a"
 PASS=0
 FAIL=0
 TOTAL=0
@@ -39,9 +38,13 @@ case "$UNAME_S" in
 esac
 
 if [ "$HOST_OS" = "Windows" ]; then
+    # Zig produces `zwasm.lib` (MSVC convention, no `lib` prefix) for
+    # `addLibrary({.linkage = .static})` on Windows.
+    LIB="zig-out/lib/zwasm.lib"
     BIN_EXT=".exe"
     TMP_DIR="${TEMP:-/tmp}"
 else
+    LIB="zig-out/lib/libzwasm.a"
     BIN_EXT=""
     TMP_DIR="/tmp"
 fi


### PR DESCRIPTION
## Summary

- Replace system \`cc\` with \`zig cc\` in \`test/c_api/run_static_link_test.sh\`. \`zig cc\` is bundled with the Zig toolchain so the script no longer assumes a system C compiler — it works identically on macOS / Linux / Windows.
- PIE coverage is preserved as a Linux-only branch (Mac never had it via the original \`PIE_FLAG=\"\"\` no-op; that loophole is now an explicit SKIP).
- Rust static-link sub-test stays SKIP on Windows because \`examples/rust/build.rs\` still emits \`cargo:rustc-link-lib=c|m\` and \`-Wl,-rpath\` — POSIX-only. Tracked as Plan C-c (separate PR).
- Drop the two \`if: runner.os != 'Windows'\` guards on \`Build static library\` and \`Run static link tests\`.

Plan C-d. Plan C-a (#68) was the prior step. Five guards remaining: C-b, C-c, C-e, C-f, C-g.

## Test plan

- [ ] CI \`test (windows-latest)\`: new \`Build static library\` and \`Run static link tests\` steps green.
- [ ] CI \`test (ubuntu-latest)\`: PIE branch exercised; Rust static-link sub-test runs (cargo present in matrix).
- [ ] CI \`test (macos-latest)\`: zig cc + Rust paths green; PIE skipped.
- [ ] Local Mac verified: \`bash test/c_api/run_static_link_test.sh --build\` → 2 PASS / 1 SKIP (PIE).
- [ ] No new flakiness in subsequent runs (re-run if a single transient ETIMEDOUT).