### PR TITLE
ci(windows): port FFI tests to Win32 — Plan C-b

### DIFF
--- a/.dev/environment.md
+++ b/.dev/environment.md
@@ -188,12 +188,6 @@ incompatibility — every one is a script-side limitation:
 
 | Step                                    | Blocker                                                 | Fix shape                                                  |
 |-----------------------------------------|---------------------------------------------------------|------------------------------------------------------------|
-<<<<<<< HEAD
-| `test/c_api/run_ffi_test.sh`            | `gcc -ldl -pthread`, `dlfcn.h` in `test_ffi.c`          | Branch for `LoadLibraryA` + `GetProcAddress` (~50 lines C) |
-=======
-| Binary size check                       | Uses GNU `strip`                                        | Expose `-Dstrip=true` in build.zig and measure directly (Mach-O / ELF / PE all handled by Zig) |
-| `size-matrix` job                       | `strip` again                                           | Same fix as binary size check; fan out to OS matrix        |
->>>>>>> d4fb8ad (ci(windows): port FFI tests to Win32 — Plan C-b)
 | `benchmark` job                         | `hyperfine` install via DEB; `bench/ci_compare.sh` GNU dependencies | Add Windows install step + audit ci_compare.sh portability |
 
 (Memory check is no longer in this table — PR #64 added a PowerShell
@@ -206,15 +200,12 @@ in place of system `cc`, which is portable; PIE coverage is preserved
 on Linux; Rust static-link uses `zwasm.lib` on Windows. `examples/rust
 cargo run` is no longer in this table — `build.rs` now has a Windows
 arm that copies `zwasm.dll` next to the cargo target binary for
-<<<<<<< HEAD
 runtime discovery. Binary size check + size-matrix are no longer in
 this table — `build.zig` exposes `-Dstrip=true` which strips the CLI
-binary at link time via LLD, portable across ELF / Mach-O / PE.)
-=======
-runtime discovery. `Run FFI tests` is no longer in this table —
-`test_ffi.c` gained `#ifdef _WIN32` branches for LoadLibraryA /
-CreateThread / `_pipe`, and the runner switched to `zig cc`.)
->>>>>>> d4fb8ad (ci(windows): port FFI tests to Win32 — Plan C-b)
+binary at link time via LLD, portable across ELF / Mach-O / PE.
+`Run FFI tests` is no longer in this table — `test_ffi.c` gained
+`#ifdef _WIN32` branches for LoadLibraryA / CreateThread / `_pipe`,
+and the runner switched to `zig cc`.)
 
 ## Nix devshell contents (current)
 

--- a/.dev/environment.md
+++ b/.dev/environment.md
@@ -188,7 +188,12 @@ incompatibility — every one is a script-side limitation:
 
 | Step                                    | Blocker                                                 | Fix shape                                                  |
 |-----------------------------------------|---------------------------------------------------------|------------------------------------------------------------|
+<<<<<<< HEAD
 | `test/c_api/run_ffi_test.sh`            | `gcc -ldl -pthread`, `dlfcn.h` in `test_ffi.c`          | Branch for `LoadLibraryA` + `GetProcAddress` (~50 lines C) |
+=======
+| Binary size check                       | Uses GNU `strip`                                        | Expose `-Dstrip=true` in build.zig and measure directly (Mach-O / ELF / PE all handled by Zig) |
+| `size-matrix` job                       | `strip` again                                           | Same fix as binary size check; fan out to OS matrix        |
+>>>>>>> d4fb8ad (ci(windows): port FFI tests to Win32 — Plan C-b)
 | `benchmark` job                         | `hyperfine` install via DEB; `bench/ci_compare.sh` GNU dependencies | Add Windows install step + audit ci_compare.sh portability |
 
 (Memory check is no longer in this table — PR #64 added a PowerShell
@@ -201,9 +206,15 @@ in place of system `cc`, which is portable; PIE coverage is preserved
 on Linux; Rust static-link uses `zwasm.lib` on Windows. `examples/rust
 cargo run` is no longer in this table — `build.rs` now has a Windows
 arm that copies `zwasm.dll` next to the cargo target binary for
+<<<<<<< HEAD
 runtime discovery. Binary size check + size-matrix are no longer in
 this table — `build.zig` exposes `-Dstrip=true` which strips the CLI
 binary at link time via LLD, portable across ELF / Mach-O / PE.)
+=======
+runtime discovery. `Run FFI tests` is no longer in this table —
+`test_ffi.c` gained `#ifdef _WIN32` branches for LoadLibraryA /
+CreateThread / `_pipe`, and the runner switched to `zig cc`.)
+>>>>>>> d4fb8ad (ci(windows): port FFI tests to Win32 — Plan C-b)
 
 ## Nix devshell contents (current)
 

--- a/.dev/resume-guide.md
+++ b/.dev/resume-guide.md
@@ -99,19 +99,34 @@ the full table; ordered here by safety / value.
 
 | Id  | Guard                                       | Work                                                                                          | Risk   |
 |-----|---------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
+<<<<<<< HEAD
 | C-b | `test/c_api/run_ffi_test.sh`                | Port `test/c_api/test_ffi.c` to use `LoadLibraryA` + `GetProcAddress` on Windows; `.dll` path branch in the shell script. ~50 lines C + 10 lines shell. | High   |
 | C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
 
 Suggested order: **C-b → C-g**. (C-a landed post-2026-04-29 —
+=======
+| C-e | Binary size check (uses GNU `strip`)        | Expose `-Dstrip=true` in build.zig; CI does `zig build -Dstrip=true -Doptimize=ReleaseSafe` and reads the binary directly. ELF/Mach-O/PE all handled by the Zig toolchain. | Medium |
+| C-f | `size-matrix` Ubuntu-only                   | Depends on C-e. Convert to OS matrix once stripping is portable.                              | Small  |
+| C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
+
+Suggested order: **C-e → C-f → C-g**. (C-a landed post-2026-04-29 —
+>>>>>>> d4fb8ad (ci(windows): port FFI tests to Win32 — Plan C-b)
 `zig build shared-lib` on Windows produces `zwasm.dll` + `zwasm.lib`
 natively from `addLibrary({.linkage = .dynamic})`; guard was a no-op.
 C-d landed post-2026-04-29 — `test/c_api/run_static_link_test.sh`
 now uses `zig cc` everywhere; PIE preserved on Linux. C-c landed
 post-2026-04-29 — `examples/rust/build.rs` gained a Windows arm
 that copies `zwasm.dll` next to the cargo target binary at runtime,
+<<<<<<< HEAD
 and uses `zwasm.lib` for static linking without `-lc/-lm`. C-e + C-f
 landed post-2026-04-29 — `build.zig` exposes `-Dstrip=true` and
 the size-matrix is now a 3-OS matrix (Ubuntu / macOS / Windows).)
+=======
+and uses `zwasm.lib` for static linking without `-lc/-lm`. C-b
+landed post-2026-04-29 — `test_ffi.c` ported via `#ifdef _WIN32`
+blocks to `LoadLibraryA` + `CreateThread` + `_pipe`; runner uses
+`zig cc`.)
+>>>>>>> d4fb8ad (ci(windows): port FFI tests to Win32 — Plan C-b)
 
 After each removal: check `gate-commit.sh` no longer needs the
 matching auto-skip in `scripts/gate-commit.sh:case "$HOST_KIND"`.

--- a/.dev/resume-guide.md
+++ b/.dev/resume-guide.md
@@ -99,34 +99,21 @@ the full table; ordered here by safety / value.
 
 | Id  | Guard                                       | Work                                                                                          | Risk   |
 |-----|---------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
-<<<<<<< HEAD
-| C-b | `test/c_api/run_ffi_test.sh`                | Port `test/c_api/test_ffi.c` to use `LoadLibraryA` + `GetProcAddress` on Windows; `.dll` path branch in the shell script. ~50 lines C + 10 lines shell. | High   |
 | C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
 
-Suggested order: **C-b → C-g**. (C-a landed post-2026-04-29 —
-=======
-| C-e | Binary size check (uses GNU `strip`)        | Expose `-Dstrip=true` in build.zig; CI does `zig build -Dstrip=true -Doptimize=ReleaseSafe` and reads the binary directly. ELF/Mach-O/PE all handled by the Zig toolchain. | Medium |
-| C-f | `size-matrix` Ubuntu-only                   | Depends on C-e. Convert to OS matrix once stripping is portable.                              | Small  |
-| C-g | `benchmark` Ubuntu-only                     | hyperfine Windows zip install + `bench/ci_compare.sh` GNU dependency audit (`/usr/bin/time`, `awk`, `comm`). Likely invasive. | High   |
-
-Suggested order: **C-e → C-f → C-g**. (C-a landed post-2026-04-29 —
->>>>>>> d4fb8ad (ci(windows): port FFI tests to Win32 — Plan C-b)
+Suggested order: **C-g**. (C-a landed post-2026-04-29 —
 `zig build shared-lib` on Windows produces `zwasm.dll` + `zwasm.lib`
 natively from `addLibrary({.linkage = .dynamic})`; guard was a no-op.
 C-d landed post-2026-04-29 — `test/c_api/run_static_link_test.sh`
 now uses `zig cc` everywhere; PIE preserved on Linux. C-c landed
 post-2026-04-29 — `examples/rust/build.rs` gained a Windows arm
 that copies `zwasm.dll` next to the cargo target binary at runtime,
-<<<<<<< HEAD
 and uses `zwasm.lib` for static linking without `-lc/-lm`. C-e + C-f
 landed post-2026-04-29 — `build.zig` exposes `-Dstrip=true` and
-the size-matrix is now a 3-OS matrix (Ubuntu / macOS / Windows).)
-=======
-and uses `zwasm.lib` for static linking without `-lc/-lm`. C-b
-landed post-2026-04-29 — `test_ffi.c` ported via `#ifdef _WIN32`
+the size-matrix is now a 3-OS matrix (Ubuntu / macOS / Windows).
+C-b landed post-2026-04-29 — `test_ffi.c` ported via `#ifdef _WIN32`
 blocks to `LoadLibraryA` + `CreateThread` + `_pipe`; runner uses
 `zig cc`.)
->>>>>>> d4fb8ad (ci(windows): port FFI tests to Win32 — Plan C-b)
 
 After each removal: check `gate-commit.sh` no longer needs the
 matching auto-skip in `scripts/gate-commit.sh:case "$HOST_KIND"`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
         run: zig build shared-lib
 
       - name: Run FFI tests (shared library)
-        if: runner.os != 'Windows'
         run: bash test/c_api/run_ffi_test.sh
 
       - name: Setup Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ behaviour change for embedders.**
   `windows-latest` (with a 1.80 MB ceiling reflecting PE overhead;
   Mac 1.30 MB, Linux 1.60 MB unchanged) and `size-matrix` is a 3-OS
   matrix (Ubuntu / macOS / Windows). Plan C-e + C-f.
+- `test/c_api/test_ffi.c` ported to Windows: dynamic loading via
+  `LoadLibraryA` + `GetProcAddress`, threading via `CreateThread` +
+  `WaitForSingleObject`, pipes via `_pipe` (binary mode). Sources are
+  selected by `#ifdef _WIN32` blocks; POSIX path unchanged. The
+  runner switches from system `gcc` to `zig cc` so it does not
+  require a host C compiler. The `if: runner.os != 'Windows'` CI
+  guard on `Run FFI tests` is dropped accordingly. `gate-commit.sh`
+  no longer auto-skips `ffi` on Windows. Plan C-b.
 
 ### Changed
 - WASI SDK version bumped 25 → 30 to align CI with `flake.nix` (which

--- a/scripts/gate-commit.sh
+++ b/scripts/gate-commit.sh
@@ -67,14 +67,9 @@ fi
 
 # Steps CI cannot run on a given host — match the `if: runner.os != X`
 # guards in .github/workflows/ci.yml so local `gate-commit.sh` lines up
-# with what CI will actually verify. Plan C tracks closing each gap.
-case "$HOST_KIND" in
-    windows)
-        # FFI test uses POSIX dlopen and assumes .so/.dylib output;
-        # see test/c_api/run_ffi_test.sh and test_ffi.c.
-        SKIP_LIST="$SKIP_LIST ffi"
-        ;;
-esac
+# with what CI will actually verify. Plan C tracks closing each gap;
+# host-specific skips are added here when (and only when) the
+# corresponding CI guard is still in place.
 
 # --- Step framework ---
 

--- a/test/c_api/run_ffi_test.sh
+++ b/test/c_api/run_ffi_test.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # run_ffi_test.sh — Build libzwasm shared lib and run FFI test suite
 #
+# Uses `zig cc` instead of system `gcc` so the script works identically
+# on macOS / Linux / Windows (Git Bash) without depending on a host C
+# compiler. The Windows runner does not ship gcc, and `zig cc` already
+# carries clang + the bundled libc headers.
+#
 # Usage:
 #   bash test/c_api/run_ffi_test.sh [--build]
 #
@@ -17,29 +22,54 @@ for arg in "$@"; do
     esac
 done
 
-# Detect platform
-if [[ "$(uname)" == "Darwin" ]]; then
-    LIB="zig-out/lib/libzwasm.dylib"
-else
-    LIB="zig-out/lib/libzwasm.so"
-fi
+UNAME_S=$(uname -s 2>/dev/null || echo unknown)
+case "$UNAME_S" in
+    MINGW*|MSYS*|CYGWIN*) HOST_OS=Windows ;;
+    Darwin)               HOST_OS=Darwin  ;;
+    Linux)                HOST_OS=Linux   ;;
+    *)                    HOST_OS=Other   ;;
+esac
 
-# Build shared library if requested or missing
+case "$HOST_OS" in
+    Darwin)
+        LIB="zig-out/lib/libzwasm.dylib"
+        BIN_EXT=""
+        EXTRA_LDFLAGS="-lpthread"
+        TMP_DIR="/tmp"
+        ;;
+    Windows)
+        # Zig installs the DLL to bin/ on Windows, with the import lib
+        # alongside in lib/. The test program loads the DLL at runtime
+        # via LoadLibraryA, so we only need the .dll path.
+        LIB="zig-out/bin/zwasm.dll"
+        BIN_EXT=".exe"
+        # No -lpthread on Windows: threading uses Win32 CreateThread
+        # via the test_ffi.c #ifdef branch.
+        EXTRA_LDFLAGS=""
+        TMP_DIR="${TEMP:-/tmp}"
+        ;;
+    *)
+        LIB="zig-out/lib/libzwasm.so"
+        BIN_EXT=""
+        EXTRA_LDFLAGS="-ldl -lpthread"
+        TMP_DIR="/tmp"
+        ;;
+esac
+
 if $BUILD || [ ! -f "$LIB" ]; then
     echo "Building shared library..."
     zig build shared-lib
 fi
 
-# Compile test binary
-echo "Compiling FFI test..."
-gcc -o /tmp/zwasm_ffi_test test/c_api/test_ffi.c -ldl -pthread -O0 -g
+echo "Compiling FFI test (zig cc)..."
+TMPBIN="${TMP_DIR}/zwasm_ffi_test_${RANDOM}${BIN_EXT}"
+rm -f "$TMPBIN"
+# shellcheck disable=SC2086
+zig cc -O0 -g -o "$TMPBIN" test/c_api/test_ffi.c $EXTRA_LDFLAGS
 
-# Run
 echo ""
-/tmp/zwasm_ffi_test "$LIB"
-EXIT=$?
-
-# Cleanup
-rm -f /tmp/zwasm_ffi_test
+EXIT=0
+"$TMPBIN" "$LIB" || EXIT=$?
+rm -f "$TMPBIN"
 
 exit $EXIT

--- a/test/c_api/test_ffi.c
+++ b/test/c_api/test_ffi.c
@@ -638,9 +638,18 @@ static void test_wasi_config_fd_api(void) {
     /* Invalid fd index (>=3) should be silently ignored */
     api.wasi_config_set_stdio_fd(wc, 5, (intptr_t)stdout_pipe[0], 0);
 
-    /* Add an FD-based preopen (borrow mode) */
+    /* Add an FD-based preopen (borrow mode). The API only stores the
+       fd integer in borrow mode, so the underlying object doesn't
+       need to be a real directory. msvcrt's `_open` rejects directory
+       paths (returns -1 with EACCES), so on Windows we fall back to
+       `_dup(0)` since fd 0 (stdin) is always present. */
+#ifdef _WIN32
+    int dir_fd = _dup(0);
+    ASSERT(dir_fd >= 0, "dup(stdin) for preopen fd");
+#else
     int dir_fd = zw_open(".", ZW_O_RDONLY);
     ASSERT(dir_fd >= 0, "open(\".\") for preopen fd");
+#endif
     api.wasi_config_preopen_fd(wc, (intptr_t)dir_fd, "/sandbox", 8,
                                1 /* dir */, 0 /* borrow */);
 

--- a/test/c_api/test_ffi.c
+++ b/test/c_api/test_ffi.c
@@ -1,10 +1,11 @@
 /*
  * test_ffi.c — Comprehensive shared-library (FFI) tests for zwasm C API
  *
- * Loads libzwasm.so/.dylib via dlopen and exercises every exported symbol
- * through the dynamic linker, exactly as Python ctypes or other FFI
- * consumers would.  This catches PIC / relocation / Debug-mode issues
- * that static-link tests miss (see GitHub issue #11).
+ * Loads libzwasm.so / .dylib / zwasm.dll via the platform's dynamic
+ * linker (dlopen on POSIX, LoadLibraryA on Windows) and exercises every
+ * exported symbol exactly as Python ctypes or other FFI consumers would.
+ * This catches PIC / relocation / Debug-mode issues that static-link
+ * tests miss (see GitHub issue #11).
  *
  * Build & run:
  *   bash test/c_api/run_ffi_test.sh          # auto-detects platform
@@ -15,10 +16,83 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <dlfcn.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <pthread.h>
+
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#  include <io.h>      /* _pipe / _write / _close / _open */
+#  include <fcntl.h>   /* _O_RDONLY / _O_BINARY */
+   typedef HMODULE zw_lib_t;
+   typedef HANDLE  zw_thread_t;
+   static zw_lib_t zw_dlopen(const char *path) { return LoadLibraryA(path); }
+   static void *   zw_dlsym(zw_lib_t h, const char *sym) {
+       return (void *)GetProcAddress(h, sym);
+   }
+   static void     zw_dlclose(zw_lib_t h) { FreeLibrary(h); }
+   static const char *zw_dlerror(void) {
+       static char buf[128];
+       DWORD code = GetLastError();
+       snprintf(buf, sizeof(buf), "GetLastError=%lu", (unsigned long)code);
+       return buf;
+   }
+   static void zw_usleep_us(unsigned us) {
+       /* Sleep takes ms; round up so we don't busy-spin under 1 ms. */
+       Sleep(us < 1000 ? 1 : us / 1000);
+   }
+   typedef DWORD (WINAPI *zw_thread_fn_t)(LPVOID);
+   /* Adapter so we can keep using `void *(*)(void *)` thread bodies. */
+   typedef struct { void *(*fn)(void *); void *arg; } zw_thread_ctx_t;
+   static DWORD WINAPI zw_thread_trampoline(LPVOID raw) {
+       zw_thread_ctx_t *ctx = (zw_thread_ctx_t *)raw;
+       ctx->fn(ctx->arg);
+       return 0;
+   }
+   static int zw_thread_create(zw_thread_t *t, void *(*fn)(void *), void *arg,
+                               zw_thread_ctx_t *ctx_out) {
+       ctx_out->fn = fn;
+       ctx_out->arg = arg;
+       *t = CreateThread(NULL, 0, zw_thread_trampoline, ctx_out, 0, NULL);
+       return *t == NULL ? -1 : 0;
+   }
+   static int zw_thread_join(zw_thread_t t) {
+       WaitForSingleObject(t, INFINITE);
+       CloseHandle(t);
+       return 0;
+   }
+   static int zw_pipe(int fds[2]) {
+       /* _O_BINARY so the test's raw byte writes don't get \r\n
+          translated when the pipe ends are inherited as text fds. */
+       return _pipe(fds, 4096, _O_BINARY);
+   }
+#  define zw_open       _open
+#  define zw_close      _close
+#  define zw_write      _write
+#  define ZW_O_RDONLY   _O_RDONLY
+#else
+#  include <dlfcn.h>
+#  include <unistd.h>
+#  include <fcntl.h>
+#  include <pthread.h>
+   typedef void *    zw_lib_t;
+   typedef pthread_t zw_thread_t;
+   static zw_lib_t zw_dlopen(const char *path) { return dlopen(path, RTLD_NOW); }
+   static void *   zw_dlsym(zw_lib_t h, const char *sym) { return dlsym(h, sym); }
+   static void     zw_dlclose(zw_lib_t h) { dlclose(h); }
+   static const char *zw_dlerror(void) { return dlerror(); }
+   static void zw_usleep_us(unsigned us) { usleep(us); }
+   typedef struct { void *(*fn)(void *); void *arg; } zw_thread_ctx_t;
+   static int zw_thread_create(zw_thread_t *t, void *(*fn)(void *), void *arg,
+                               zw_thread_ctx_t *ctx_out) {
+       (void)ctx_out;  /* POSIX takes the body directly, no trampoline. */
+       return pthread_create(t, NULL, fn, arg);
+   }
+   static int zw_thread_join(zw_thread_t t) { return pthread_join(t, NULL); }
+   static int zw_pipe(int fds[2]) { return pipe(fds); }
+#  define zw_open       open
+#  define zw_close      close
+#  define zw_write      write
+#  define ZW_O_RDONLY   O_RDONLY
+#endif
 
 /* ------------------------------------------------------------------ */
 /* Test harness                                                        */
@@ -158,28 +232,28 @@ typedef struct {
 static void *cancel_thread_main(void *raw) {
     CancelThreadArgs *args = (CancelThreadArgs *)raw;
     /* Keep cancel requests alive across invoke start/reset race. */
-    usleep(100);
+    zw_usleep_us(100);
     for (int i = 0; i < 200; i++) {
         api.module_cancel(args->module);
-        usleep(100);
+        zw_usleep_us(100);
     }
     return NULL;
 }
 
-static void *lib_handle = NULL;
+static zw_lib_t lib_handle = NULL;
 
 #define LOAD_SYM(field, name) do { \
-    api.field = (typeof(api.field))dlsym(lib_handle, name); \
+    api.field = (typeof(api.field))zw_dlsym(lib_handle, name); \
     if (!api.field) { \
-        fprintf(stderr, "dlsym(%s): %s\n", name, dlerror()); \
+        fprintf(stderr, "dlsym(%s): %s\n", name, zw_dlerror()); \
         return false; \
     } \
 } while(0)
 
 static bool load_api(const char *path) {
-    lib_handle = dlopen(path, RTLD_NOW);
+    lib_handle = zw_dlopen(path);
     if (!lib_handle) {
-        fprintf(stderr, "dlopen(%s): %s\n", path, dlerror());
+        fprintf(stderr, "dlopen(%s): %s\n", path, zw_dlerror());
         return false;
     }
     LOAD_SYM(module_new,             "zwasm_module_new");
@@ -553,7 +627,7 @@ static void test_wasi_config_fd_api(void) {
 
     /* Set stdio overrides (use pipe fds) */
     int stdout_pipe[2];
-    ASSERT(pipe(stdout_pipe) == 0, "pipe() for stdout");
+    ASSERT(zw_pipe(stdout_pipe) == 0, "pipe() for stdout");
 
     /* Override stdout (fd 1) with write end of pipe, borrow mode */
     api.wasi_config_set_stdio_fd(wc, 1, (intptr_t)stdout_pipe[1], 0 /* borrow */);
@@ -565,7 +639,7 @@ static void test_wasi_config_fd_api(void) {
     api.wasi_config_set_stdio_fd(wc, 5, (intptr_t)stdout_pipe[0], 0);
 
     /* Add an FD-based preopen (borrow mode) */
-    int dir_fd = open(".", O_RDONLY);
+    int dir_fd = zw_open(".", ZW_O_RDONLY);
     ASSERT(dir_fd >= 0, "open(\".\") for preopen fd");
     api.wasi_config_preopen_fd(wc, (intptr_t)dir_fd, "/sandbox", 8,
                                1 /* dir */, 0 /* borrow */);
@@ -573,10 +647,10 @@ static void test_wasi_config_fd_api(void) {
     api.wasi_config_delete(wc);
 
     /* Borrowed fds should still be valid */
-    ASSERT(write(stdout_pipe[1], "ok", 2) == 2, "borrowed stdout pipe still writable");
-    close(stdout_pipe[0]);
-    close(stdout_pipe[1]);
-    close(dir_fd);
+    ASSERT(zw_write(stdout_pipe[1], "ok", 2) == 2, "borrowed stdout pipe still writable");
+    zw_close(stdout_pipe[0]);
+    zw_close(stdout_pipe[1]);
+    zw_close(dir_fd);
 }
 
 static void test_repeated_create_destroy(void) {
@@ -638,9 +712,10 @@ static void test_cancel_api(void) {
 
     CancelThreadArgs cargs = { .module = loop_mod };
 
-    pthread_t tid;
-    int create_rc = pthread_create(&tid, NULL, cancel_thread_main, &cargs);
-    ASSERT(create_rc == 0, "pthread_create for cancel thread");
+    zw_thread_t tid;
+    zw_thread_ctx_t tctx;
+    int create_rc = zw_thread_create(&tid, cancel_thread_main, &cargs, &tctx);
+    ASSERT(create_rc == 0, "thread create for cancel thread");
     if (create_rc == 0) {
         bool ok = api.module_invoke(loop_mod, "loop", NULL, 0, NULL, 0);
         /* invoke() MUST fail — the loop is infinite, so success is impossible */
@@ -648,7 +723,7 @@ static void test_cancel_api(void) {
         const char *err = api.last_error();
         ASSERT(err != NULL && strstr(err, "Canceled") != NULL,
                "last_error indicates Canceled");
-        ASSERT(pthread_join(tid, NULL) == 0, "pthread_join cancel thread");
+        ASSERT(zw_thread_join(tid) == 0, "thread join cancel thread");
     }
 
     api.module_delete(loop_mod);
@@ -663,9 +738,12 @@ int main(int argc, char **argv) {
     if (argc > 1) {
         lib_path = argv[1];
     } else {
-        /* Auto-detect */
+        /* Auto-detect. Zig installs DLLs to bin/ on Windows but
+           shared objects to lib/ on POSIX. */
 #ifdef __APPLE__
         lib_path = "zig-out/lib/libzwasm.dylib";
+#elif defined(_WIN32)
+        lib_path = "zig-out/bin/zwasm.dll";
 #else
         lib_path = "zig-out/lib/libzwasm.so";
 #endif
@@ -698,6 +776,6 @@ int main(int argc, char **argv) {
 
     printf("\n%d/%d passed, %d failed\n", tests_passed, tests_run, tests_failed);
 
-    dlclose(lib_handle);
+    zw_dlclose(lib_handle);
     return (tests_failed == 0) ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

\`test/c_api/test_ffi.c\` ported to Windows via \`#ifdef _WIN32\` blocks. Each subsystem has a thin shim so the test bodies stay portable:

| Subsystem | POSIX | Windows |
|-----------|-------|---------|
| Dynamic load | \`dlopen\` / \`dlsym\` / \`dlclose\` | \`LoadLibraryA\` / \`GetProcAddress\` / \`FreeLibrary\` |
| Threading | \`pthread_create\` / \`pthread_join\` | \`CreateThread\` + trampoline / \`WaitForSingleObject\` |
| Pipes | \`pipe(fds)\` | \`_pipe(fds, 4096, _O_BINARY)\` |
| Sleep | \`usleep(us)\` | \`Sleep((us)/1000)\` (rounded up to 1 ms) |
| File ops | \`open\` / \`close\` / \`write\` | \`_open\` / \`_close\` / \`_write\` |
| Auto-detect | \`zig-out/lib/lib*.so\|.dylib\` | \`zig-out/bin/zwasm.dll\` |

\`test/c_api/run_ffi_test.sh\` switches from system \`gcc\` to \`zig cc\` so it works on every supported host without depending on a separate C compiler. Link-flag handling branches by \`uname -s\` (Mac drops \`-ldl\`; Linux keeps both \`-ldl\` + \`-lpthread\`; Windows drops both — Win32 + msvcrt are auto-linked).

The \`if: runner.os != 'Windows'\` guard on \`Run FFI tests\` drops accordingly. \`scripts/gate-commit.sh\` no longer auto-skips \`ffi\` on Windows; the case arm collapses with only a doc comment left behind.

Plan C-b. After merge: only C-g remains in Plan C.

## Test plan

- [ ] CI \`test (windows-latest)\` Run FFI tests step: 80/80 passed, 0 failed.
- [ ] CI \`test (ubuntu-latest)\` / \`test (macos-latest)\` Run FFI tests step still 80/80.
- [x] Local Mac (aarch64): \`bash test/c_api/run_ffi_test.sh\` → 80/80 passed.
- [ ] No regression in cancellable-loop test on Windows (CreateThread vs pthread).