### PR TITLE
ci(windows): drop Rust example dynamic guard — Plan C-c

### DIFF
--- a/.dev/environment.md
+++ b/.dev/environment.md
@@ -189,7 +189,6 @@ incompatibility — every one is a script-side limitation:
 | Step                                    | Blocker                                                 | Fix shape                                                  |
 |-----------------------------------------|---------------------------------------------------------|------------------------------------------------------------|
 | `test/c_api/run_ffi_test.sh`            | `gcc -ldl -pthread`, `dlfcn.h` in `test_ffi.c`          | Branch for `LoadLibraryA` + `GetProcAddress` (~50 lines C) |
-| `examples/rust` `cargo run`             | `build.rs` solves dynamic-lib path Linux/Mac only       | Add Windows branch in `build.rs`                           |
 | Binary size check                       | Uses GNU `strip`                                        | Expose `-Dstrip=true` in build.zig and measure directly (Mach-O / ELF / PE all handled by Zig) |
 | `size-matrix` job                       | `strip` again                                           | Same fix as binary size check; fan out to OS matrix        |
 | `benchmark` job                         | `hyperfine` install via DEB; `bench/ci_compare.sh` GNU dependencies | Add Windows install step + audit ci_compare.sh portability |
@@ -201,8 +200,10 @@ Zig produces `zwasm.dll` + `zwasm.lib` natively from
 `addLibrary({.linkage = .dynamic})`. `zig build static-lib` + static
 link tests are no longer in this table — the script now uses `zig cc`
 in place of system `cc`, which is portable; PIE coverage is preserved
-on Linux; Rust static-link skips on Windows pending the C-c
-`examples/rust/build.rs` POSIX-isms fix.)
+on Linux; Rust static-link uses `zwasm.lib` on Windows. `examples/rust
+cargo run` is no longer in this table — `build.rs` now has a Windows
+arm that copies `zwasm.dll` next to the cargo target binary for
+runtime discovery.)
 
 ## Nix devshell contents (current)
 

--- a/.dev/resume-guide.md
+++ b/.dev/resume-guide.md
@@ -99,19 +99,19 @@ the full table; ordered here by safety / value.
 
 | Id  | Guard                                       | Work                                                                                          | Risk   |
 |-----|---------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
-| C-c | `examples/rust` `cargo run`                 | Add Windows arm to `examples/rust/build.rs` for the dynamic library lookup; remove guard.     | Medium |
 | C-e | Binary size check (uses GNU `strip`)        | Expose `-Dstrip=true` in build.zig; CI does `zig build -Dstrip=true -Doptimize=ReleaseSafe` and reads the binary directly. ELF/Mach-O/PE all handled by the Zig toolchain. | Medium |
 | C-f | `size-matrix` Ubuntu-only                   | Depends on C-e. Convert to OS matrix once stripping is portable.                              | Small  |
 | C-b | `test/c_api/run_ffi_test.sh`                | Port `test/c_api/test_ffi.c` to use `LoadLibraryA` + `GetProcAddress` on Windows; `.dll` path branch in the shell script. ~50 lines C + 10 lines shell. | High   |
 | C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
 
-Suggested order: **C-e → C-f → C-c → C-b → C-g**. (C-a landed
-post-2026-04-29 — `zig build shared-lib` on Windows produces
-`zwasm.dll` + `zwasm.lib` natively from
-`addLibrary({.linkage = .dynamic})`; guard was a no-op. C-d landed
-post-2026-04-29 — `test/c_api/run_static_link_test.sh` now uses
-`zig cc` everywhere; PIE preserved on Linux; Rust skipped on Windows
-until C-c lands.)
+Suggested order: **C-e → C-f → C-b → C-g**. (C-a landed post-2026-04-29
+— `zig build shared-lib` on Windows produces `zwasm.dll` + `zwasm.lib`
+natively from `addLibrary({.linkage = .dynamic})`; guard was a no-op.
+C-d landed post-2026-04-29 — `test/c_api/run_static_link_test.sh` now
+uses `zig cc` everywhere; PIE preserved on Linux. C-c landed
+post-2026-04-29 — `examples/rust/build.rs` gained a Windows arm that
+copies `zwasm.dll` next to the cargo target binary at runtime, and
+uses `zwasm.lib` for static linking without `-lc/-lm`.)
 
 After each removal: check `gate-commit.sh` no longer needs the
 matching auto-skip in `scripts/gate-commit.sh:case "$HOST_KIND"`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
           rustc --version
 
       - name: Run Rust FFI example (dynamic)
-        if: runner.os != 'Windows'
         run: cd examples/rust && cargo run
 
       - name: Build static library (PIC + compiler_rt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,12 @@ behaviour change for embedders.**
 - `zig build static-lib -Dpic=true -Dcompiler-rt=true` and
   `test/c_api/run_static_link_test.sh` now run on Windows in CI.
   The C link tests use `zig cc` (portable across Mac/Linux/Windows)
-  instead of system `cc`. PIE coverage is preserved on Linux. Rust
-  static-link still skips on Windows because
-  `examples/rust/build.rs` is POSIX-only (Plan C-c). Plan C-d.
+  instead of system `cc`. PIE coverage is preserved on Linux. Plan C-d.
+- `examples/rust` `cargo run` now runs on Windows in CI. `build.rs`
+  gained a Windows arm: dynamic linking copies `zwasm.dll` next to
+  the cargo target binary so the OS finds it via the executable
+  directory at runtime (PE has no `-Wl,-rpath`); static linking uses
+  `zwasm.lib` and skips the POSIX-only `-lc` / `-lm`. Plan C-c.
 
 ### Changed
 - WASI SDK version bumped 25 → 30 to align CI with `flake.nix` (which

--- a/examples/rust/build.rs
+++ b/examples/rust/build.rs
@@ -10,21 +10,59 @@ fn main() {
         .canonicalize()
         .expect("zig-out/lib not found — run `zig build lib` first");
 
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let is_windows = target_os == "windows";
+
     if env::var("ZWASM_STATIC").is_ok() {
-        // Static linking: requires libzwasm.a built with -Dpic=true -Dcompiler-rt=true
-        // Copy only the .a to a temp dir to prevent the linker from picking the .dylib/.so
+        // Static linking: requires libzwasm.a (POSIX) / zwasm.lib (Windows MSVC)
+        // built with `-Dpic=true -Dcompiler-rt=true`. Copy only the archive
+        // to a temp dir so the linker can't pick the .dylib/.so/.dll.
         let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
         let static_dir = out_dir.join("zwasm_static");
         std::fs::create_dir_all(&static_dir).unwrap();
-        std::fs::copy(lib_dir.join("libzwasm.a"), static_dir.join("libzwasm.a")).unwrap();
+        let archive_name = if is_windows { "zwasm.lib" } else { "libzwasm.a" };
+        std::fs::copy(lib_dir.join(archive_name), static_dir.join(archive_name)).unwrap();
         println!("cargo:rustc-link-search=native={}", static_dir.display());
         println!("cargo:rustc-link-lib=static=zwasm");
-        println!("cargo:rustc-link-lib=c");
-        println!("cargo:rustc-link-lib=m");
+        if !is_windows {
+            // POSIX libc / libm. On Windows MSVC the CRT is auto-linked
+            // by rustc; explicit `-lc` / `-lm` would fail because they
+            // are not separate libraries on that ABI.
+            println!("cargo:rustc-link-lib=c");
+            println!("cargo:rustc-link-lib=m");
+        }
     } else {
-        // Dynamic linking (default)
+        // Dynamic linking (default).
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
         println!("cargo:rustc-link-lib=zwasm");
-        println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lib_dir.display());
+        if is_windows {
+            // Windows DLL search order looks at the executable directory
+            // first. Zig installs `zwasm.dll` to `zig-out/bin/`; copy it
+            // alongside the cargo target binary so `cargo run` finds it
+            // at runtime. There is no analogue of `-Wl,-rpath` on PE.
+            let bin_dir = manifest
+                .join("..")
+                .join("..")
+                .join("zig-out")
+                .join("bin")
+                .canonicalize()
+                .expect("zig-out/bin not found — run `zig build shared-lib` first");
+            let dll_src = bin_dir.join("zwasm.dll");
+            // OUT_DIR is `<target>/<profile>/build/<crate>-<hash>/out`,
+            // so `<target>/<profile>` is three ancestors up.
+            let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+            let target_profile_dir = out_dir
+                .ancestors()
+                .nth(3)
+                .expect("OUT_DIR ancestor lookup")
+                .to_path_buf();
+            let dll_dst = target_profile_dir.join("zwasm.dll");
+            std::fs::copy(&dll_src, &dll_dst)
+                .expect("copying zwasm.dll next to cargo target binary");
+            println!("cargo:rerun-if-changed={}", dll_src.display());
+        } else {
+            // POSIX: rpath the zig-out/lib directory directly.
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lib_dir.display());
+        }
     }
 }


### PR DESCRIPTION
## Summary

\`examples/rust/build.rs\` gains a Windows arm:

- **Dynamic** linking copies \`zwasm.dll\` from \`zig-out/bin/\` next to the cargo target binary so the OS finds it via the executable directory at runtime. PE has no analogue of \`-Wl,-rpath\`.
- **Static** linking uses \`zwasm.lib\` (the MSVC convention, not \`libzwasm.a\`) and skips the POSIX-only \`-lc\` / \`-lm\` directives because Windows MSVC auto-links the CRT.

The \`if: runner.os != 'Windows'\` guard on the \`Run Rust FFI example (dynamic)\` CI step drops accordingly. Mac / Linux paths unchanged.

Plan C-c. Stacked semantically on C-a (#68, merged). The static-link Rust sub-test in \`test/c_api/run_static_link_test.sh\` is still SKIP'd on Windows in #69 — un-skipping that is a one-line follow-up after both PRs land.

## Test plan

- [ ] CI \`test (windows-latest)\` Rust dynamic step passes (\`f() = 42\`).
- [ ] CI \`test (ubuntu-latest)\` / \`test (macos-latest)\` Rust dynamic step still passes (no path regression).
- [ ] Local Mac dynamic: \`zig build shared-lib && cd examples/rust && cargo run\` → \`f() = 42\` ✅
- [ ] Local Mac static: \`zig build static-lib -Dpic=true -Dcompiler-rt=true && cd examples/rust && cargo clean && ZWASM_STATIC=1 cargo run\` → \`f() = 42\` ✅
- [ ] No effect on Mac/Linux at runtime — DLL-copy branch is gated on \`target_os == "windows"\`.