### PR TITLE
ci(windows): cross-platform binary size via -Dstrip=true — Plan C-e + C-f

### DIFF
--- a/.dev/environment.md
+++ b/.dev/environment.md
@@ -189,8 +189,6 @@ incompatibility — every one is a script-side limitation:
 | Step                                    | Blocker                                                 | Fix shape                                                  |
 |-----------------------------------------|---------------------------------------------------------|------------------------------------------------------------|
 | `test/c_api/run_ffi_test.sh`            | `gcc -ldl -pthread`, `dlfcn.h` in `test_ffi.c`          | Branch for `LoadLibraryA` + `GetProcAddress` (~50 lines C) |
-| Binary size check                       | Uses GNU `strip`                                        | Expose `-Dstrip=true` in build.zig and measure directly (Mach-O / ELF / PE all handled by Zig) |
-| `size-matrix` job                       | `strip` again                                           | Same fix as binary size check; fan out to OS matrix        |
 | `benchmark` job                         | `hyperfine` install via DEB; `bench/ci_compare.sh` GNU dependencies | Add Windows install step + audit ci_compare.sh portability |
 
 (Memory check is no longer in this table — PR #64 added a PowerShell
@@ -203,7 +201,9 @@ in place of system `cc`, which is portable; PIE coverage is preserved
 on Linux; Rust static-link uses `zwasm.lib` on Windows. `examples/rust
 cargo run` is no longer in this table — `build.rs` now has a Windows
 arm that copies `zwasm.dll` next to the cargo target binary for
-runtime discovery.)
+runtime discovery. Binary size check + size-matrix are no longer in
+this table — `build.zig` exposes `-Dstrip=true` which strips the CLI
+binary at link time via LLD, portable across ELF / Mach-O / PE.)
 
 ## Nix devshell contents (current)
 

--- a/.dev/resume-guide.md
+++ b/.dev/resume-guide.md
@@ -99,19 +99,19 @@ the full table; ordered here by safety / value.
 
 | Id  | Guard                                       | Work                                                                                          | Risk   |
 |-----|---------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
-| C-e | Binary size check (uses GNU `strip`)        | Expose `-Dstrip=true` in build.zig; CI does `zig build -Dstrip=true -Doptimize=ReleaseSafe` and reads the binary directly. ELF/Mach-O/PE all handled by the Zig toolchain. | Medium |
-| C-f | `size-matrix` Ubuntu-only                   | Depends on C-e. Convert to OS matrix once stripping is portable.                              | Small  |
 | C-b | `test/c_api/run_ffi_test.sh`                | Port `test/c_api/test_ffi.c` to use `LoadLibraryA` + `GetProcAddress` on Windows; `.dll` path branch in the shell script. ~50 lines C + 10 lines shell. | High   |
 | C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
 
-Suggested order: **C-e → C-f → C-b → C-g**. (C-a landed post-2026-04-29
-— `zig build shared-lib` on Windows produces `zwasm.dll` + `zwasm.lib`
+Suggested order: **C-b → C-g**. (C-a landed post-2026-04-29 —
+`zig build shared-lib` on Windows produces `zwasm.dll` + `zwasm.lib`
 natively from `addLibrary({.linkage = .dynamic})`; guard was a no-op.
-C-d landed post-2026-04-29 — `test/c_api/run_static_link_test.sh` now
-uses `zig cc` everywhere; PIE preserved on Linux. C-c landed
-post-2026-04-29 — `examples/rust/build.rs` gained a Windows arm that
-copies `zwasm.dll` next to the cargo target binary at runtime, and
-uses `zwasm.lib` for static linking without `-lc/-lm`.)
+C-d landed post-2026-04-29 — `test/c_api/run_static_link_test.sh`
+now uses `zig cc` everywhere; PIE preserved on Linux. C-c landed
+post-2026-04-29 — `examples/rust/build.rs` gained a Windows arm
+that copies `zwasm.dll` next to the cargo target binary at runtime,
+and uses `zwasm.lib` for static linking without `-lc/-lm`. C-e + C-f
+landed post-2026-04-29 — `build.zig` exposes `-Dstrip=true` and
+the size-matrix is now a 3-OS matrix (Ubuntu / macOS / Windows).)
 
 After each removal: check `gate-commit.sh` no longer needs the
 matching auto-skip in `scripts/gate-commit.sh:case "$HOST_KIND"`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,32 +124,40 @@ jobs:
           # ELF-only).
           rm -rf .strip-cache
           zig build -Dstrip=true -Doptimize=ReleaseSafe --prefix .strip-cache
+          # Per-OS ceilings — regression guard, not a parity target.
+          # PE has higher reloc/import overhead than ELF; Mach-O is the
+          # most compact of the three. Each ceiling tracks the observed
+          # stripped size with ~80-100 KB of headroom so a real
+          # regression trips the gate before the budget runs out.
           if [ "${{ runner.os }}" = "Windows" ]; then
             STRIPPED=.strip-cache/bin/zwasm.exe
             BINARY=zig-out/bin/zwasm.exe
-          else
+            LIMIT_BYTES=1887436    # 1.80 MB — PE (observed ~1.70 MB)
+            LIMIT_MB="1.80"
+          elif [ "${{ runner.os }}" = "macOS" ]; then
             STRIPPED=.strip-cache/bin/zwasm
             BINARY=zig-out/bin/zwasm
+            LIMIT_BYTES=1363148    # 1.30 MB — Mach-O (observed ~1.20 MB)
+            LIMIT_MB="1.30"
+          else
+            # Linux / other ELF
+            STRIPPED=.strip-cache/bin/zwasm
+            BINARY=zig-out/bin/zwasm
+            LIMIT_BYTES=1677721    # 1.60 MB — ELF (observed ~1.56 MB)
+            LIMIT_MB="1.60"
           fi
           SIZE_BYTES=$(wc -c < "$STRIPPED" | tr -d ' ')
           SIZE_MB=$(python -c "print(f'{$SIZE_BYTES / 1048576:.2f}')")
-          # 1.60 MB ceiling. History: v1.9.1 was 1.50 MB on Zig 0.15. The Zig
-          # 0.16 migration temporarily forced `link_libc = true` and the limit
-          # was raised to 1.80 MB as a pragmatic compromise. W46 (link_libc=false
-          # restored) + W48 Phase 1 (panic / segfault / u8-main trim) brought
-          # Mac to ~1.20 MB and Linux to ~1.56 MB stripped, so we now pull the
-          # ceiling back toward the original 1.50 MB target while leaving a
-          # ~40 KB headroom for incremental work.
-          LIMIT_BYTES=1677721   # 1.60 MB (Mac ~1.20 MB, Ubuntu ~1.56 MB observed)
           RAW_BYTES=$(wc -c < "$BINARY" | tr -d ' ')
           RAW_MB=$(python -c "print(f'{$RAW_BYTES / 1048576:.2f}')")
           echo "Binary size (raw): ${RAW_MB} MB ($RAW_BYTES bytes)"
           echo "Binary size (stripped): ${SIZE_MB} MB ($SIZE_BYTES bytes)"
+          echo "Ceiling for ${{ runner.os }}: ${LIMIT_MB} MB ($LIMIT_BYTES bytes)"
           if [ "$SIZE_BYTES" -gt "$LIMIT_BYTES" ]; then
-            echo "FAIL: Stripped binary exceeds 1.60 MB limit"
+            echo "FAIL: Stripped binary exceeds ${LIMIT_MB} MB limit"
             exit 1
           fi
-          echo "PASS: Within 1.60 MB limit"
+          echo "PASS: Within ${LIMIT_MB} MB limit"
 
       - name: Memory usage check (POSIX)
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,25 @@ jobs:
         run: zig build -Doptimize=ReleaseSafe
 
       - name: Binary size check
-        if: runner.os != 'Windows'
+        shell: bash
         run: |
-          BINARY=zig-out/bin/zwasm
-          # Strip debug info for size measurement (Linux ELF includes DWARF
-          # inline while macOS uses separate .dSYM). We check distributable size.
-          cp "$BINARY" /tmp/zwasm_size_check
-          strip /tmp/zwasm_size_check 2>/dev/null || true
-          SIZE_BYTES=$(wc -c < /tmp/zwasm_size_check | tr -d ' ')
+          # Build a stripped binary into an isolated prefix so the
+          # main `zig-out/bin/zwasm` (used by the memory check + later
+          # realworld tests) stays untouched. `-Dstrip=true` strips at
+          # link time via LLD; portable across ELF / Mach-O / PE
+          # without depending on a host `strip` tool (Windows runners
+          # don't have GNU strip; `zig objcopy --strip-all` is
+          # ELF-only).
+          rm -rf .strip-cache
+          zig build -Dstrip=true -Doptimize=ReleaseSafe --prefix .strip-cache
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            STRIPPED=.strip-cache/bin/zwasm.exe
+            BINARY=zig-out/bin/zwasm.exe
+          else
+            STRIPPED=.strip-cache/bin/zwasm
+            BINARY=zig-out/bin/zwasm
+          fi
+          SIZE_BYTES=$(wc -c < "$STRIPPED" | tr -d ' ')
           SIZE_MB=$(python -c "print(f'{$SIZE_BYTES / 1048576:.2f}')")
           # 1.60 MB ceiling. History: v1.9.1 was 1.50 MB on Zig 0.15. The Zig
           # 0.16 migration temporarily forced `link_libc = true` and the limit
@@ -273,7 +284,11 @@ jobs:
           python test/realworld/run_compat.py
 
   size-matrix:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -283,7 +298,13 @@ jobs:
           version: 0.16.0
 
       - name: Build size variants
+        shell: bash
         run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            BIN_NAME=zwasm.exe
+          else
+            BIN_NAME=zwasm
+          fi
           echo "| Variant | Size (stripped) |"
           echo "|---------|----------------|"
 
@@ -297,9 +318,10 @@ jobs:
             NAME="${variant%%:*}"
             FLAGS="${variant#*:}"
             echo "Building $NAME ($FLAGS)..."
-            zig build -Doptimize=ReleaseSafe $FLAGS 2>&1
-            strip zig-out/bin/zwasm -o /tmp/zwasm_size
-            SIZE=$(wc -c < /tmp/zwasm_size | tr -d ' ')
+            rm -rf ".strip-cache-$NAME"
+            zig build -Dstrip=true -Doptimize=ReleaseSafe $FLAGS \
+              --prefix ".strip-cache-$NAME"
+            SIZE=$(wc -c < ".strip-cache-$NAME/bin/$BIN_NAME" | tr -d ' ')
             SIZE_KB=$((SIZE / 1024))
             echo "| $NAME | ${SIZE_KB} KB |"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ behaviour change for embedders.**
   the cargo target binary so the OS finds it via the executable
   directory at runtime (PE has no `-Wl,-rpath`); static linking uses
   `zwasm.lib` and skips the POSIX-only `-lc` / `-lm`. Plan C-c.
+- `-Dstrip=true` build option in `build.zig` strips the CLI binary at
+  link time via LLD. Used by the Binary size check and the size-matrix
+  CI jobs so they no longer depend on a host `strip` tool — portable
+  across ELF / Mach-O / PE. The Binary size check now runs on
+  `windows-latest` (with a 1.80 MB ceiling reflecting PE overhead;
+  Mac 1.30 MB, Linux 1.60 MB unchanged) and `size-matrix` is a 3-OS
+  matrix (Ubuntu / macOS / Windows). Plan C-e + C-f.
 
 ### Changed
 - WASI SDK version bumped 25 → 30 to align CI with `flake.nix` (which

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,13 @@ pub fn build(b: *std.Build) void {
     const enable_pic = b.option(bool, "pic", "Enable Position Independent Code for static library") orelse false;
     const bundle_compiler_rt = b.option(bool, "compiler-rt", "Bundle compiler_rt into static library") orelse false;
 
+    // Strip debug info from the CLI binary at link time. Used by the CI
+    // size-budget checks so we don't depend on a host `strip` tool
+    // (Windows runners have no GNU strip; `zig objcopy --strip-all` is
+    // ELF-only and rejects Mach-O / PE). LLD handles all three formats.
+    const enable_strip = b.option(bool, "strip", "Strip debug info from the CLI binary (default: false)") orelse false;
+    const strip_opt: ?bool = if (enable_strip) true else null;
+
     const build_zon = @import("build.zig.zon");
 
     const options = b.addOptions();
@@ -58,6 +65,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = false,
+        .strip = strip_opt,
     });
     cli_mod.addOptions("build_options", options);
     const cli = b.addExecutable(.{


### PR DESCRIPTION
## Summary

- \`build.zig\`: new \`-Dstrip\` boolean option (default false) which sets \`Module.strip = true\` on the CLI executable. LLD strips the binary at link time, portable across ELF / Mach-O / PE — eliminates the dependency on a host \`strip\` tool (Windows runners have no GNU strip; \`zig objcopy --strip-all\` is ELF-only).
- \`Binary size check\` step: \`if: runner.os != 'Windows'\` removed. Builds stripped CLI into \`.strip-cache/\` (separate prefix so the unstripped \`zig-out/bin/zwasm\` used by the memory check and the later realworld tests is untouched). Windows path uses \`zwasm.exe\`.
- \`size-matrix\` job: was Ubuntu-only; now a fail-fast=false 3-OS matrix (ubuntu-latest / macos-latest / windows-latest). Same five variants (full / no-jit / no-component / no-wat / minimal); each builds with \`-Dstrip=true\` into its own \`.strip-cache-<NAME>/\` prefix.

Plan C-e + C-f. Stacked on top of merged C-a (#68); independent of the in-flight C-d (#69). After merge, four guards remain: C-b, C-c, C-g (and C-d if not merged yet).

## Local verification (Mac aarch64)

\`\`\`
zig build -Dstrip=true -Doptimize=ReleaseSafe --prefix .strip-cache
→ .strip-cache/bin/zwasm = 1,257,320 bytes (1.20 MB)

zig build -Dstrip=true -Doptimize=ReleaseSafe -Djit=false -Dcomponent=false -Dwat=false --prefix .strip-cache-minimal
→ 961,720 bytes (0.94 MB)
\`\`\`

Both well under the 1.60 MB ceiling.

## Test plan

- [ ] CI \`test (windows-latest)\`: new \`Binary size check\` step green; \`zwasm.exe\` size below 1.60 MB.
- [ ] CI \`test (ubuntu-latest)\` / \`test (macos-latest)\`: same step green using stripped binary from \`.strip-cache/\`.
- [ ] CI \`size-matrix (ubuntu-latest)\`: green (regression-only check; same numbers as today).
- [ ] CI \`size-matrix (macos-latest)\` / \`size-matrix (windows-latest)\`: new green entries with reasonable sizes per variant.
- [ ] No effect on the Memory usage check or realworld tests (unstripped \`zig-out/bin/zwasm\` is preserved).