### PR TITLE
feat(flake): explicit URL+sha256 pins for wasm-tools + wasmtime (W50 PR-A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ zig-cache/
 
 # Nix / direnv
 .direnv/
+# `nix build` default output symlink
+result
+result-*
 
 # Python
 __pycache__/

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,66 @@
           ''
         else null;
 
+        # wasm-tools 1.246.1 (per-architecture URLs and hashes; mirrors versions.lock).
+        wasmToolsArchInfo = {
+          "aarch64-darwin" = {
+            url = "https://github.com/bytecodealliance/wasm-tools/releases/download/v1.246.1/wasm-tools-1.246.1-aarch64-macos.tar.gz";
+            sha256 = "1i4vs5kmas0vahgd48yjjcg5h7qppq74jbchnfd7d6qzzylff0g8";
+          };
+          "x86_64-darwin" = {
+            url = "https://github.com/bytecodealliance/wasm-tools/releases/download/v1.246.1/wasm-tools-1.246.1-x86_64-macos.tar.gz";
+            sha256 = "1nidj7vx4h7aw2a2x4p645kmilmhb2lry4pk7464z5n8hcqk1774";
+          };
+          "x86_64-linux" = {
+            url = "https://github.com/bytecodealliance/wasm-tools/releases/download/v1.246.1/wasm-tools-1.246.1-x86_64-linux.tar.gz";
+            sha256 = "1k20522vvvz704v3ndj9bdnh3p530g893df97yvq3ms4v1kdcq1x";
+          };
+          "aarch64-linux" = {
+            url = "https://github.com/bytecodealliance/wasm-tools/releases/download/v1.246.1/wasm-tools-1.246.1-aarch64-linux.tar.gz";
+            sha256 = "1rqiy1kv81iskad1906488sq20fx16xjbbg6yhf3wb9jsc9hrlqv";
+          };
+        }.${system} or (throw "Unsupported system for wasm-tools: ${system}");
+
+        wasmToolsSrc = builtins.fetchTarball {
+          url = wasmToolsArchInfo.url;
+          sha256 = wasmToolsArchInfo.sha256;
+        };
+
+        wasmToolsBin = pkgs.runCommand "wasm-tools-1.246.1-wrapper" {} ''
+          mkdir -p $out/bin
+          ln -s ${wasmToolsSrc}/wasm-tools $out/bin/wasm-tools
+        '';
+
+        # wasmtime 42.0.1 (per-architecture URLs and hashes; mirrors versions.lock).
+        wasmTimeArchInfo = {
+          "aarch64-darwin" = {
+            url = "https://github.com/bytecodealliance/wasmtime/releases/download/v42.0.1/wasmtime-v42.0.1-aarch64-macos.tar.xz";
+            sha256 = "13yyvmnyzzzwf3gkb0in9w67s7jybb69bdma71xpnm5ch3v9wrsb";
+          };
+          "x86_64-darwin" = {
+            url = "https://github.com/bytecodealliance/wasmtime/releases/download/v42.0.1/wasmtime-v42.0.1-x86_64-macos.tar.xz";
+            sha256 = "1qvksa3k8vv4q2xmvviqmd50qk9s1ydc5ssz17jyi3f5v4h4zksd";
+          };
+          "x86_64-linux" = {
+            url = "https://github.com/bytecodealliance/wasmtime/releases/download/v42.0.1/wasmtime-v42.0.1-x86_64-linux.tar.xz";
+            sha256 = "0k76lip8iqrcnc4jbv706kqgxd35f4034qysdvwm1nzbpbxpzxw2";
+          };
+          "aarch64-linux" = {
+            url = "https://github.com/bytecodealliance/wasmtime/releases/download/v42.0.1/wasmtime-v42.0.1-aarch64-linux.tar.xz";
+            sha256 = "02r0lmqrzi0xszkn8pnfix0g9wk4il82b1xgwypwhmkj6n7x0l0j";
+          };
+        }.${system} or (throw "Unsupported system for wasmtime: ${system}");
+
+        wasmTimeSrc = builtins.fetchTarball {
+          url = wasmTimeArchInfo.url;
+          sha256 = wasmTimeArchInfo.sha256;
+        };
+
+        wasmTimeBin = pkgs.runCommand "wasmtime-42.0.1-wrapper" {} ''
+          mkdir -p $out/bin
+          ln -s ${wasmTimeSrc}/wasmtime $out/bin/wasmtime
+        '';
+
       in {
         devShells.default = pkgs.mkShell {
           name = "zwasm";
@@ -88,8 +148,8 @@
             # Compiler
             zigBin
 
-            # Wasm runtimes (benchmark comparison targets)
-            wasmtime
+            # Wasm runtimes (benchmark comparison targets) — pinned at versions.lock WASMTIME_VERSION
+            wasmTimeBin
 
             # JS/Wasm runtimes
             bun
@@ -99,12 +159,14 @@
             yq-go
             jq
 
-            # Benchmarking
+            # Benchmarking — hyperfine has no aarch64-darwin prebuilt asset
+            # upstream, so we keep the nixpkgs derivation here. Pinning is
+            # tracked separately; not blocking for spec/realworld.
             hyperfine
 
             # Wasm build tools
             tinygo
-            wasm-tools  # json-from-wast (spec test conversion), component inspection
+            wasmToolsBin  # json-from-wast (spec test conversion), component inspection — pinned at versions.lock WASM_TOOLS_VERSION
 
             # Real-world wasm compilation toolchains
             go          # GOOS=wasip1 GOARCH=wasm (Go 1.21+)

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 # scripts/sync-versions.sh — verify .github/versions.lock matches flake.nix.
 #
-# Two pins live in flake.nix today: Zig and WASI SDK. Other tools come
-# from nixpkgs at the flake.lock revision and do not embed an
-# explicit version literal in flake.nix, so they are checked
-# best-effort or skipped here. When Plan B's flake.nix extension lands
-# (explicit pins for wasm-tools / wasmtime / hyperfine), add them to
-# CHECKS below.
+# Four pins live in flake.nix today: Zig, WASI SDK, wasm-tools, wasmtime
+# (the last two added in W50 PR-A). Hyperfine has no aarch64-darwin
+# prebuilt asset upstream, so it is still resolved via nixpkgs and not
+# checked here.
 #
 # Exit codes:
 #   0  versions.lock is consistent with flake.nix
@@ -54,6 +52,18 @@ flake_wasi="$(grep -oE 'wasi-sdk/releases/download/wasi-sdk-[0-9]+' "$FLAKE" \
     | head -1 \
     | sed -E 's|.*wasi-sdk-||')"
 check WASI_SDK_VERSION "$WASI_SDK_VERSION" "$flake_wasi"
+
+# wasm-tools: URL pattern is .../wasm-tools/releases/download/v<X.Y.Z>/...
+flake_wasm_tools="$(grep -oE 'wasm-tools/releases/download/v[0-9]+\.[0-9]+\.[0-9]+' "$FLAKE" \
+    | head -1 \
+    | sed -E 's|.*/v||')"
+check WASM_TOOLS_VERSION "$WASM_TOOLS_VERSION" "$flake_wasm_tools"
+
+# wasmtime: URL pattern is .../wasmtime/releases/download/v<X.Y.Z>/...
+flake_wasmtime="$(grep -oE 'wasmtime/releases/download/v[0-9]+\.[0-9]+\.[0-9]+' "$FLAKE" \
+    | head -1 \
+    | sed -E 's|.*/v||')"
+check WASMTIME_VERSION "$WASMTIME_VERSION" "$flake_wasmtime"
 
 echo
 if [ "$mismatches" -eq 0 ]; then


### PR DESCRIPTION
First step toward **W50 / Plan B sub-3** (CI Nix-ify). Makes \`.github/versions.lock\` the single source of truth not just textually but structurally — instead of the Nix devshell pulling whatever wasm-tools / wasmtime nixpkgs-unstable happens to ship today, fetch the exact pinned releases that \`versions.lock\` declares.

Pattern mirrors the existing Zig + WASI SDK entries: per-architecture URL + sha256 (base32, derived via \`nix-prefetch-url --type sha256 --unpack\`), then a tiny \`pkgs.runCommand\` wrapper that links the binary into \`\$out/bin\`. Covers all four platforms (\`aarch64-darwin\` / \`x86_64-darwin\` / \`aarch64-linux\` / \`x86_64-linux\`); falls through to \`throw\` for anything else.

## Why now

PR-B / PR-C / PR-D will switch \`ci.yml\` test jobs to use this devshell via \`DeterminateSystems/nix-installer-action\`. Until the flake itself produces version-stable outputs, the CI move would just shift the drift surface from \"per-tool install steps in YAML\" to \"per-flake-revision drift in nixpkgs\". This PR closes that loop first; CI is not touched.

## What changed

- **\`flake.nix\`**: added \`wasmToolsArchInfo\` / \`wasmToolsBin\` (1.246.1) and \`wasmTimeArchInfo\` / \`wasmTimeBin\` (42.0.1); \`buildInputs\` swapped from \`pkgs.wasm-tools\` / \`pkgs.wasmtime\` to the new wrappers. \`hyperfine\` kept on nixpkgs because upstream has no \`aarch64-darwin\` prebuilt asset (single-arch gap; tracked as a non-blocker — hyperfine is a measurement tool, version drift doesn't change spec/realworld outcomes).
- **\`scripts/sync-versions.sh\`**: header note refreshed (4 pins now live in flake.nix); added two new \`check()\` entries that grep wasm-tools / wasmtime release URLs out of flake.nix and compare against \`WASM_TOOLS_VERSION\` / \`WASMTIME_VERSION\`. The \`versions-lock-sync\` CI job (#62) automatically picks these up.
- **\`.gitignore\`**: added \`result\` and \`result-*\` (the default \`nix build\` output symlinks; shouldn't be tracked).

## Verified locally

\`\`\`
$ nix flake check --all-systems --no-build
  ✅ devShells.aarch64-darwin.default
  ✅ devShells.x86_64-darwin.default
  ✅ devShells.aarch64-linux.default
  ✅ devShells.x86_64-linux.default

$ wasm-tools --version  → wasm-tools 1.246.1 (b960a8735 2026-03-31)
$ wasmtime --version    → wasmtime 42.0.1 (6844a83b5 2026-02-25)

$ bash scripts/sync-versions.sh
  [OK]   ZIG_VERSION            0.16.0
  [OK]   WASI_SDK_VERSION       30
  [OK]   WASM_TOOLS_VERSION     1.246.1
  [OK]   WASMTIME_VERSION       42.0.1
  sync-versions: OK
\`\`\`

## Test plan

- [x] \`nix flake check --all-systems --no-build\` ✅ all 4 systems
- [x] Local \`wasm-tools --version\` / \`wasmtime --version\` confirm correct binaries
- [x] \`scripts/sync-versions.sh\` ✅ 4 pins matched
- [ ] CI green on this branch (\`versions-lock-sync\` job in particular)