### PR TITLE
ci: add test-nix Linux job using Nix devshell (W50 PR-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,65 @@ jobs:
       - uses: actions/checkout@v4
       - run: bash scripts/sync-versions.sh
 
+  # Linux test path uses the Nix devshell (W50 PR-B). The flake.nix
+  # provides version-pinned Zig / WASI SDK / wasm-tools / wasmtime /
+  # TinyGo / Go / hyperfine — i.e. the same tools the Mac/Linux
+  # `direnv allow` shell delivers locally — so this job runs the
+  # `scripts/gate-commit.sh` Commit Gate verbatim. Rust still comes
+  # from the runner image's pre-installed rustup; that's the same
+  # split as developers using `rustup target add wasm32-wasip1` on
+  # top of the Nix devshell.
+  #
+  # macOS + Windows continue to run the existing per-tool install
+  # path in the `test` job below; PR-C migrates macOS, PR-D handles
+  # Windows via `pwsh scripts/windows/install-tools.ps1`.
+  test-nix:
+    name: test (ubuntu-latest, nix devshell)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Setup Rust (wasm32-wasip1 target)
+        run: |
+          source .github/versions.lock
+          rustup install "$RUST_VERSION" --no-self-update
+          rustup default "$RUST_VERSION"
+          rustup target add wasm32-wasip1
+          rustc --version
+
+      - name: Cache Zig build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache
+            zig-cache
+            ~/.cache/zig
+          key: zig-Linux-nix-${{ hashFiles('build.zig', 'build.zig.zon', 'src/**/*.zig') }}
+          restore-keys: |
+            zig-Linux-nix-
+
+      - name: Run Commit Gate inside Nix devshell
+        run: |
+          nix develop --command bash -c '
+            set -euo pipefail
+            echo "=== devshell tool versions ==="
+            zig version
+            wasm-tools --version
+            wasmtime --version
+            echo "WASI_SDK_PATH=$WASI_SDK_PATH"
+            export PATH="$HOME/.cargo/bin:$PATH"
+            bash scripts/gate-commit.sh
+          '
+
   test:
     defaults:
       run:
@@ -23,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Second step in **W50 / Plan B sub-3** (CI Nix-ify). Promotes \`scripts/gate-commit.sh\` from a developer-only entrypoint to the Linux CI Commit Gate, run inside the Nix devshell.

The flake.nix devshell already provides version-pinned Zig (0.16.0), WASI SDK 30, wasm-tools 1.246.1, wasmtime 42.0.1 (last two pinned via PR-A #80), TinyGo, Go, hyperfine — i.e. the same toolchain Mac/Linux developers get from \`direnv allow\`. CI now runs that exact toolchain instead of a parallel set of per-tool install steps.

Rust still comes from the runner image's pre-installed rustup; that mirrors the local-developer story (\`rustup target add wasm32-wasip1\` on top of the Nix devshell). PATH inheritance through \`nix develop --command\` carries \`~/.cargo/bin\` into the shell.

## What changed

- **New \`test-nix\` job** (ubuntu-latest only): \`DeterminateSystems/nix-installer-action\` + \`magic-nix-cache-action\` + \`nix develop --command bash -c 'bash scripts/gate-commit.sh'\`. Sanity-prints \`zig / wasm-tools / wasmtime / WASI_SDK_PATH\` versions before the gate so failures are easy to attribute.
- **Existing \`test\` job** matrix narrowed from \`[ubuntu, macos, windows]\` → \`[macos, windows]\`. macOS migrates in PR-C, Windows in PR-D (via \`pwsh windows/install-tools.ps1\`).
- **size-matrix** and **benchmark** jobs untouched (separate jobs; their nix-ification is out of scope here).

## Why split macOS off into PR-C

\`magic-nix-cache-action\` had a 2025 outage and \`macos-latest + nix-installer-action\` has occasional flakes per the W50 design notes. Linux is the stablest path; landing it first means PR-C/D inherit a known-good \`test-nix\` shape and any flake-induced failure stays local to its own PR.

## Test plan

CI is the test:
- [x] \`flake.nix\` already proven across all 4 systems via \`nix flake check --all-systems --no-build\` (PR-A #80)
- [ ] New \`test-nix\` job green on Linux
- [ ] Old \`test\` job (now macos+windows only) still green — sanity that the matrix shrink didn't break anything
- [ ] No regressions in other jobs (size-matrix, benchmark, versions-lock-sync)

## If this PR fails

Stop conditions per session: two non-flaky failures on the same PR → leave as draft, move on. Likely failure modes:
1. \`magic-nix-cache-action\` cold start / quota issues — usually self-resolves on rerun.
2. \`nix develop\` env not picking up \`~/.cargo/bin\` — visible in the sanity-version block; would need a small env adjustment.
3. gate-commit.sh hitting a step that needs a tool the devshell doesn't ship — visible from the failed-step name in the gate summary line.