### PR TITLE
docs(scaffolding): maintenance-mode necessity audit + deloop stale docs (E)

### DIFF
--- a/.claude/skills/dispatch_consistency_audit/SKILL.md
+++ b/.claude/skills/dispatch_consistency_audit/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: dispatch_consistency_audit
-description: Audit Q3 C adoption's dispatch substrate consistency — three-way match of ZirOp tag count = per-op file count = 5-axis handler implementation count; `wasm_level` / `wasi_level` metadata consistency; sampling check that build-option DCE works as expected. Fires after §9.12-B completion and at periodic audit_scaffolding boundaries.
+description: Audit Q3 C adoption's dispatch substrate consistency — three-way match of ZirOp tag count = per-op file count = 5-axis handler implementation count; `wasm_level` / `wasi_level` metadata consistency; sampling check that build-option DCE works as expected. Fires at periodic audit_scaffolding boundaries and on explicit request (the §9.12-B build trigger is now DONE — the substrate exists, so the check is always live).
 ---
 
 # dispatch_consistency_audit
 
 > **Status**: landed at §9.12-A (2026-05-19). Justified by ADR-0071 §Q3 +
-> ADR-0073 (both Accepted). Currently runs in **pre-§9.12-B mode** which
-> reports "substrate not yet built" gracefully. **Post-§9.12-B mode**
-> activates once `src/ir/dispatch_collector.zig` exists with the
-> `collected_ops` declaration; the skill auto-detects and switches.
+> ADR-0073 (both Accepted). **Post-§9.12-B mode is now ACTIVE** —
+> `src/ir/dispatch_collector.zig` exists with the `collected_ops`
+> declaration, so the full three-way match runs. (Maintenance mode: invoke
+> at periodic `audit_scaffolding` boundaries, not on a campaign phase edge.)
 
 ## Purpose
 

--- a/.claude/skills/meta_audit/SKILL.md
+++ b/.claude/skills/meta_audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meta_audit
-description: Periodic deliberate-skepticism audit against ROADMAP §1/§2/§9/§14/§15 and recent ADRs. Triggers on Phase boundary OR opportunistic drift signals from audit_scaffolding §J. Produces a report under .dev/meta_audits/, may seed ADRs / lessons / rule amendments. User-gated; this skill is NOT autonomous-fired by /continue.
+description: Periodic deliberate-skepticism audit against ROADMAP §1/§2/§9/§14/§15 and recent ADRs. Triggers on opportunistic drift signals from audit_scaffolding §J, or on explicit user request before a significant change. Produces a report under .dev/meta_audits/, may seed ADRs / lessons / rule amendments. User-gated; NOT autonomous-fired (the campaign phase-boundary trigger is retired — there are no more phases).
 ---
 
 # meta_audit

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -3,79 +3,71 @@
 > ≤ 100 lines (soft) / 120 (hard). Canonical fresh-session entry point. Framing:
 > [`handover_doc_discipline.md`](../.claude/rules/handover_doc_discipline.md).
 
-## Current state — Phase 17 完成形 plateau; v2.0.0-alpha.3 TAGGED @fc7ff0b3b; plateau GENUINELY CLEAN
+## Current state — MAINTENANCE MODE (post-v2.0.0)
 
-**Mode: overnight autonomous niche-debt discharge** (user 2026-06-23: "逐次修正、取り組めるところを；枯渇しても判断して進める").
-`.auto`→JIT flip DONE + 3-host green; tag `v2.0.0-alpha.3` @fc7ff0b3b (tag-only, Latest stays v1.11.0); cljw pins it.
-No active campaign/bundle.
+**v2.0.0 shipped to `main`** (tag `v2.0.0` @3da4c8681; release.yml auto-built
+Release + Latest→v2). v1 frozen at `v1.11.1`. The from-scratch build campaign is
+COMPLETE; the autonomous `/continue` loop is RETIRED. Dev model: cut a
+`develop/<slug>` branch from `main` → PR → CI `ci-required` 3-OS gate must be
+green to merge. **Release stays user-only (ADR-0156)** — never autonomously tag /
+publish / cut over. No active campaign/bundle; no cron self-re-arm.
 
-**This session closed ALL named niche JIT gaps** (latest @aa00e0efd):
-- **D-498 @ab996afc0** — JIT C-API funcref param+result marshalling (`invokeRefIdx` 1/2-param ref-result arms). Deleted.
-- **D-497 @11d70d69f, 3-host GREEN** — JIT funcref-table grow (ADR-0201): setup pre-allocs funcptr/typeidx mirrors to
-  growCapacity; jitTableGrowGuest (resolve *FuncEntity) vs jitTableGrowHost (fail-safe clear); arm64 X25 reload after
-  table-0 grow; `wasm_table_grow` C-API JIT arm. Deleted.
-- **D-499 @cd0a75e96 RATIFIED interp-only** (note) — targeted fix intractable (always-R15 regresses Win64 buffer-write;
-  trap stub structurally needs R15); runaway-safety intact both arches; 3 facade tests `.interp`-pinned.
-- **D-500 RESOLVED** (note) — component CM-API `.interp` is RATIFIED ARCHITECTURE (ADR-0172: cross-instance aliasing is
-  Zone-2, component-on-JIT precluded), NOT a workaround; residual general Win64 `wrapper_thunk` ≥2-arg/3-result gap → D-477 sliver(4).
-- **D-477 sliver(3) @083affd47 RESOLVED+tested** — mixed (i32,f64)→f64 JIT export works via the 2-arg buffer-thunk
-  fall-through (regression guard added). **SIMD-spill dedup @df3fa42d7** (xmmDefSpilledV128→delegates).
+## Active maintenance work (batched to keep CI frugal)
 
-**NEXT**: LOOP CLEAN-STOPPED (bucket-3, 2026-06-24) — work exhaustively complete; all remaining forward work is
-external-signal-gated (build-on-demand / parked / user-gated) AND every autonomous-prep path walked (handover, debt,
-lessons, proposal_watch, coherence audit, loader+exec fuzz sweeps, v128 Phase-I). Resume-chain clean: git synced
-@19e4850fe, no cron, no orphans. Next `/continue` (user direction / a real signal) resumes instantly. Detail:
-no `now`-class debt; remaining work is build-on-demand/parked (below). v128-host-invoke bundle
-OPENED then PARKED 2026-06-24 after Phase-I survey (ae0522a8): the only easy win (no-arg `()→v128` result) ALREADY
-WORKS (runner.zig:698 runWasi→callV128NoArgs→ScalarResult.v128; "wasmtime supports this"). The genuine remainder is
-the delicate ~7-site thunk path (v128 PARAMS + general marshalling, model-A) with LOW marginal value (SIMD correctness
-already covered: simd_assert 25075/0 + fuzz-loader 1665 JIT clean + spec-driver `()→v128`) and NO waiting consumer →
-correct call = do NOT grind; build when the SIMD-differential productization (or a real v128-host-invoke need) lands.
-**Fuzz sweeps CLEAN** (2026-06-23 @7af222e9a): loader campaign `2008 processed, 1777 compiled (1266 interp + 1665 JIT),
-231 rejected, 0 crashes`; exec-differential (interp-vs-JIT, D-469) seed `9/9 funcs, 0 mismatched`. Robustness +
-JIT-correctness reconfirmed. NOTE: exec-diff over the RAW SMITH campaign corpus reports `0 funcs compared` (smith
-exports no 0-param/scalar-result funcs — KNOWN limitation, lesson 2026-06-20) → don't re-run exec-diff on raw smith;
-the curated `exec_seed` is its real coverage. Re-run loader: `nix develop .#gen --command bash scripts/gen_fuzz_corpus.sh campaign && zig build fuzz-campaign`.
-
-## v128-host-invoke — Phase-I done, BUILD-ON-DEMAND (preserved for the real-consumer cycle)
-
-Implementation plan ready (survey ae0522a8 + `private/notes/d477-remaining-slices-design.md` Slice 3): model-A = v128 as
-2 consecutive 16-aligned u64 slots in the `[*]u64` buffer; a SHARED `argByteOffsets(sig)` drives thunk-loads + runner-
-packing; per-arch param emit arm64 `LDR Q`/SysV `MOVUPS`/Win64 BY-REFERENCE; adding `.v128` to the shared `TypedResult`
-union (entry_buffer_write.zig:253) touches ~7 exhaustive switches. **Easy part (no-arg `()→v128`) already done**
-(runner.zig:698). Build when a real consumer needs v128 PARAMS/general marshalling (SIMD-differential productization).
+Post-v2.0.0 sweep (see `.dev/meta_audits/2026-07-03-maintenance-scaffolding-audit.md`):
+- **Batch A — ledger/proposal reconcile** (doc-only) — PR #118 OPEN, `ci-required` green.
+  Debt reconciled vs code truth: closed D-294/296/297/322/500, reclassified
+  D-254→now / D-249→note, recorded D-502/503/504. Ledger → 62 entries, ZERO now-class.
+- **E — scaffolding necessity audit** — report landed; E-段2 prunes in flight on
+  `develop/scaffolding-maintenance` (deloop retired-campaign docs, cap-posture +
+  gate-cadence changes are NEEDS-ADR → user-gated, see the report §B/§C).
+- **Batch B (Component域)** + **Batch C (table64-JIT)** = queued code PRs (below). **D held.**
 
 ## Operational invariants (keep using)
 
-- **Win64 fast-repro** (~2min): cross-build `zig build test -Dtarget=x86_64-windows-gnu` on Mac (run-step "fails" but
-  test.exe builds) → `scp` to windowsmini → ssh-run from the repo dir (cwd matters for file-fixture tests).
-- **Mac `zig build test` is INSUFFICIENT for flip/ABI-class changes** — ubuntu-gate mandatory; arm64 masks x86_64 bugs.
-  Rosetta `-Dtarget=x86_64-macos` REPRODUCES x86_64-linux JIT bugs. JIT-codegen fix → verify arm64 AND x86_64-macos.
-- **Step-0.7 NOTE**: `failed command: …--listen=-` / host-example exe lines are COSMETIC (exit 0); trust
-  `[run_remote_*] OK/FAIL` + `N passed, 0 failed`.
+- **Win64 fast-repro** (~2min): cross-build `zig build test -Dtarget=x86_64-windows-gnu`
+  on Mac (run-step "fails" but test.exe builds) → `scp` to windowsmini → ssh-run from
+  the repo dir (cwd matters for file-fixture tests).
+- **Mac `zig build test` is INSUFFICIENT for flip/ABI-class changes** — ubuntu-gate
+  mandatory; arm64 masks x86_64 bugs. Rosetta `-Dtarget=x86_64-macos` REPRODUCES
+  x86_64-linux JIT bugs. JIT-codegen fix → verify arm64 AND x86_64-macos.
+- **Step-0.7 NOTE**: `failed command: …--listen=-` / host-example exe lines are
+  COSMETIC (exit 0); trust `[run_remote_*] OK/FAIL` + `N passed, 0 failed`.
+- CI `ci_gate.sh` runs `zig fmt` + `test-all` (+ JIT/DCE/AOT). It does NOT run
+  `file_size_check`/`zone_check`/`spill_aware_check` — those are local `gate_commit.sh`
+  only (see the scaffolding-audit report's load-bearing finding).
 
 ## Parked / gated — do NOT speculatively grind (see debt.yaml)
 
-- **D-477 slivers** (partial, build-on-demand, no DIRECT consumer): (1) v128 args/results invoke (Win64-by-ref gotcha;
-  would unblock the SIMD differential oracle — but indirect + itself otherwise-blocked); (2) Win64 ≥4-param stack-spill;
-  (4) Win64 ≥2-arg/3-result MEMORY-class thunk (folded from D-500). Full recipe: `private/notes/d477-remaining-slices-design.md`
-  + debt D-477. **RE-EXAMINED 2026-06-23 — design note + debt BOTH classify these "build-on-demand NICHE"; do NOT
-  re-investigate or speculatively build.** Trigger = a real consumer (e.g. SIMD-differential productization, a v128/Win64
-  host-invoke need). SIMD correctness already covered (simd_assert 25075/0 + fuzz-loader 1665 JIT-compiled clean).
-- **validator.zig at 3449/3450 cap** — NEXT validator edit MUST extract per the file's marker plan first.
-- D-305 long-tail (niche CM shapes; `component_graph.zig` 1895/2000 split first); D-464 async adversarial; D-475
-  table64-JIT (perf, Win64-risk); D-462 feature-separation (user-gated). 22 `blocked-by` = future-bucket/parked.
+- **D-477 slivers** (partial, build-on-demand, no DIRECT consumer): v128 args/results
+  invoke (Win64-by-ref gotcha); Win64 ≥4-param stack-spill; Win64 ≥2-arg/3-result
+  MEMORY-class thunk. Recipe: `private/notes/d477-remaining-slices-design.md` + debt
+  D-477. Trigger = a real consumer. SIMD correctness already covered (simd_assert
+  25075/0 + fuzz-loader 1665 JIT-compiled clean). **D-478** = JIT FP host-callback
+  bridge + funcref `Table.set` panic + proc_exit exit-code.
+- **D-475 table64-JIT** (Batch C): interp is fully conformant; JIT is guarded
+  (`JitTable64Unsupported`). u32→u64 4-cycle bundle, Win64-risk — do with FRESH context.
+- **D-502** CM utf16/latin1 canonical-ABI string encodings; **D-444** split
+  `component_wasi_p2.zig` (2228 > 2000) — both Batch B (Component域).
+- **validator.zig at 3392/3510** — next validator edit extracts per the marker plan first.
+- D-305 long-tail (niche CM shapes; `component_graph.zig` 1895/2000 split first);
+  D-464 async adversarial; D-462 feature-separation (user-gated). blocked-by rows = parked.
 
-## State (release = USER-ONLY, ADR-0156 — the loop NEVER tags/publishes)
+## State (release = USER-ONLY, ADR-0156)
 
-- **Wasm 1.0/2.0/3.0**: 100% spec, 0 skip. **WASI 0.1** complete; **0.2/CM** default-ON; **0.3 core** done. Sandbox triad.
-- **Surfaces**: C-API · Zig-API (full WASI parity) · lean CLI · memory-safety sound · dogfooded into cw. Runners ReleaseSafe.
-- **EH**: cross-instance JIT EH both arches. Interp+JIT EH corpus green. Realworld 56 fixtures interp 56/0; JIT diff-gated.
-- **Debt**: 67 entries — **ZERO `now`-class** (22 blocked-by, 42 note, 3 partial). 完成形 plateau (all dims confirmed,
-  surface audits clean 2026-06-18, interp+JIT fuzz 0-crash, v1-JIT parity D-265 closed).
+- **Wasm 1.0/2.0/3.0**: 100% spec, 0 skip. **WASI 0.1** complete; **0.2/CM** default-ON;
+  **0.3 core** done. Sandbox triad (fuel / interrupt / memory+table cap) cross-engine.
+- **Surfaces**: C-API · Zig-API (full WASI parity) · lean CLI · memory-safety sound ·
+  dogfooded into cljw (pins zwasm by git tag-hash). Runners ReleaseSafe.
+- **EH**: cross-instance JIT EH both arches. Interp+JIT EH corpus green. Realworld 56
+  fixtures interp 56/0; JIT diff-gated.
+- **Debt**: 62 entries — ZERO `now`-class (after Batch A). 完成形 plateau (all dims
+  confirmed, surface audits clean, interp+JIT fuzz 0-crash, v1-JIT parity D-265 closed).
+- **Proposals**: reviewed 2026-07-03; no phase advances; 3.0 corpora unaffected.
 
 ## Key refs
 
 - [`flake.nix`](../flake.nix) `devShells.gen` / `.#gen-wasip3`. [`docs/zig_api_design.md`](../docs/zig_api_design.md).
-- ADRs: **0156** (NO autonomous release) · **0153** (rework) · **0201** (funcref-table grow) · **0172** (components=interp) ·
-  **0099** (file-size caps) · **0126** (iso-recursive equality). lessons INDEX: `.dev/lessons/INDEX.md` (Step 0.4 keyword index).
+- ADRs: **0156** (NO autonomous release) · **0153** (rework) · **0201** (funcref-table grow) ·
+  **0172** (components=interp) · **0099** (file-size caps) · **0126** (iso-recursive equality).
+  lessons INDEX: `.dev/lessons/INDEX.md`.

--- a/.dev/meta_audits/2026-07-03-maintenance-scaffolding-audit.md
+++ b/.dev/meta_audits/2026-07-03-maintenance-scaffolding-audit.md
@@ -1,0 +1,99 @@
+# Maintenance-mode scaffolding necessity audit (2026-07-03)
+
+> **Doc-state**: ACTIVE — report only (改変ゼロ). Drives the E-段2 edit batch.
+> Supersedes nothing; complements `audit_scaffolding` (staleness) with a
+> **necessity** lens under the post-v2.0.0 premise shift.
+
+## Premise
+
+The dev scaffolding was built by an **autonomous `/continue` build-campaign
+loop**, now RETIRED (v2.0.0 shipped to `main`; maintenance mode = cut a
+`develop/<slug>` branch → PR; CI's 3-OS `ci-required` gate runs on every PR).
+Much scaffolding was campaign machinery (loop self-perpetuation) or an
+AI-over-generation **smell detector** during rapid build. This audit judges
+each piece's NECESSITY now, not just its staleness. Three read-only survey
+agents covered: (A) loop machinery + working-doc discipline, (B) caps + gate
+scripts, (C) auto-loaded rules + skills.
+
+## The load-bearing structural finding (reframes everything)
+
+**CI's `ci_gate.sh` runs only `zig fmt` + `test-all` (+ extended JIT/DCE/AOT).
+It does NOT run `file_size_check` / `zone_check` / `spill_aware_check`.** Those
+three fire ONLY in the local `gate_commit.sh`. So the caps and smell detectors
+are purely a **local pre-commit affordance** — the authoritative `ci-required`
+PR gate never sees them. Consequence: *relaxing a local check ≈ deleting it*
+(there is no CI backstop). Two forks follow from this, both surfaced below.
+
+## A. Autonomous, doc/config-only (E-段2 executes — cheap CI, no ADR)
+
+| Item | Verdict | Action |
+|---|---|---|
+| `.dev/handover.md` | STALE + reshape | Rewrite to a plain maintenance **state doc**. Currently claims `v2.0.0-alpha.3` / Latest `v1.11.0` / "LOOP CLEAN-STOPPED bucket-3 / re-arm / wakeup" — all false post-v2.0.0. |
+| `continue/SKILL.md`, `LOOP.md`, `RESUME.md` | SIMPLIFY | Strip retired loop mechanics (Steps 6-8 push/kick/`ScheduleWakeup(60)`, `zwasm-from-scratch` push, self-re-arm, "loop never voluntarily exits"). Keep resume + TDD + PR flow, chunk-type taxonomy, anti-patterns. |
+| `continue/{LOOP,RESUME,STOP_BUCKETS}.md` | ARCHIVE | Move under an `archive/` marker (or `.dev/archive/`) so they stop reading as live procedure; keep as dated history. `STOP_BUCKETS.md` fully superseded by SKILL's 3-bucket summary. |
+| `continue/{GATE,REWORK}.md` | KEEP | GATE = scope-adaptive pre-PR verification (banner→`ci-required`); REWORK = ADR-0153 rework procedure, still cited. |
+| `handover_doc_discipline.md` (+ ref) | SIMPLIFY | Drop §1 "forbidden surrender phrase" grep + bucket-3 stop template (existed to stop the LOOP surrendering; no loop now). Keep §2 no-predictions, §6 length cap, fact-source table. |
+| `rules/{extended_challenge,textbook_survey}.md` | SIMPLIFY | Invariant stays live (don't-paper-over-absence; Step-0 survey); deloop the "/continue stop bucket-2" / "the autonomous loop" framing. |
+| `dispatch_consistency_audit/SKILL.md` | RE-SCOPE | Drop the dead "fires after §9.12-B completion" phase trigger (`b9a138f3` done); keep the periodic 3-way axis-match check (`dispatch_collector.zig` still live). |
+| `meta_audit/SKILL.md` | RE-SCOPE | Drop the dead "Phase boundary" auto-trigger; retain as the user-gated skepticism audit. |
+| `.claude/settings.local.json` | PRUNE | Remove the 3 allow entries targeting the retired `-zwasm-from-scratch/memory` working dir (dead grant: an `rm -rf` + 2 reads). |
+| EXEMPT marker prose (instance.zig ~15-line changelog, validator.zig, …) | RELAX | Collapse each to one line (rationale + ADR ref); ADR-0099's revision history already holds the raise-log. Marker-only edits are sanctioned (memory `feedback_filesize_cap_relax_ok`). NOTE: touching a `.zig` file → heavy CI, so batch these with Batch B/C code PRs, not the doc PR. |
+| debt.yaml header "Refresh on every /continue resume Step 0.5" | SIMPLIFY | Reword to "per-session / pre-PR". |
+
+**All 21 auto-loaded rules KEEP** — lean ADR-0118 D2 stubs, path-gated on
+`src/`/`build`/`.dev`, fire on any maintenance edit; none bloated, none
+orphaned, none loop-only in substance. All 24 `references/*.md` KEEP.
+`audit_scaffolding` + `debug_jit_auto` skills KEEP. `zone_check` /
+`spill_aware_check` / `orphan_guard` / `gate_commit` KEEP (see §B caveat).
+
+## B. NEEDS-ADR / user decision (do NOT auto-execute — frozen-invariant land)
+
+These deviate ROADMAP §-protected areas or the CLAUDE.md **Frozen invariants**;
+per §18.2 an ADR is filed first, and the gate-cadence change touches a frozen
+invariant → user ratification, not autonomous.
+
+1. **File-size cap POSTURE** (ADR-0099 D1/D4, ROADMAP §A2/§5). Recommendation:
+   demote the 2000 hard-cap from a `--gate` BLOCK to a WARN (the
+   smell-during-rapid-AI-generation premise is gone; pressure files are all
+   irreducible catalogs/spec-walkers already investigated). Keep the soft-1000
+   WARN as an advisory signal. → **amend ADR-0099**.
+2. **Windows-BATCHED / `--suspend` cadence + `gate_merge.sh`** (ADR-0076 D8,
+   ADR-0174; a CLAUDE.md Frozen invariant). Recommendation: since CI runs the
+   Windows leg on **every PR**, local Windows gating is no longer load-bearing
+   for merge safety — retire `should_gate_windows.sh`'s BATCHED/suspend
+   heuristic, demote `gate_merge.sh` to an optional pre-PR pre-flight. →
+   **amend ADR-0076 / ADR-0174**.
+3. debt.yaml `status` legend (ADR-0129) + `front:` grouping (ADR-0186) — still
+   fit maintenance; **no change** (listed so it's not mistaken for prunable).
+
+## C. The relax-vs-promote fork (decide before touching §B.1/§B.2)
+
+Because CI never runs `file_size_check`/`zone_check`/`spill_aware_check`,
+"relax locally" and "delete" are nearly equivalent. If any of the three is
+judged still load-bearing — **`zone_check`** (Zone 0–3 layering, a real
+architectural guarantee not covered by tests) and **`spill_aware_check`** (a
+bare `resolveGpr` on a spilled vreg → runtime `UnsupportedOp` miscompile) are
+the candidates — the correctness-preserving move is to **add it to
+`ci_gate.sh`** (promote to the authoritative gate) rather than relax it. This
+is a genuine choice for the user:
+- **Promote** zone_check + spill_aware_check into CI → they become real merge
+  gates (slightly slower CI, but enforced for external contributors too).
+- **Leave local-only** → accept they are author-discipline nudges that a
+  contributor bypasses; then relaxing the caps is low-risk.
+
+## Batching plan (CI-frugal)
+
+- **E-段2a (doc-only PR)**: handover rewrite, continue-doc deloop+archive,
+  handover_doc_discipline trim, extended_challenge/textbook_survey deloop,
+  dispatch_consistency_audit + meta_audit re-scope, settings.local.json prune,
+  debt.yaml header reword, this report. One doc-only PR → `ci-required` near-instant.
+- **EXEMPT-marker prose collapse**: ride Batch B/C (they already touch `.zig`).
+- **§B ADR items + §C fork**: surface to user; on ratification, one ADR PR
+  (doc-only) then the script edits.
+
+## Source
+
+Read-only survey agents 2026-07-03 (A: loop docs, B: caps/scripts, C: rules/skills).
+Anchors: ADR-0099 (caps), ADR-0076/0174 (gate cadence), ADR-0118 (rule stubs),
+ADR-0129/0186 (debt schema), ADR-0153 (rework). Memory:
+`feedback_filesize_cap_relax_ok`, `feedback_system_defenses_over_scripts`.


### PR DESCRIPTION
Post-v2.0.0 the autonomous `/continue` build-campaign loop is **retired**. This audits the dev scaffolding (scripts / rules / skills / docs) for **necessity under the changed premise** and de-loops the parts that lied about it. **Doc/config-only** → `ci-required` near-instant.

## Landed here (autonomous, unambiguous)
- **E-段1 report** `.dev/meta_audits/2026-07-03-maintenance-scaffolding-audit.md` — full necessity audit from 3 read-only survey agents.
- **`.dev/handover.md`** — rewritten from the stale `v2.0.0-alpha.3` / `v1.11.0` / "LOOP CLEAN-STOPPED bucket-3" narrative to a plain maintenance **state doc** (v2.0.0 on main, v1 frozen `v1.11.1`, `develop/<slug>`→PR, release user-only). Operational invariants + parked list preserved.
- **`dispatch_consistency_audit`** — post-§9.12-B mode is now ACTIVE (substrate exists); dropped the dead phase-boundary trigger, kept the periodic one.
- **`meta_audit`** — dropped the dead campaign phase-boundary auto-trigger; stays user-gated.
- **`settings.local.json`** (local, gitignored — not in this diff) — pruned 3 dead grants targeting the retired `-zwasm-from-scratch` working dir.

## The load-bearing finding
CI's `ci_gate.sh` runs only `zig fmt` + `test-all` (+ JIT/DCE/AOT). It **never** runs `file_size_check` / `zone_check` / `spill_aware_check` — those fire only in local `gate_commit.sh`. So the caps + smell detectors are author-nudges the `ci-required` gate never sees → **"relax locally" ≈ "delete"**.

## Held for your decision (NOT done here — see report §A/§B/§C)
**Doc-only, low-risk (can do on your OK):**
- Archive the retired `continue/{LOOP,RESUME,STOP_BUCKETS}.md` under an `archive/` marker; deloop the framing in `handover_doc_discipline` (drop the surrender-phrase grep + bucket-3 stop), `extended_challenge`, `textbook_survey` (keep the invariants, drop the loop wording).

**NEEDS-ADR / genuine choices:**
1. **File-size cap posture** (ADR-0099): demote the 2000 hard-cap from a commit-BLOCK to a WARN? The smell-during-rapid-AI-generation premise is gone; pressure files are all irreducible catalogs. + collapse the heavy EXEMPT-marker changelogs (instance.zig ~15 lines) to one line.
2. **Windows-BATCHED / `--suspend` + `gate_merge.sh`** (ADR-0076/0174, a Frozen invariant): CI runs Windows on every PR, so local Windows gating is no longer merge-load-bearing — retire the BATCHED/suspend heuristic, demote `gate_merge.sh` to optional pre-flight?
3. **relax-vs-promote fork**: since CI never runs `zone_check`/`spill_aware_check`, if they're load-bearing the correctness-preserving move is to **add them to `ci_gate.sh`** (real merge gates) rather than relax. Promote, or accept them as local-only nudges?

---
Part of the batched maintenance series (A ledger #118 · **E scaffolding** · B Component域 · C table64-JIT · D held). Opened for review — not auto-merging.