### PR TITLE
ci: extend test-nix to macos-latest (W50 PR-C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,26 @@ jobs:
       - uses: actions/checkout@v4
       - run: bash scripts/sync-versions.sh
 
-  # Linux test path uses the Nix devshell (W50 PR-B). The flake.nix
-  # provides version-pinned Zig / WASI SDK / wasm-tools / wasmtime /
-  # TinyGo / Go / hyperfine — i.e. the same tools the Mac/Linux
-  # `direnv allow` shell delivers locally — so this job runs the
-  # `scripts/gate-commit.sh` Commit Gate verbatim. Rust still comes
-  # from the runner image's pre-installed rustup; that's the same
-  # split as developers using `rustup target add wasm32-wasip1` on
-  # top of the Nix devshell.
+  # Linux + macOS test path uses the Nix devshell (W50 PR-B + PR-C).
+  # The flake.nix provides version-pinned Zig / WASI SDK / wasm-tools
+  # / wasmtime / TinyGo / Go / hyperfine — i.e. the same tools the
+  # Mac/Linux `direnv allow` shell delivers locally — so this job
+  # runs the `scripts/gate-commit.sh` Commit Gate verbatim. Rust
+  # still comes from the runner image's pre-installed rustup; that's
+  # the same split as developers using `rustup target add
+  # wasm32-wasip1` on top of the Nix devshell.
   #
-  # macOS + Windows continue to run the existing per-tool install
-  # path in the `test` job below; PR-C migrates macOS, PR-D handles
-  # Windows via `pwsh scripts/windows/install-tools.ps1`.
+  # Windows continues to run the existing per-tool install path in
+  # the `test` job below; PR-D will migrate it to
+  # `pwsh scripts/windows/install-tools.ps1` + the same gate-commit
+  # entrypoint.
   test-nix:
-    name: test (ubuntu-latest, nix devshell)
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }}, nix devshell)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
@@ -58,9 +63,9 @@ jobs:
             .zig-cache
             zig-cache
             ~/.cache/zig
-          key: zig-Linux-nix-${{ hashFiles('build.zig', 'build.zig.zon', 'src/**/*.zig') }}
+          key: zig-${{ runner.os }}-nix-${{ hashFiles('build.zig', 'build.zig.zon', 'src/**/*.zig') }}
           restore-keys: |
-            zig-Linux-nix-
+            zig-${{ runner.os }}-nix-
 
       - name: Run Commit Gate inside Nix devshell
         run: |
@@ -82,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Third step in **W50 / Plan B sub-3** (CI Nix-ify). Adds macOS to the Nix-based test job that landed in PR-B (#81). Same flake.nix devshell, same gate-commit entrypoint, same Rust-from-runner arrangement — only the runner OS changes.

## What changed

- \`test-nix\` matrix expanded from \`[ubuntu-latest]\` → \`[ubuntu-latest, macos-latest]\`. Job display name uses \`\${{ matrix.os }}\` so the GitHub UI distinguishes the two.
- \`test\` job matrix narrowed from \`[macos-latest, windows-latest]\` → \`[windows-latest]\`. PR-D migrates Windows.
- Zig cache key already used \`runner.os\`, so \`Linux\` and \`macOS\` caches stay separate naturally; updated the literal \`Linux\` prefix to \`runner.os\` to match.

## Risk

\`macos-latest + nix-installer-action\` has had occasional flakes in the past per W50 design notes. PR-B's success on Linux gives confidence the gate-commit path inside the devshell is sound; if macOS-specific flake behaviour surfaces, the plan is to leave this PR as draft and inspect rather than retry-spam.

## Test plan

CI-only:
- [x] Diff is 1 file (ci.yml), +21 / -16; pure structural change
- [ ] \`test (ubuntu-latest, nix devshell)\` still green (regression check)
- [ ] \`test (macos-latest, nix devshell)\` green (new path)
- [ ] \`test (windows-latest)\` still green (untouched)
- [ ] No flake-cache eviction issues on the macOS path