### PR TITLE
docs+ci: trailing cleanup after #75..#78

### DIFF
--- a/.dev/memo.md
+++ b/.dev/memo.md
@@ -24,7 +24,7 @@ Session handover document. Read at session start.
 ## Current Task
 
 **Plan C effectively complete + W52 + D137 shipped
-(2026-04-29 PM).** Nine new PRs to main on top of the morning's
+(2026-04-29 PM).** Eleven new PRs to main on top of the morning's
 seven (#60..#67):
 
 - **#68** Plan C-a — `zig build shared-lib` Windows guard removed.
@@ -49,6 +49,10 @@ seven (#60..#67):
   Gate items / runner forms / per-OS size ceilings.
 - **#76** dropped obsolete `.dev/checklist-jit-fuel-timeout.md`
   (all items shipped: PR #6 timeout, fuel-bypass fix, `--timeout`).
+- **#77** CHANGELOG `[Unreleased]` PR-tags + D137 entry, memo.md
+  Current Task refresh.
+- **#78** README front page — W52 status (local 50/50 via installer)
+  + per-OS size ceilings (Mac 1.30 / Linux 1.60 / Windows 1.80 MB; D137).
 
 `Plan C` tracker is empty except **C-g** (benchmark Ubuntu-only),
 which is intentionally Ubuntu-only per `CLAUDE.md`'s bench policy
@@ -58,7 +62,7 @@ is the Ubuntu-vs-Ubuntu regression guard). Treating C-g as
 closed.
 
 Per-merge `bench/history.yaml` rows recorded on Mac M4 Pro for
-each of #68..#76.
+each of #68..#78.
 
 Quick orientation if continuing:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
       - name: E2E tests (Debug)
         env:
           WASMTIME_MISC_DIR: /tmp/wasmtime/tests/misc_testsuite
-        run: bash test/e2e/run_e2e.sh --convert --summary
+        run: python3 test/e2e/run_e2e.py --convert --summary
 
   fuzz:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@ behaviour change for embedders.**
 - Removed obsolete `.dev/checklist-jit-fuel-timeout.md` planning doc
   (all items shipped: PR #6 timeout merge, fuel-bypass fix, `--timeout`
   CLI option). (#76)
+- README front page updated: W52 status (Windows realworld 50/50
+  via local installer; CI parity is W50) + per-OS size ceilings
+  (Mac 1.30 / Linux 1.60 / Windows 1.80 MB; D137). (#78)
 
 ## [1.11.0] - 2026-04-26
 


### PR DESCRIPTION
Three independent micro-fixes bundled (each ≤3 lines):

- **\`.dev/memo.md\` \`## Current Task\`** (N1): \"Nine\" → \"Eleven\"; append #77 / #78 to the merged-PR list; bench-record range #68..#76 → #68..#78.
- **\`CHANGELOG.md\` \`[Unreleased]\` Internal** (N2): add the README front-page update entry tagged (#78).
- **\`.github/workflows/nightly.yml:51\`** (N3): switch the E2E step from \`bash test/e2e/run_e2e.sh\` to \`python3 test/e2e/run_e2e.py\`, matching \`ci.yml:109\` and CLAUDE.md's authoritative form. The \`.sh\` is just \`exec python3 …py\`, so behaviour is identical.

No code, build, or test behaviour changes.

## Test plan
- [x] Diff is doc + CI-runner-form (3 files, +10 / -3)
- [ ] CI green on this branch