### PR TITLE
ci(release): install wasm-tools so the ReleaseSafe build succeeds (v2.0.0 hotfix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,24 @@ jobs:
           tar -xJf /tmp/zig.tar.xz -C ~/.local
           echo "$HOME/.local/${dir}" >> "$GITHUB_PATH"
 
+      # The default `zig build` install set includes the spec-assert test exes,
+      # which run `wasm-tools parse` at build time to generate spectest.wasm
+      # (build.zig ~L263). ci.yml installs wasm-tools for the same reason; the
+      # release build (Linux host, cross-compiling every target) needs the
+      # host's Linux wasm-tools regardless of the -Dtarget.
+      - name: Install wasm-tools (build-time; spectest.wasm generation)
+        shell: bash
+        run: |
+          set -euo pipefail
+          source .github/versions.lock
+          asset="wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux"
+          url="https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/${asset}.tar.gz"
+          mkdir -p "$HOME/.local/bin"
+          cd "$HOME/.local/bin"
+          curl -fsSL "$url" -o wt.tar.gz
+          tar -xzf wt.tar.gz --strip-components=1 "${asset}/wasm-tools"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Build + package all targets (ReleaseSafe)
         shell: bash
         run: |


### PR DESCRIPTION
Hotfix for the failed v2.0.0 release run: `zig build -Doptimize=ReleaseSafe` in release.yml builds the default install set (incl. spec-assert test exes → `wasm-tools parse` for spectest.wasm), but the runner only had Zig → wasm-tools FileNotFound → all target builds failed before any Release was cut. Adds the same wasm-tools install ci.yml uses. Workflow-only change (test-all unaffected); verified equivalent locally (ubuntunote Linux→aarch64-macos ReleaseSafe cross-build succeeds with wasm-tools; the Mach-O arm64 binary runs on macOS). `actionlint` clean.