### PR TITLE
docs: align Merge Gate / runner forms / per-OS size ceilings

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -25,11 +25,12 @@ Before starting, verify:
 1. Ensure on `main` branch: `git checkout main && git status`
 2. `zig build test` — all pass, 0 fail, 0 leak
 3. `python3 test/spec/run_spec.py --build --summary` — 62,263+ pass, fail=0, skip=0
-4. `bash test/e2e/run_e2e.sh --convert --summary` — 792+ pass, fail=0, leak=0
-5. `bash test/realworld/run_compat.sh` — PASS=30, FAIL=0, CRASH=0 (requires `build_all.sh` first if wasm files missing)
-6. `bash bench/run_bench.sh` — full benchmark suite, no regression
-7. Size guard:
-   - Binary (ReleaseSafe, stripped): ≤ 1.60 MB (Linux ELF ~1.56 MB; Mac ~1.20 MB)
+4. `python3 test/e2e/run_e2e.py --convert --summary` — 796+ pass, fail=0, leak=0
+5. `python3 test/realworld/run_compat.py` — PASS=50, FAIL=0, CRASH=0 (requires `build_all.py` first if wasm files missing)
+6. `bash test/c_api/run_ffi_test.sh --build` — 0 failed
+7. `bash bench/run_bench.sh` — full benchmark suite, no regression
+8. Size guard (stripped via `-Dstrip=true`):
+   - Mac ≤ 1.30 MB (~1.20 MB), Linux ≤ 1.60 MB (~1.56 MB), Windows ≤ 1.80 MB (~1.70 MB)
    - Memory (sieve benchmark): ≤ 4.5 MB RSS
 
 ## Phase 2: zwasm Verification (Ubuntu x86_64 via OrbStack)
@@ -46,14 +47,15 @@ See `.dev/references/ubuntu-testing-guide.md` for commands. Setup: `.dev/referen
    ```
 2. Unit tests: `orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && zig build test"` — all pass, 0 fail, 0 leak
 3. Spec tests: `orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && python3 test/spec/run_spec.py --build --summary"` — fail=0, skip=0
-4. E2E tests: `orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && bash test/e2e/run_e2e.sh --convert --summary"` — fail=0, leak=0
+4. E2E tests: `orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && python3 test/e2e/run_e2e.py --convert --summary"` — fail=0, leak=0
 5. Real-world compat:
    ```bash
-   orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && export WASI_SDK_PATH=/opt/wasi-sdk && bash test/realworld/build_all.sh"
-   orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && bash test/realworld/run_compat.sh --verbose"
+   orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && export WASI_SDK_PATH=/opt/wasi-sdk && python3 test/realworld/build_all.py"
+   orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && python3 test/realworld/run_compat.py --verbose"
    ```
-   PASS=30, FAIL=0, CRASH=0 (needs `build_all.sh` first; requires WASI SDK + Rust wasm32-wasip1)
-6. Benchmarks: `orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && bash bench/run_bench.sh --quick"` — no extreme regression
+   PASS=50, FAIL=0, CRASH=0 (needs `build_all.py` first; requires WASI SDK + Rust wasm32-wasip1 + Go + TinyGo)
+6. FFI tests: `orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && bash test/c_api/run_ffi_test.sh --build"` — 0 failed
+7. Benchmarks: `orb run -m my-ubuntu-amd64 bash -lc "cd ~/zwasm && bash bench/run_bench.sh --quick"` — no extreme regression
 
 If Ubuntu reveals failures not seen on Mac, **fix the root cause** before proceeding.
 
@@ -112,8 +114,8 @@ If Ubuntu reveals failures not seen on Mac, **fix the root cause** before procee
 
 | Phase | Gate | Pass criteria |
 |-------|------|---------------|
-| 1 | Mac local | unit(0 fail/leak) + spec(0 fail/skip) + E2E(0 fail/leak) + compat(30/0/0) + bench + size(≤1.60MB/≤4.5MB) |
-| 2 | Ubuntu OrbStack | unit(0 fail/leak) + spec(0 fail/skip) + E2E(0 fail/leak) + compat(30/0/0) + bench |
+| 1 | Mac local | unit(0 fail/leak) + spec(0 fail/skip) + E2E(0 fail/leak) + compat(50/0/0) + FFI(0 failed) + bench + size (Mac ≤1.30MB / Linux ≤1.60MB / Win ≤1.80MB; mem ≤4.5MB) |
+| 2 | Ubuntu OrbStack | unit(0 fail/leak) + spec(0 fail/skip) + E2E(0 fail/leak) + compat(50/0/0) + FFI(0 failed) + bench |
 | 3 | CW local | CW unit + e2e + portability (local zwasm path) |
 | 4 | zwasm tag | version bump + CHANGELOG + tag + push + CI green |
 | 5 | CW tag | URL+hash update + CW tests pass + push |

--- a/.dev/roadmap.md
+++ b/.dev/roadmap.md
@@ -99,12 +99,19 @@ Details: `roadmap-archive.md`.
 ## Merge Gate Checklist
 
 All items must pass on **Mac AND Ubuntu x86_64** before merging to main.
+Authoritative source: `CLAUDE.md` → "Merge Gate Checklist". One-liner:
+`bash scripts/gate-merge.sh`.
 
 - `zig build test` — all pass, 0 fail, 0 leak
 - `python3 test/spec/run_spec.py --build --summary` — fail=0, skip=0
-- `bash test/e2e/run_e2e.sh --convert --summary` — fail=0
-- `bash test/realworld/run_compat.sh` — PASS=50, FAIL=0, CRASH=0
+- `python3 test/e2e/run_e2e.py --convert --summary` — fail=0, leak=0
+- `python3 test/realworld/run_compat.py` — PASS=50, FAIL=0, CRASH=0
 - `bash test/c_api/run_ffi_test.sh --build` — 0 failed
-- `zig build test -Djit=false -Dcomponent=false -Dwat=false` — 0 fail
-- Binary ≤ 1.60 MB (stripped; Linux ELF ~1.56 MB. Mac ~1.20 MB), memory ≤ 4.5 MB RSS
-  - History: 1.50 MB on Zig 0.15 → 1.80 MB during 0.16 `link_libc=true` transition → 1.60 MB after W46 + W48 Phase 1. Reaching 1.50 MB tracked as W48 Phase 2 (non-blocking).
+- `zig build test -Djit=false -Dcomponent=false -Dwat=false` — minimal build 0 fail
+- `bash scripts/sync-versions.sh` — `versions.lock` ↔ `flake.nix` agree
+- Benchmarks pass (no regression). Post-merge on Mac:
+  `bash scripts/record-merge-bench.sh` appends one row to `bench/history.yaml`
+  (full hyperfine 5+3, ~5 min) — canonical Mac M4 Pro absolute baseline.
+- Binary stripped (`-Dstrip=true`): Mac ≤ 1.30 MB (~1.20 MB), Linux ≤ 1.60 MB (~1.56 MB),
+  Windows ≤ 1.80 MB (~1.70 MB); memory ≤ 4.5 MB RSS
+  - History: 1.50 MB on Zig 0.15 → 1.80 MB during 0.16 `link_libc=true` transition → per-OS ceilings after W46 + W48 Phase 1 + D137. Reaching the original 1.50 MB Linux target tracked as W48 Phase 2 (non-blocking).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,8 @@ This document describes the execution pipeline and file organization.
 | Unit tests | `zig build test` | All src files |
 | Spec tests | `python3 test/spec/run_spec.py --build --summary` | 62,263 tests |
 | E2E tests | `python3 test/e2e/run_e2e.py --convert --summary` | 796 tests |
-| Real-world | `bash test/realworld/run_compat.sh` | 30 programs |
+| Real-world | `python3 test/realworld/run_compat.py` | 50 programs (Mac/Ubuntu); 25 (Windows C+C++ subset) |
+| FFI tests | `bash test/c_api/run_ffi_test.sh --build` | 80 cases (Mac/Ubuntu/Windows) |
 | Fuzz | `bash test/fuzz/fuzz_campaign.sh --duration=60` | Continuous |
 
 ## Allocator Flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,12 @@ PRs are automatically checked for:
 - Unit tests pass (macOS + Ubuntu + Windows)
 - Spec tests pass (62,263 tests)
 - E2E tests pass (796 assertions)
-- Binary size <= 1.60 MB (stripped, Linux ELF ~1.56 MB; Mac Mach-O ~1.20 MB). Originally 1.50 MB on Zig 0.15; raised to 1.80 MB as a pragmatic compromise during the Zig 0.16 / `link_libc = true` transition; pulled back to 1.60 MB after W46 (link_libc=false restored) + W48 Phase 1 (panic / segfault / u8-main trim). Reaching the original 1.50 MB target is tracked as W48 Phase 2 (see `.dev/checklist.md`) — non-blocking.
-- No benchmark regression > 20%
+- Real-world compat (Mac+Ubuntu 50/50; Windows 25/25 C+C++ subset)
+- FFI tests pass (Mac+Ubuntu+Windows; 80 cases)
+- Minimal build (`-Djit=false -Dcomponent=false -Dwat=false`) compiles and tests pass
+- `versions.lock` ↔ `flake.nix` agree (mechanised by `versions-lock-sync` job)
+- Binary size: Mac ≤ 1.30 MB, Linux ≤ 1.60 MB, Windows ≤ 1.80 MB (stripped via `-Dstrip=true`; observed ~1.20 MB Mac, ~1.56 MB Linux, ~1.70 MB Windows). Originally 1.50 MB on Zig 0.15; raised to 1.80 MB as a pragmatic compromise during the Zig 0.16 / `link_libc = true` transition; pulled back to per-OS ceilings after W46 (link_libc=false restored) + W48 Phase 1 (panic / segfault / u8-main trim) + D137 (cross-platform stripping + per-OS ceilings). Reaching the original 1.50 MB Linux target is tracked as W48 Phase 2 (see `.dev/checklist.md`) — non-blocking.
+- No benchmark regression > 20% (Ubuntu-vs-Ubuntu, soft check via `bench/ci_compare.sh`)
 - ReleaseSafe build success
 
 ## Commit guidelines


### PR DESCRIPTION
## Summary

Sweep doc drift surfaced by the post-Plan-C / W52 / D137 landings (PRs #68..#74).
`CLAUDE.md` is the authoritative gate spec; the four audience-facing surfaces below
now agree with it. Pure documentation — no code or build changes.

- **ARCHITECTURE.md** test-suites table: real-world `30` → `50 (Mac/Ubuntu) + 25 (Windows C+C++ subset)`; switched to the \`python3 …py\` form CLAUDE.md and \`gate-commit.sh\` use; added an FFI tests row.
- **CONTRIBUTING.md** \"CI checks\" list: added real-world, FFI, minimal build, and \`versions.lock\`↔\`flake.nix\` rows; binary size moved to the per-OS ceilings (Mac 1.30 / Linux 1.60 / Windows 1.80 MB) introduced by D137.
- **.dev/roadmap.md** Merge Gate Checklist: pointed at CLAUDE.md as the authoritative source; switched e2e/realworld to \`python3 …py\`; added \`sync-versions.sh\`, FFI, post-merge \`record-merge-bench.sh\`, and per-OS size ceilings.
- **.claude/skills/release/SKILL.md** Phase 1 + Phase 2 + Checklist Summary: realworld 30 → 50 PASS; added FFI tests; per-OS size ceilings; runner forms aligned with the \`.py\` runners CI exercises.

## Test plan

- [x] Diff is doc-only (4 \`.md\` files, +34 / -20)
- [x] \`bash scripts/gate-commit.sh --only=tests\` green on Mac (run pre-edit on main)
- [x] \`bash scripts/sync-versions.sh\` exits 0
- [ ] CI green on this branch