### PR TITLE
ci(deps): bump pinned Actions to latest + align nightly wasm-tools

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,13 +37,13 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
 
       - name: Cache Zig 0.16.0
         id: cache-zig
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local/zig-0.16.0
           key: zig-0.16.0-aarch64-macos
@@ -91,7 +91,7 @@ jobs:
             "bench/results/ci/aarch64-darwin-${short}.yaml"
 
       - name: Upload fragment artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-fragment-aarch64-darwin
           path: bench/results/ci/aarch64-darwin-*.yaml
@@ -104,13 +104,13 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
 
       - name: Cache Zig 0.16.0
         id: cache-zig
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local/zig-0.16.0
           key: zig-0.16.0-x86_64-linux
@@ -161,7 +161,7 @@ jobs:
             "bench/results/ci/x86_64-linux-${short}.yaml"
 
       - name: Upload fragment artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-fragment-x86_64-linux
           path: bench/results/ci/x86_64-linux-*.yaml
@@ -175,20 +175,20 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
           fetch-depth: 1
           persist-credentials: true
 
       - name: Download mac fragment
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bench-fragment-aarch64-darwin
           path: bench/results/ci/
 
       - name: Download linux fragment
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bench-fragment-x86_64-linux
           path: bench/results/ci/

--- a/.github/workflows/bench_baseline.yml
+++ b/.github/workflows/bench_baseline.yml
@@ -39,13 +39,13 @@ jobs:
             runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
 
       - name: Cache Zig 0.16.0
         id: cache-zig
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local/zig-0.16.0
           key: zig-0.16.0-${{ matrix.name }}
@@ -92,7 +92,7 @@ jobs:
         run: bash scripts/record_baseline_v1_regression.sh
 
       - name: Upload baseline artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: baseline-${{ matrix.name }}
           path: bench/baseline_v1_regression.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       code: ${{ steps.detect.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Detect non-doc changes
@@ -108,13 +108,13 @@ jobs:
             advisory: true
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
 
       - name: Cache Zig 0.16.0
         id: cache-zig
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local/zig-0.16.0
           key: zig-0.16.0-${{ matrix.name }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,13 +34,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
 
       - name: Cache Zig 0.16.0
         id: cache-zig
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local/zig-0.16.0
           key: zig-0.16.0-x86_64-linux
@@ -57,12 +57,12 @@ jobs:
       - name: Add Zig to PATH
         run: echo "$HOME/.local/zig-0.16.0" >> "$GITHUB_PATH"
 
-      - name: Install wasm-tools 1.247.0
+      - name: Install wasm-tools 1.251.0
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/bytecodealliance/wasm-tools/releases/download/v1.247.0/wasm-tools-1.247.0-x86_64-linux.tar.gz" -o /tmp/wt.tar.gz
+          curl -fsSL "https://github.com/bytecodealliance/wasm-tools/releases/download/v1.251.0/wasm-tools-1.251.0-x86_64-linux.tar.gz" -o /tmp/wt.tar.gz
           tar -xzf /tmp/wt.tar.gz -C /tmp
-          echo "/tmp/wasm-tools-1.247.0-x86_64-linux" >> "$GITHUB_PATH"
+          echo "/tmp/wasm-tools-1.251.0-x86_64-linux" >> "$GITHUB_PATH"
 
       - name: Verify toolchain
         run: |
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
 
@@ -95,7 +95,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Zig 0.16.0
         shell: bash


### PR DESCRIPTION
Consolidates the queued bot PRs into one change, and closes the obsolete ones.

## Applied (dependabot Actions bumps — were #108–#111)
SHA pins updated across **all** workflow files (their individual PRs conflicted
with the new `ci.yml` `changes` job, so they're consolidated here):

| action | old | new |
|---|---|---|
| actions/checkout | v4.3.1 | v7.0.0 |
| actions/download-artifact | v4.3.0 | v8.0.1 |
| actions/upload-artifact | v4.6.2 | v7.0.1 |
| actions/cache | v4.3.0 | v6.1.0 |

Plus: `nightly.yml` wasm-tools pin `1.247.0 → 1.251.0` to match
`.github/versions.lock` (source-of-truth mirror) — removes a stale drift.

## Closed as obsolete (not applicable to v2 `main`)
- Spec-testsuite auto-bumps **#106 / #103 / #101 / #99 / #95** and wasm-tools
  **#104**: these target the retired v1 `.github/spec-sha` mechanism (that file
  no longer exists on v2 `main`; nothing reads it). v2 pins the spec testsuite
  via `.dev/spec_pin.yaml` + a `nightly.yml` drift alert
  (`scripts/check_spec_bump.sh`), and wasm-tools is already at 1.251.0. So these
  are dead against the current trunk.

## Verification
- `actionlint .github/workflows/*.yml` — clean.
- Only `ci.yml` runs on PR CI (it exercises the checkout + cache bumps). The
  artifact-action bumps live in release/bench/nightly workflows that fire on
  their own schedule/tag triggers — watch their next run.