### PR TITLE
ci(c-g step 5): flip benchmark job to a 3-OS matrix

### DIFF
--- a/.github/versions.lock
+++ b/.github/versions.lock
@@ -34,8 +34,11 @@ WASMTIME_VERSION=42.0.1
 WASI_SDK_VERSION=30
 # rustup install in ci.yml; install-tools.ps1 rustup-init toolchain on Windows.
 RUST_VERSION=stable
-# bench job DEB download in ci.yml.
-HYPERFINE_VERSION=1.18.0
+# Windows install-tools.ps1 release zip; Linux/macOS get hyperfine
+# via nix devshell (nixpkgs revision pins the actual version, so this
+# entry is the Windows-side mirror). Bumped 1.18.0 → 1.20.0 in C-g
+# step 5 to match the nixpkgs version on aarch64-darwin / x86_64-linux.
+HYPERFINE_VERSION=1.20.0
 # install-tools.ps1 release zip on Windows; Nix devshell on Linux/macOS.
 GO_VERSION=1.25.5
 # install-tools.ps1 release zip on Windows; Nix devshell on Linux/macOS.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,18 +278,48 @@ jobs:
       - name: Verify minimal build tests pass
         run: zig build test -Djit=false -Dcomponent=false -Dwat=false
 
+  # 3-OS bench matrix (C-g step 5, 2026-04-29). Each runner does its
+  # own fresh measurement of base vs PR — never compared across
+  # OSes / architectures because the hardware deltas dwarf any
+  # codegen-level signal we could detect. The durable per-arch
+  # baselines live in bench/history.yaml (see CLAUDE.md Merge Gate
+  # item 10); CI exists to catch *intra-runner* regressions on PRs.
   benchmark:
-    needs: test
-    runs-on: ubuntu-latest
+    name: benchmark (${{ matrix.os }})
+    needs: [test-nix, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install Zig
-        uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: 0.16.0
+      # Linux / macOS — nix devshell brings zig + hyperfine.
+      - name: Install Nix
+        if: runner.os != 'Windows'
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Magic Nix cache
+        if: runner.os != 'Windows'
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      # Windows — install-tools.ps1 brings zig + hyperfine via
+      # `versions.lock` pins, exposing them through $GITHUB_PATH so
+      # subsequent bash steps see them. `-OnlyTool` arms keep the
+      # bench job from pulling Go / TinyGo / Rust / WASI SDK that
+      # the realworld test job needs but the benchmarks do not.
+      - name: Provision toolchain (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -File scripts/windows/install-tools.ps1 -OnlyTool zig
+          pwsh -NoLogo -File scripts/windows/install-tools.ps1 -OnlyTool hyperfine
 
       - name: Cache Zig build artifacts
         uses: actions/cache@v4
@@ -298,32 +328,42 @@ jobs:
             .zig-cache
             zig-cache
             ~/.cache/zig
-          key: zig-Linux-${{ hashFiles('build.zig', 'build.zig.zon', 'src/**/*.zig') }}
+            ~/AppData/Local/zig
+          key: zig-${{ runner.os }}-bench-${{ hashFiles('build.zig', 'build.zig.zon', 'src/**/*.zig') }}
           restore-keys: |
-            zig-Linux-
-
-      - name: Install hyperfine
-        run: |
-          source .github/versions.lock
-          curl -L --retry 3 --retry-delay 5 -f -o /tmp/hyperfine.deb \
-            "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/hyperfine_${HYPERFINE_VERSION}_amd64.deb"
-          sudo dpkg -i /tmp/hyperfine.deb
+            zig-${{ runner.os }}-bench-
 
       - name: Build ReleaseSafe
-        run: zig build -Doptimize=ReleaseSafe
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            zig build -Doptimize=ReleaseSafe
+          else
+            nix develop --command zig build -Doptimize=ReleaseSafe
+          fi
 
       - name: Benchmark regression check
         if: github.event_name == 'pull_request'
         # Soft-fail (continue-on-error) so noisy single-bench wobbles do
-        # not block PRs. Real regressions surface as repeated reds across
-        # PRs and are flagged in the PR check log; the durable Mac
-        # baseline lives in bench/history.yaml (recorded locally, see
-        # CLAUDE.md Merge Gate item 10). Ubuntu-vs-Ubuntu only —
-        # cross-platform comparison would be meaningless given the
-        # hardware delta.
+        # not block PRs. Real regressions surface as repeated reds
+        # across PRs and are flagged in the PR check log; the durable
+        # per-arch baselines live in bench/history.yaml (recorded
+        # locally, see CLAUDE.md Merge Gate item 10). Each runner
+        # measures fresh base + PR builds on the same host, so the
+        # comparison is intra-runner only — never mix the three
+        # series.
         continue-on-error: true
-        run: bash bench/ci_compare.sh --base=origin/main --threshold=20 --runs=3 --warmup=1 --skip-build
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            bash bench/ci_compare.sh --base=origin/main --threshold=20 --runs=3 --warmup=1 --skip-build
+          else
+            nix develop --command bash bench/ci_compare.sh --base=origin/main --threshold=20 --runs=3 --warmup=1 --skip-build
+          fi
 
       - name: Benchmark record (main push)
         if: github.event_name == 'push'
-        run: bash bench/ci_compare.sh --record-only --runs=3 --warmup=1 --skip-build
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            bash bench/ci_compare.sh --record-only --runs=3 --warmup=1 --skip-build
+          else
+            nix develop --command bash bench/ci_compare.sh --record-only --runs=3 --warmup=1 --skip-build
+          fi

--- a/scripts/windows/install-tools.ps1
+++ b/scripts/windows/install-tools.ps1
@@ -41,7 +41,7 @@ param(
     # -SkipRust avoids re-bootstrapping a self-contained rustup tree
     # under %LOCALAPPDATA%\zwasm-tools\rust-stable\.
     [switch]$SkipRust,
-    [ValidateSet('zig', 'wasm-tools', 'wasmtime', 'wasi-sdk', 'rust', 'go', 'tinygo', 'binaryen', 'all')]
+    [ValidateSet('zig', 'wasm-tools', 'wasmtime', 'wasi-sdk', 'rust', 'go', 'tinygo', 'binaryen', 'hyperfine', 'all')]
     [string]$OnlyTool = 'all'
 )
 
@@ -94,10 +94,11 @@ foreach ($k in 'ZIG_VERSION', 'WASM_TOOLS_VERSION', 'WASMTIME_VERSION', 'WASI_SD
 # install needs them but they're missing — keeps the script honest
 # about its inputs.
 $realworldKeys = @{
-    rust     = 'RUST_VERSION'
-    go       = 'GO_VERSION'
-    tinygo   = 'TINYGO_VERSION'
-    binaryen = 'BINARYEN_VERSION'
+    rust      = 'RUST_VERSION'
+    go        = 'GO_VERSION'
+    tinygo    = 'TINYGO_VERSION'
+    binaryen  = 'BINARYEN_VERSION'
+    hyperfine = 'HYPERFINE_VERSION'
 }
 foreach ($pair in $realworldKeys.GetEnumerator()) {
     $tool = $pair.Key; $key = $pair.Value
@@ -275,6 +276,19 @@ if ($OnlyTool -in @('all', 'tinygo')) {
     $paths['tinygo'] = $dir
 }
 
+if ($OnlyTool -in @('all', 'hyperfine')) {
+    # hyperfine is the benchmarking driver used by `bench/record.sh`,
+    # `bench/ci_compare.sh`, and the per-merge bench step. The Windows
+    # zip extracts to
+    # `hyperfine-vN.M.K-x86_64-pc-windows-msvc/hyperfine.exe` so
+    # Resolve-SingleSubdir flattens the version-stamped top dir,
+    # leaving `hyperfine.exe` directly inside the install dir.
+    $hf = $versions.HYPERFINE_VERSION
+    $url = "https://github.com/sharkdp/hyperfine/releases/download/v$hf/hyperfine-v$hf-x86_64-pc-windows-msvc.zip"
+    $dir = Install-Tool -Name 'hyperfine' -Version $hf -Url $url -Format 'zip'
+    $paths['hyperfine'] = $dir
+}
+
 if ($OnlyTool -in @('all', 'binaryen', 'tinygo')) {
     # TinyGo invokes `wasm-opt` as part of its wasm build pipeline.
     # On Linux/macOS the Nix `tinygo` derivation is wrapped to prepend
@@ -417,11 +431,13 @@ function Update-UserPath {
 #   go                          — bin/ subdir holding go.exe + gofmt.exe.
 #   tinygo                      — bin/ subdir holding tinygo.exe.
 #   binaryen                    — bin/ subdir holding wasm-opt.exe et al.
+#   hyperfine                   — hyperfine.exe directly in the stamped dir.
 #   rust                        — cargo/bin/ holding cargo.exe + rustup.exe.
 $pathsToAdd = @()
 if ($paths.ContainsKey('zig'))        { $pathsToAdd += $paths['zig'] }
 if ($paths.ContainsKey('wasm-tools')) { $pathsToAdd += $paths['wasm-tools'] }
 if ($paths.ContainsKey('wasmtime'))   { $pathsToAdd += $paths['wasmtime'] }
+if ($paths.ContainsKey('hyperfine'))  { $pathsToAdd += $paths['hyperfine'] }
 if ($paths.ContainsKey('go'))         { $pathsToAdd += (Join-Path $paths['go']       'bin') }
 if ($paths.ContainsKey('tinygo'))     { $pathsToAdd += (Join-Path $paths['tinygo']   'bin') }
 if ($paths.ContainsKey('binaryen'))   { $pathsToAdd += (Join-Path $paths['binaryen'] 'bin') }
@@ -461,4 +477,7 @@ Write-Host "       CARGO_HOME / RUSTUP_HOME changes."
 Write-Host "Verify (core):     zig version; wasm-tools --version; wasmtime --version; bash --version"
 if ($OnlyTool -in @('all', 'go', 'tinygo', 'rust')) {
     Write-Host "Verify (realworld): go version; tinygo version; cargo --version; rustup --version"
+}
+if ($OnlyTool -in @('all', 'hyperfine')) {
+    Write-Host "Verify (bench):    hyperfine --version"
 }


### PR DESCRIPTION
## Summary

- Closes the matrix-flip half of Plan C-g. The benchmark job was Ubuntu-only because hyperfine had to be installed manually via DEB and there was no Windows path. After #86 made `bench/history.yaml` multi-arch, the only thing standing between us and per-OS regression checks on PR was the toolchain provisioning gap on Windows.

## Changes

`scripts/windows/install-tools.ps1`
- new `-OnlyTool hyperfine` arm pinned via `versions.lock` `HYPERFINE_VERSION`. Release zip flattens through `Resolve-SingleSubdir` so `hyperfine.exe` lands at the install root.
- `realworldKeys` gains `hyperfine = HYPERFINE_VERSION` (loud failure if the pin is missing).
- ValidateSet, `Update-UserPath`, and the final Verify banner pick up hyperfine.

`.github/versions.lock`
- `HYPERFINE_VERSION` 1.18.0 → 1.20.0 to match the nixpkgs version already in the nix devshell on aarch64-darwin / x86_64-linux.

`.github/workflows/ci.yml`
- `benchmark` job becomes `os: [ubuntu-latest, macos-latest, windows-latest]`. Linux/macOS provision via nix devshell (same pattern as `test-nix`); Windows uses `install-tools.ps1 -OnlyTool zig` + `-OnlyTool hyperfine`, skipping the realworld toolchain it doesn't need.
- The previous Linux-only DEB + `setup-zig` steps are gone. The intra-runner regression check and the push-to-main `--record-only` step are unchanged in spirit; they just pick `nix develop --command` vs plain bash based on `$RUNNER_OS`.
- `needs: [test-nix, test]` so the bench matrix fans out only after all three platform test jobs have gated the PR.

## Cross-runner comparison

Still meaningless. The job docstring spells that out: each runner measures fresh base + PR builds on the same host, so the comparison is intra-runner only. The durable per-arch absolute-time baselines remain in `bench/history.yaml`.

## Test plan

- [ ] CI matrix passes on all three runners
- [ ] First push-to-main `--record-only` step on Mac/Windows succeeds (no .deb-flavored Linux assumption left in the path)
- [ ] OrbStack/Rosetta x86_64-linux row in `history.yaml` can be supplemented with a native-Linux row in a follow-up