### PR TITLE
feat(component): D-502 utf16/latin1+utf16 string encodings + D-504 wasi_p2 hardening (Batch B)

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -3,27 +3,6 @@
 # Refresh on every /continue resume — .claude/skills/continue/RESUME.md Step 0.5.
 
 entries:
-  - id: "D-504"
-    layer: "code"
-    status: "note"
-    description: |-
-      note (low, defensible-by-design but undocumented abort surface): the
-      WASI-P2 clock/random builtins `@panic` if `host.io` is unset
-      (component_wasi_p2.zig — 5 sites). The component-run path always plants
-      `host.io`, so this is a host-SETUP precondition failure, NOT a
-      guest-triggerable trap (contrast D-495's guarded guest-reachable path).
-      Still, an `@panic` is a hard host abort where a `return error.HostIoUnset`
-      (surfaced as an instantiate/link error) would be the あるべき論. DISCHARGE:
-      replace the 5 `@panic` sites with a defensive error return + a one-line
-      doc comment stating the precondition. Rides Batch B (component域); pairs
-      with the fd.zig:808 comment-rot fix (CREAT/EXCL/TRUNC are actually
-      honoured at 854-863 — the "for now" docstring is stale).
-    first_raised: "2026-07-03"
-    last_reviewed: "2026-07-03"
-    refs: |-
-      src/api/component_wasi_p2.zig:289,301,394,890,903 (@panic if host.io unset) ·
-      src/wasi/fd.zig:808 (stale "for now" docstring; body 854-863 honours oflags) ·
-      sibling D-495 (guarded guest-reachable surface, the contrast case)
   - id: "D-503"
     layer: "code"
     status: "note"
@@ -46,28 +25,30 @@ entries:
       src/validate/validator.zig (3392/3510) · ADR-0099 · memory feedback_filesize_cap_relax_ok
   - id: "D-502"
     layer: "code"
-    status: "partial"
+    status: "note"
     description: |-
-      Component Model canonical-ABI `utf16` / `latin1+utf16` string encodings
-      are unimplemented — `lift/lowerString` reject any non-utf8 `string_encoding`
-      with `StringError.UnsupportedEncoding` (canon.zig:285,298, guard-only). Only
-      utf8 lift/lower is wired; the `StringEncoding` enum + the latin1/utf16 tag
-      bit (canon.zig:269) are defined but the lowering/lifting bodies were left
-      "implemented in the next chunk" (canon.zig:276) and never landed. This is a
-      real CM canonical-ABI surface gap (a component declaring `string-encoding`
-      utf16/latin1+utf16 in its canon opts fails to lift/lower strings), distinct
-      from debt D-445's task.return encoding-MISMATCH check. Clean-errors rather
-      than miscompiles (no silent wrong answer). DISCHARGE: implement utf16 +
-      latin1+utf16 lift/lower (UTF-16LE codec + the latin1/utf16 discriminated
-      path per Canonical ABI §String) + flip the two negative fixtures
-      (canon.zig:730-731) to positive round-trips. Reference: wasmtime
-      `crates/wasmtime/src/runtime/component/func/options.rs` StringEncoding +
-      `~/Documents/OSS/WebAssembly/component-model` CanonicalABI.md. Rides Batch B.
+      RESOLVED at the canon layer (Batch B): Component Model canonical-ABI
+      `utf16` / `latin1+utf16` string encodings are now IMPLEMENTED on both the
+      lower path (@69d7c8b75) and the lift path (@298444253). `lowerString`
+      dispatches utf8/utf16/latin1_utf16; `liftString` gained an `arena` param and
+      returns a uniformly OWNED host-UTF-8 buffer (utf8 copied; utf16 /
+      latin1+utf16 transcoded — UTF-16LE codec + surrogate pairs + the
+      UTF16_TAG-bit latin1/utf16 discriminant). `StringError += InvalidUtf16,
+      OutOfMemory`; fixtures cover round-trips (incl. a supplementary code point)
+      + dangling-surrogate / unaligned-ptr traps.
+      RESIDUAL (smaller, distinct): the component-INVOKE convenience path
+      `invokeStringExport` (component.zig) still hard-gates to utf8
+      (`r.string_encoding != .utf8 → UnsupportedEncoding`) — it does not yet
+      thread the resolved lift-func `string-encoding` into `invokeString`'s
+      CanonContext. The codec is done; only the invoke-path plumbing remains.
+      DISCHARGE (residual): thread the resolved encoding into invokeString's
+      CanonContext + drop the utf8 gate + add a non-utf8 export round-trip fixture.
     first_raised: "2026-07-03"
     last_reviewed: "2026-07-03"
     refs: |-
-      src/feature/component/canon.zig:223,269,276,285,298 (StringEncoding + UnsupportedEncoding guards) ·
-      canon.zig:730-731 (negative fixtures to flip) · ~/Documents/OSS/WebAssembly/component-model/design/mvp/CanonicalABI.md
+      src/feature/component/canon.zig (lowerString / liftString / liftUtf16 / liftLatin1 — DONE) ·
+      src/api/component.zig invokeStringExport (residual utf8 gate) ·
+      ~/Documents/OSS/WebAssembly/component-model/design/mvp/CanonicalABI.md §String
   - id: "D-501"
     layer: "code"
     status: "note"

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -15,13 +15,17 @@ publish / cut over. No active campaign/bundle; no cron self-re-arm.
 ## Active maintenance work (batched to keep CI frugal)
 
 Post-v2.0.0 sweep (see `.dev/meta_audits/2026-07-03-maintenance-scaffolding-audit.md`):
-- **Batch A — ledger/proposal reconcile** (doc-only) — PR #118 OPEN, `ci-required` green.
-  Debt reconciled vs code truth: closed D-294/296/297/322/500, reclassified
-  D-254→now / D-249→note, recorded D-502/503/504. Ledger → 62 entries, ZERO now-class.
-- **E — scaffolding necessity audit** — report landed; E-段2 prunes in flight on
-  `develop/scaffolding-maintenance` (deloop retired-campaign docs, cap-posture +
-  gate-cadence changes are NEEDS-ADR → user-gated, see the report §B/§C).
-- **Batch B (Component域)** + **Batch C (table64-JIT)** = queued code PRs (below). **D held.**
+- **Batch A — ledger/proposal reconcile** (doc-only) — MERGED #118. Debt reconciled
+  vs code truth (closed D-294/296/297/322/500; reclassified D-254→now / D-249→note).
+- **Batch E — scaffolding necessity audit** (doc-only) — MERGED #119. handover reshaped
+  to a state doc; retired-loop skill triggers de-looped. **Pending USER decisions**
+  (report §B/§C): file-size cap posture (ADR-0099), Windows-BATCHED / `gate_merge`
+  cadence (ADR-0076/0174), and the relax-vs-promote-to-`ci_gate` fork.
+- **Batch B — Component域** (code) — MERGED #120. D-502 utf16/latin1+utf16 canon
+  string codec (lower+lift) COMPLETE (residual = `invokeStringExport` utf8-gate, see
+  the D-502 note); D-504 discharged (wasi_p2 @panic→NoHostIo + fd.zig doc-rot).
+- **Batch C — table64-JIT** (D-475) = queued code PR (Win64-risk, do with FRESH
+  context). **D held.** **D-444** (component_wasi_p2 split) gated on the cap-posture decision.
 
 ## Operational invariants (keep using)
 
@@ -61,7 +65,7 @@ Post-v2.0.0 sweep (see `.dev/meta_audits/2026-07-03-maintenance-scaffolding-audi
   dogfooded into cljw (pins zwasm by git tag-hash). Runners ReleaseSafe.
 - **EH**: cross-instance JIT EH both arches. Interp+JIT EH corpus green. Realworld 56
   fixtures interp 56/0; JIT diff-gated.
-- **Debt**: 62 entries — ZERO `now`-class (after Batch A). 完成形 plateau (all dims
+- **Debt**: 61 entries — ZERO `now`-class (after Batch A/B). 完成形 plateau (all dims
   confirmed, surface audits clean, interp+JIT fuzz 0-crash, v1-JIT parity D-265 closed).
 - **Proposals**: reviewed 2026-07-03; no phase advances; 3.0 corpora unaffected.
 

--- a/src/api/component.zig
+++ b/src/api/component.zig
@@ -213,8 +213,9 @@ pub const ComponentInstance = struct {
         const cx2 = try self.canonContext();
         const out_ptr = try readU32LE(cx2.mem(), ret_ptr);
         const out_len = try readU32LE(cx2.mem(), ret_ptr + 4);
-        const borrowed = try canon.liftString(cx2, out_ptr, out_len);
-        const owned = try out_alloc.dupe(u8, borrowed);
+        // liftString allocates the (possibly transcoded) result directly into
+        // out_alloc — an owned host copy, independent of guest memory.
+        const owned = try canon.liftString(cx2, out_alloc, out_ptr, out_len);
         errdefer out_alloc.free(owned);
 
         if (post_return) |pr| {

--- a/src/api/component_graph.zig
+++ b/src/api/component_graph.zig
@@ -1700,7 +1700,8 @@ fn boundaryMarshal(caller: *Caller, bctx: *BoundaryCtx, args: []const RtValue) B
 fn stringErrToTrap(e: canon.StringError) BoundaryError {
     return switch (e) {
         error.OutOfBounds, error.AllocFailed => error.OutOfBoundsStore,
-        error.InvalidUtf8, error.StringTooLong, error.UnsupportedEncoding => error.OutOfBoundsLoad,
+        error.OutOfMemory => error.OutOfMemory,
+        error.InvalidUtf8, error.InvalidUtf16, error.StringTooLong, error.UnsupportedEncoding => error.OutOfBoundsLoad,
     };
 }
 
@@ -1734,16 +1735,15 @@ fn retPtrMarshal(caller: *Caller, bctx: *BoundaryCtx, retptr: u32) BoundaryError
     if (@as(usize, callee_ret) + 8 > callee_cx.mem().len) return error.OutOfBoundsLoad;
     const b_ptr = std.mem.readInt(u32, callee_cx.mem()[callee_ret..][0..4], .little);
     const b_len = std.mem.readInt(u32, callee_cx.mem()[callee_ret + 4 ..][0..4], .little);
-    const lifted = canon.liftString(callee_cx, b_ptr, b_len) catch |e| return stringErrToTrap(e);
+    const lifted = canon.liftString(callee_cx, caller.allocator(), b_ptr, b_len) catch |e| return stringErrToTrap(e);
+    defer caller.allocator().free(lifted);
 
-    // 3. Lower the string into the IMPORTER's memory (snapshot first: the lift
-    //    borrows callee memory, the lower realloc may move it). Then write the
-    //    A-side (ptr,len) at the importer's retptr in the importer's memory.
+    // 3. Lower the string into the IMPORTER's memory. `lifted` is an OWNED host
+    //    copy (independent of callee memory), so the importer's realloc moving
+    //    its own memory can't disturb it. Write the A-side (ptr,len) at retptr.
     const importer = bctx.importer orelse return error.OutOfBoundsStore;
-    const tmp = try caller.allocator().dupe(u8, lifted);
-    defer caller.allocator().free(tmp);
     const importer_cx = importer.canonContext();
-    const lowered = canon.lowerString(importer_cx, tmp) catch |e| return stringErrToTrap(e);
+    const lowered = canon.lowerString(importer_cx, lifted) catch |e| return stringErrToTrap(e);
     if (@as(usize, retptr) + 8 > importer_cx.mem().len) return error.OutOfBoundsStore;
     std.mem.writeInt(u32, importer_cx.mem()[retptr..][0..4], lowered.ptr, .little);
     std.mem.writeInt(u32, importer_cx.mem()[retptr + 4 ..][0..4], lowered.packed_length, .little);
@@ -1844,16 +1844,15 @@ fn strRetStrTrampoline(caller: *Caller, param_ptr: u32, param_len: u32, retptr: 
     if (@as(usize, callee_ret) + 8 > callee_cx.mem().len) return error.OutOfBoundsLoad;
     const b_ptr = std.mem.readInt(u32, callee_cx.mem()[callee_ret..][0..4], .little);
     const b_len = std.mem.readInt(u32, callee_cx.mem()[callee_ret + 4 ..][0..4], .little);
-    const lifted = canon.liftString(callee_cx, b_ptr, b_len) catch |e| return stringErrToTrap(e);
+    const lifted = canon.liftString(callee_cx, caller.allocator(), b_ptr, b_len) catch |e| return stringErrToTrap(e);
+    defer caller.allocator().free(lifted);
 
-    // 4. Lower the string into the IMPORTER's memory (snapshot first: the lift
-    //    borrows callee memory, the lower realloc may move it). Then write the
-    //    A-side (ptr,len) at the importer's retptr in the importer's memory.
+    // 4. Lower the string into the IMPORTER's memory. `lifted` is an OWNED host
+    //    copy (independent of callee memory), so the importer's realloc moving
+    //    its own memory can't disturb it. Write the A-side (ptr,len) at retptr.
     const importer = bctx.importer orelse return error.OutOfBoundsStore;
-    const tmp = try caller.allocator().dupe(u8, lifted);
-    defer caller.allocator().free(tmp);
     const importer_cx = importer.canonContext();
-    const lowered = canon.lowerString(importer_cx, tmp) catch |e| return stringErrToTrap(e);
+    const lowered = canon.lowerString(importer_cx, lifted) catch |e| return stringErrToTrap(e);
     if (@as(usize, retptr) + 8 > importer_cx.mem().len) return error.OutOfBoundsStore;
     std.mem.writeInt(u32, importer_cx.mem()[retptr..][0..4], lowered.ptr, .little);
     std.mem.writeInt(u32, importer_cx.mem()[retptr + 4 ..][0..4], lowered.packed_length, .little);

--- a/src/api/component_tests.zig
+++ b/src/api/component_tests.zig
@@ -314,7 +314,8 @@ test "IT-3a: cabi_realloc-via-guest — string lower/lift over real guest memory
     const lowered = try canon.lowerString(cx, "héllo, 世界");
     try testing.expect(lowered.ptr >= 16); // past the bump start
     // ...and lift it back out of the guest linear memory.
-    const back = try canon.liftString(cx, lowered.ptr, lowered.packed_length);
+    const back = try canon.liftString(cx, testing.allocator, lowered.ptr, lowered.packed_length);
+    defer testing.allocator.free(back);
     try testing.expectEqualStrings("héllo, 世界", back);
 }
 
@@ -343,8 +344,12 @@ test "IT-3a: two allocations via the guest allocator don't overlap" {
     const a = try canon.lowerString(cx, "first");
     const b = try canon.lowerString(cx, "second");
     try testing.expect(b.ptr >= a.ptr + a.packed_length); // bump advanced
-    try testing.expectEqualStrings("first", try canon.liftString(cx, a.ptr, a.packed_length));
-    try testing.expectEqualStrings("second", try canon.liftString(cx, b.ptr, b.packed_length));
+    const back_a = try canon.liftString(cx, testing.allocator, a.ptr, a.packed_length);
+    defer testing.allocator.free(back_a);
+    try testing.expectEqualStrings("first", back_a);
+    const back_b = try canon.liftString(cx, testing.allocator, b.ptr, b.packed_length);
+    defer testing.allocator.free(back_b);
+    try testing.expectEqualStrings("second", back_b);
 }
 
 /// Provenance of the REAL string→string component fixture (`greet(name: string)

--- a/src/api/component_wasi_p2.zig
+++ b/src/api/component_wasi_p2.zig
@@ -286,7 +286,7 @@ fn p2Exit(caller: *Caller, status: u32) WasiP2Error!void {
 fn p2MonotonicNow(caller: *Caller) WasiP2Error!i64 {
     const ctx = caller.data(WasiP2Ctx);
     const ns = wasi_clocks.clockTimeNs(ctx.host, 1) catch
-        @panic("WASI-P2 monotonic-clock.now: host clock unavailable (host.io unset)");
+        return WasiP2Error.NoHostIo; // precondition: the component-run path plants host.io
     return @bitCast(ns);
 }
 
@@ -298,7 +298,7 @@ fn p2WallNow(caller: *Caller, retptr: u32) WasiP2Error!void {
     const ctx = caller.data(WasiP2Ctx);
     const mem = try ctxMemory(caller);
     const ns = wasi_clocks.clockTimeNs(ctx.host, 0) catch
-        @panic("WASI-P2 wall-clock.now: host clock unavailable (host.io unset)");
+        return WasiP2Error.NoHostIo; // precondition: the component-run path plants host.io
     try mem.write(retptr, @as(u64, ns / std.time.ns_per_s));
     try mem.write(retptr + 8, @as(u32, @intCast(ns % std.time.ns_per_s)));
 }
@@ -391,7 +391,7 @@ fn p2RandomGetBytes(caller: *Caller, len: u64, retptr: u32) WasiP2Error!void {
     if (n != 0) {
         const dest = mem.sliceAt(data_ptr, n) catch return WasiP2Error.OutOfBounds;
         if (wasi_clocks.randomFill(ctx.host, dest) != .success)
-            @panic("WASI-P2 get-random-bytes: secure random unavailable (host.io unset)");
+            return WasiP2Error.NoHostIo; // precondition: the component-run path plants host.io
     }
     try mem.write(retptr, data_ptr); // list data ptr
     try mem.write(retptr + 4, n); // list length
@@ -887,7 +887,7 @@ fn p2RandomGetU64(caller: *Caller) WasiP2Error!i64 {
     const ctx = caller.data(WasiP2Ctx);
     var buf: [8]u8 = undefined;
     if (wasi_clocks.randomFill(ctx.host, &buf) != .success)
-        @panic("WASI-P2 get-random-u64: secure random unavailable (host.io unset)");
+        return WasiP2Error.NoHostIo; // precondition: the component-run path plants host.io
     return @bitCast(std.mem.readInt(u64, &buf, .little));
 }
 
@@ -900,7 +900,7 @@ fn p2RandomInsecureSeed(caller: *Caller, retptr: u32) WasiP2Error!void {
     const mem = try ctxMemory(caller);
     var buf: [16]u8 = undefined;
     if (wasi_clocks.randomFill(ctx.host, &buf) != .success)
-        @panic("WASI-P2 insecure-seed: secure random unavailable (host.io unset)");
+        return WasiP2Error.NoHostIo; // precondition: the component-run path plants host.io
     try mem.write(retptr, std.mem.readInt(u64, buf[0..8], .little));
     try mem.write(retptr + 8, std.mem.readInt(u64, buf[8..16], .little));
 }

--- a/src/feature/component/canon.zig
+++ b/src/feature/component/canon.zig
@@ -279,8 +279,14 @@ pub const LoweredString = struct { ptr: u32, packed_length: u32 };
 pub const StringError = error{
     OutOfBounds,
     InvalidUtf8,
+    /// A lone/mismatched UTF-16 surrogate encountered while lifting a utf16 /
+    /// latin1+utf16 guest string.
+    InvalidUtf16,
     StringTooLong,
-    /// utf16 / latin1+utf16 lowering/lifting — implemented in the next chunk.
+    /// The host arena allocation backing a lifted (transcoded) string failed.
+    OutOfMemory,
+    /// A `string-encoding` a higher layer (e.g. `invokeStringExport`) doesn't
+    /// yet thread through; the canon codec itself supports all three encodings.
     UnsupportedEncoding,
 } || ReallocError;
 
@@ -377,17 +383,77 @@ fn writeUtf16LeInto(dst: []u8, s: []const u8) void {
     }
 }
 
-/// Lift a guest UTF-8 string (`load_string_from_range`): bounds-check + UTF-8
-/// validate the `[ptr, ptr+byte_length)` range. Returns a slice BORROWING
-/// guest memory (valid until the memory is mutated).
-pub fn liftString(cx: CanonContext, ptr: u32, packed_length: u32) StringError![]const u8 {
-    if (cx.string_encoding != .utf8) return StringError.UnsupportedEncoding;
-    const byte_length = packed_length; // utf8: code units == bytes, no tag bit
+/// Lift a guest string into HOST UTF-8 per the component's `string-encoding`
+/// (`CanonicalABI.md` `load_string_from_range`). The result is ALWAYS allocated
+/// from `arena` (uniform ownership): utf8 is validated + copied; utf16 /
+/// latin1+utf16 are transcoded. (utf8 alone could borrow guest memory, but the
+/// two non-utf8 encodings MUST allocate to transcode, so a uniform arena-owned
+/// contract avoids a mixed borrow/owned return the callers would have to reason
+/// about.)
+pub fn liftString(cx: CanonContext, arena: std.mem.Allocator, ptr: u32, packed_length: u32) StringError![]u8 {
+    switch (cx.string_encoding) {
+        .utf8 => {
+            const byte_length = packed_length; // code units == bytes, no tag bit
+            if (byte_length > MAX_STRING_BYTE_LENGTH) return StringError.StringTooLong;
+            if (@as(usize, ptr) + byte_length > cx.mem().len) return StringError.OutOfBounds;
+            const bytes = cx.mem()[ptr..][0..byte_length];
+            if (!std.unicode.utf8ValidateSlice(bytes)) return StringError.InvalidUtf8;
+            return arena.dupe(u8, bytes) catch return StringError.OutOfMemory;
+        },
+        .utf16 => return liftUtf16(cx, arena, ptr, packed_length),
+        .latin1_utf16 => {
+            if (packed_length & UTF16_TAG != 0)
+                return liftUtf16(cx, arena, ptr, packed_length & ~UTF16_TAG);
+            return liftLatin1(cx, arena, ptr, packed_length);
+        },
+    }
+}
+
+/// utf16 lift: `packed_length` is the code-unit count, byte_length = 2×units,
+/// guest ptr must be 2-aligned. Decode UTF-16LE (surrogate pairs) → host UTF-8.
+fn liftUtf16(cx: CanonContext, arena: std.mem.Allocator, ptr: u32, code_units: u32) StringError![]u8 {
+    if (code_units > MAX_STRING_BYTE_LENGTH) return StringError.StringTooLong;
+    const byte_length: usize = @as(usize, code_units) * 2;
+    if (ptr % 2 != 0) return StringError.OutOfBounds; // spec: utf16 range is 2-aligned
+    if (@as(usize, ptr) + byte_length > cx.mem().len) return StringError.OutOfBounds;
+    const src = cx.mem()[ptr..][0..byte_length];
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(arena);
+    var i: usize = 0;
+    while (i < byte_length) {
+        const unit = std.mem.readInt(u16, src[i..][0..2], .little);
+        i += 2;
+        var cp: u21 = undefined;
+        if (unit >= 0xD800 and unit <= 0xDBFF) {
+            if (i + 2 > byte_length) return StringError.InvalidUtf16; // dangling high surrogate
+            const lo = std.mem.readInt(u16, src[i..][0..2], .little);
+            if (lo < 0xDC00 or lo > 0xDFFF) return StringError.InvalidUtf16;
+            i += 2;
+            cp = 0x10000 + (@as(u21, unit - 0xD800) << 10) + (lo - 0xDC00);
+        } else if (unit >= 0xDC00 and unit <= 0xDFFF) {
+            return StringError.InvalidUtf16; // lone low surrogate
+        } else cp = unit;
+        var buf: [4]u8 = undefined;
+        const n = std.unicode.utf8Encode(cp, &buf) catch return StringError.InvalidUtf16;
+        out.appendSlice(arena, buf[0..n]) catch return StringError.OutOfMemory;
+    }
+    return out.toOwnedSlice(arena) catch return StringError.OutOfMemory;
+}
+
+/// latin1 lift: one byte per code point (each < 0x100 → always a valid scalar),
+/// transcode to host UTF-8.
+fn liftLatin1(cx: CanonContext, arena: std.mem.Allocator, ptr: u32, byte_length: u32) StringError![]u8 {
     if (byte_length > MAX_STRING_BYTE_LENGTH) return StringError.StringTooLong;
     if (@as(usize, ptr) + byte_length > cx.mem().len) return StringError.OutOfBounds;
-    const bytes = cx.mem()[ptr..][0..byte_length];
-    if (!std.unicode.utf8ValidateSlice(bytes)) return StringError.InvalidUtf8;
-    return bytes;
+    const src = cx.mem()[ptr..][0..byte_length];
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(arena);
+    for (src) |b| {
+        var buf: [2]u8 = undefined;
+        const n = std.unicode.utf8Encode(@as(u21, b), &buf) catch unreachable; // b < 0x100
+        out.appendSlice(arena, buf[0..n]) catch return StringError.OutOfMemory;
+    }
+    return out.toOwnedSlice(arena) catch return StringError.OutOfMemory;
 }
 
 pub const LiftError = error{
@@ -577,7 +643,7 @@ pub fn load(cx: CanonContext, arena: std.mem.Allocator, ty: CanonType, ptr: u32)
             .string => {
                 const sptr: u32 = @intCast(try loadInt(cx, ptr, 4));
                 const slen: u32 = @intCast(try loadInt(cx, ptr + 4, 4));
-                return .{ .string = try liftString(cx, sptr, slen) };
+                return .{ .string = try liftString(cx, arena, sptr, slen) };
             },
             .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .error_context => return lift(coreFromBits(try loadInt(cx, ptr, primSize(p)), p), p),
         },
@@ -779,7 +845,8 @@ test "round-trip: utf8 string guest↔host via realloc + memory" {
 
     const lowered = try lowerString(cx, "héllo, 世界"); // multibyte utf8
     try testing.expect(lowered.ptr >= 8);
-    const back = try liftString(cx, lowered.ptr, lowered.packed_length);
+    const back = try liftString(cx, testing.allocator, lowered.ptr, lowered.packed_length);
+    defer testing.allocator.free(back);
     try testing.expectEqualStrings("héllo, 世界", back);
 }
 
@@ -790,7 +857,9 @@ test "round-trip: empty string" {
     const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc };
     const lowered = try lowerString(cx, "");
     try testing.expectEqual(@as(u32, 0), lowered.packed_length);
-    try testing.expectEqualStrings("", try liftString(cx, lowered.ptr, lowered.packed_length));
+    const back = try liftString(cx, testing.allocator, lowered.ptr, lowered.packed_length);
+    defer testing.allocator.free(back);
+    try testing.expectEqualStrings("", back);
 }
 
 test "lift: out-of-bounds range rejected" {
@@ -798,7 +867,7 @@ test "lift: out-of-bounds range rejected" {
     var bump = Bump{ .next = 0 };
     var mem_slice: []u8 = &mem;
     const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc };
-    try testing.expectError(StringError.OutOfBounds, liftString(cx, 4, 100));
+    try testing.expectError(StringError.OutOfBounds, liftString(cx, testing.allocator, 4, 100));
 }
 
 test "lift: invalid utf8 rejected" {
@@ -806,7 +875,7 @@ test "lift: invalid utf8 rejected" {
     var bump = Bump{ .next = 0 };
     var mem_slice: []u8 = &mem;
     const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc };
-    try testing.expectError(StringError.InvalidUtf8, liftString(cx, 0, 2));
+    try testing.expectError(StringError.InvalidUtf8, liftString(cx, testing.allocator, 0, 2));
 }
 
 test "lowerString utf16: BMP + supplementary (surrogate pair)" {
@@ -834,6 +903,53 @@ test "lowerString latin1+utf16: all-latin1 stays latin1, mixed flips to tagged u
     const l2 = try lowerString(cx, "A\u{03BB}");
     try testing.expectEqual(@as(u32, 2 | UTF16_TAG), l2.packed_length);
     try testing.expectEqualSlices(u8, &[_]u8{ 0x41, 0x00, 0xBB, 0x03 }, mem[l2.ptr..][0..4]);
+}
+
+test "round-trip utf16: host↔guest via lower + lift (incl. supplementary)" {
+    var mem = [_]u8{0} ** 64;
+    var bump = Bump{ .next = 0 };
+    var mem_slice: []u8 = &mem;
+    const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc, .string_encoding = .utf16 };
+    const s = "Aé世\u{10437}"; // 1/2/3-byte utf8 + a supplementary (surrogate-pair) code point
+    const lowered = try lowerString(cx, s);
+    const back = try liftString(cx, testing.allocator, lowered.ptr, lowered.packed_length);
+    defer testing.allocator.free(back);
+    try testing.expectEqualStrings(s, back);
+}
+
+test "round-trip latin1+utf16: latin1 path and tagged-utf16 path both survive" {
+    var mem = [_]u8{0} ** 64;
+    var bump = Bump{ .next = 0 };
+    var mem_slice: []u8 = &mem;
+    const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc, .string_encoding = .latin1_utf16 };
+    const latin1 = "A\u{00FF}"; // all < 0x100 → latin1, no tag
+    const l1 = try lowerString(cx, latin1);
+    try testing.expectEqual(@as(u32, 0), l1.packed_length & UTF16_TAG);
+    const b1 = try liftString(cx, testing.allocator, l1.ptr, l1.packed_length);
+    defer testing.allocator.free(b1);
+    try testing.expectEqualStrings(latin1, b1);
+    const mixed = "A\u{03BB}世"; // ≥ 0x100 → tagged utf16
+    const l2 = try lowerString(cx, mixed);
+    try testing.expect(l2.packed_length & UTF16_TAG != 0);
+    const b2 = try liftString(cx, testing.allocator, l2.ptr, l2.packed_length);
+    defer testing.allocator.free(b2);
+    try testing.expectEqualStrings(mixed, b2);
+}
+
+test "lift utf16: dangling high surrogate rejected" {
+    var mem = [_]u8{ 0x00, 0xD8, 0, 0, 0, 0, 0, 0 }; // lone high surrogate U+D800 (LE)
+    var bump = Bump{ .next = 0 };
+    var mem_slice: []u8 = &mem;
+    const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc, .string_encoding = .utf16 };
+    try testing.expectError(StringError.InvalidUtf16, liftString(cx, testing.allocator, 0, 1));
+}
+
+test "lift utf16: unaligned ptr rejected" {
+    var mem = [_]u8{0} ** 8;
+    var bump = Bump{ .next = 0 };
+    var mem_slice: []u8 = &mem;
+    const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc, .string_encoding = .utf16 };
+    try testing.expectError(StringError.OutOfBounds, liftString(cx, testing.allocator, 1, 1)); // ptr=1 not 2-aligned
 }
 
 test "store/load round-trip: list<u32>" {
@@ -1243,7 +1359,7 @@ pub fn liftFlat(cx: CanonContext, arena: std.mem.Allocator, t: CanonType, flats:
             .string => {
                 const ptr: u32 = @bitCast((try takeFlat(flats, idx, .i32)).i32);
                 const plen: u32 = @bitCast((try takeFlat(flats, idx, .i32)).i32);
-                return .{ .string = try liftString(cx, ptr, plen) };
+                return .{ .string = try liftString(cx, arena, ptr, plen) };
             },
             .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .error_context => {
                 const ct = flatCoreType(p) orelse return LiftFlatError.ValueTypeMismatch;

--- a/src/feature/component/canon.zig
+++ b/src/feature/component/canon.zig
@@ -269,6 +269,13 @@ pub const BorrowRepError = error{ NoResourceContext, InvalidHandle };
 /// 28 bits (leaves the high bit free as the latin1/utf16 tag).
 pub const MAX_STRING_BYTE_LENGTH: u32 = (1 << 28) - 1;
 
+/// `CanonicalABI.md` UTF16_TAG — bit 31 of the packed length. Set on a
+/// latin1+utf16 string that had to be stored as utf16 (a code point ≥ 0x100);
+/// clear means the payload is latin1 (1 byte per code point).
+pub const UTF16_TAG: u32 = 1 << 31;
+
+pub const LoweredString = struct { ptr: u32, packed_length: u32 };
+
 pub const StringError = error{
     OutOfBounds,
     InvalidUtf8,
@@ -277,18 +284,97 @@ pub const StringError = error{
     UnsupportedEncoding,
 } || ReallocError;
 
-/// Lower a host UTF-8 string into guest memory (`store_string_into_range`):
-/// allocate `len` bytes via the guest realloc, copy the bytes, and return the
-/// `(ptr, packed_length)` pair the canonical ABI flattens to two i32s. For
-/// utf8 `packed_length == byte_length` (no tag bit).
-pub fn lowerString(cx: CanonContext, s: []const u8) StringError!struct { ptr: u32, packed_length: u32 } {
-    if (cx.string_encoding != .utf8) return StringError.UnsupportedEncoding;
+/// Lower a host UTF-8 string into guest memory per the component's declared
+/// `string-encoding` (`CanonicalABI.md` `store_string`). The host source is
+/// ALWAYS validated UTF-8, so this is the 3-destination subset of the spec
+/// (utf8 → {utf8, utf16, latin1+utf16}); there is no utf16-source machinery.
+/// Returns the `(ptr, packed_length)` pair the canonical ABI flattens to two i32s.
+pub fn lowerString(cx: CanonContext, s: []const u8) StringError!LoweredString {
+    return switch (cx.string_encoding) {
+        .utf8 => lowerUtf8(cx, s),
+        .utf16 => lowerUtf16(cx, s),
+        .latin1_utf16 => lowerLatin1OrUtf16(cx, s),
+    };
+}
+
+/// utf8 dest: copy bytes verbatim, align 1, `packed_length == byte_length`.
+fn lowerUtf8(cx: CanonContext, s: []const u8) StringError!LoweredString {
     if (s.len > MAX_STRING_BYTE_LENGTH) return StringError.StringTooLong;
     const byte_len: u32 = @intCast(s.len);
     const ptr = try cx.realloc(0, 0, 1, byte_len);
     if (@as(usize, ptr) + s.len > cx.mem().len) return StringError.OutOfBounds;
     @memcpy(cx.mem()[ptr..][0..s.len], s);
     return .{ .ptr = ptr, .packed_length = byte_len };
+}
+
+/// utf16 dest (`store_utf8_to_utf16`): host UTF-8 is validated, so the exact
+/// code-unit count is known up front (no worst-case-alloc + shrink). align 2,
+/// `packed_length == code_units` (no tag).
+fn lowerUtf16(cx: CanonContext, s: []const u8) StringError!LoweredString {
+    const units = std.unicode.calcUtf16LeLen(s) catch return StringError.InvalidUtf8;
+    if (units > MAX_STRING_BYTE_LENGTH) return StringError.StringTooLong;
+    const code_units: u32 = @intCast(units);
+    const byte_len = code_units * 2;
+    const ptr = try cx.realloc(0, 0, 2, byte_len);
+    if (@as(usize, ptr) + byte_len > cx.mem().len) return StringError.OutOfBounds;
+    writeUtf16LeInto(cx.mem()[ptr..][0..byte_len], s);
+    return .{ .ptr = ptr, .packed_length = code_units };
+}
+
+/// latin1+utf16 dest (`store_string_to_latin1_or_utf16`): latin1 (1 byte/char)
+/// iff every code point < 0x100, else utf16 with `UTF16_TAG` set. We SCAN the
+/// source first — the observable result (bytes + packed length) is identical to
+/// the spec's in-place inflate, with fewer footguns.
+fn lowerLatin1OrUtf16(cx: CanonContext, s: []const u8) StringError!LoweredString {
+    if (!std.unicode.utf8ValidateSlice(s)) return StringError.InvalidUtf8;
+    var latin1_able = true;
+    var n_cps: usize = 0;
+    var scan = std.unicode.Utf8View.initUnchecked(s).iterator();
+    while (scan.nextCodepoint()) |cp| {
+        n_cps += 1;
+        if (cp >= 0x100) {
+            latin1_able = false;
+            break;
+        }
+    }
+    if (latin1_able) {
+        if (n_cps > MAX_STRING_BYTE_LENGTH) return StringError.StringTooLong;
+        const byte_len: u32 = @intCast(n_cps);
+        const ptr = try cx.realloc(0, 0, 2, byte_len);
+        if (@as(usize, ptr) + byte_len > cx.mem().len) return StringError.OutOfBounds;
+        var w: usize = ptr;
+        var it = std.unicode.Utf8View.initUnchecked(s).iterator();
+        while (it.nextCodepoint()) |cp| : (w += 1) cx.mem()[w] = @intCast(cp); // cp < 0x100
+        return .{ .ptr = ptr, .packed_length = byte_len };
+    }
+    const units = std.unicode.calcUtf16LeLen(s) catch return StringError.InvalidUtf8;
+    if (units > MAX_STRING_BYTE_LENGTH) return StringError.StringTooLong;
+    const code_units: u32 = @intCast(units);
+    const byte_len = code_units * 2;
+    const ptr = try cx.realloc(0, 0, 2, byte_len);
+    if (@as(usize, ptr) + byte_len > cx.mem().len) return StringError.OutOfBounds;
+    writeUtf16LeInto(cx.mem()[ptr..][0..byte_len], s);
+    return .{ .ptr = ptr, .packed_length = code_units | UTF16_TAG };
+}
+
+/// Transcode validated UTF-8 `s` into UTF-16LE bytes in `dst` (len == 2×units).
+/// Alignment-safe: `writeInt` is byte-wise, so a merely 2-aligned guest ptr is fine.
+fn writeUtf16LeInto(dst: []u8, s: []const u8) void {
+    var w: usize = 0;
+    var it = std.unicode.Utf8View.initUnchecked(s).iterator();
+    while (it.nextCodepoint()) |cp| {
+        if (cp <= 0xFFFF) {
+            std.mem.writeInt(u16, dst[w..][0..2], @intCast(cp), .little);
+            w += 2;
+        } else {
+            const c = cp - 0x10000;
+            const hi: u16 = @intCast(0xD800 + (c >> 10));
+            const lo: u16 = @intCast(0xDC00 + (c & 0x3FF));
+            std.mem.writeInt(u16, dst[w..][0..2], hi, .little);
+            std.mem.writeInt(u16, dst[w + 2 ..][0..2], lo, .little);
+            w += 4;
+        }
+    }
 }
 
 /// Lift a guest UTF-8 string (`load_string_from_range`): bounds-check + UTF-8
@@ -723,12 +809,31 @@ test "lift: invalid utf8 rejected" {
     try testing.expectError(StringError.InvalidUtf8, liftString(cx, 0, 2));
 }
 
-test "string: non-utf8 encoding deferred" {
-    var mem = [_]u8{0} ** 8;
+test "lowerString utf16: BMP + supplementary (surrogate pair)" {
+    var mem = [_]u8{0} ** 32;
     var bump = Bump{ .next = 0 };
     var mem_slice: []u8 = &mem;
     const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc, .string_encoding = .utf16 };
-    try testing.expectError(StringError.UnsupportedEncoding, lowerString(cx, "x"));
+    // "A𐐷" = U+0041 + U+10437 (one BMP unit + a surrogate pair = 3 code units).
+    const lowered = try lowerString(cx, "A\u{10437}");
+    try testing.expectEqual(@as(u32, 3), lowered.packed_length); // 3 code units, no tag
+    const b = mem[lowered.ptr..][0..6];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x41, 0x00, 0x01, 0xD8, 0x37, 0xDC }, b);
+}
+
+test "lowerString latin1+utf16: all-latin1 stays latin1, mixed flips to tagged utf16" {
+    var mem = [_]u8{0} ** 64;
+    var bump = Bump{ .next = 0 };
+    var mem_slice: []u8 = &mem;
+    const cx = CanonContext{ .memory_ctx = @ptrCast(&mem_slice), .memory_fn = CanonContext.sliceMemoryFn, .realloc_ctx = @ptrCast(&bump), .realloc_fn = Bump.realloc, .string_encoding = .latin1_utf16 };
+    // "Aÿ" — U+0041 + U+00FF, both < 0x100 → latin1, 1 byte each, no tag.
+    const l1 = try lowerString(cx, "A\u{00FF}");
+    try testing.expectEqual(@as(u32, 2), l1.packed_length);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x41, 0xFF }, mem[l1.ptr..][0..2]);
+    // "Aλ" — U+03BB ≥ 0x100 → utf16 with UTF16_TAG, 2 code units.
+    const l2 = try lowerString(cx, "A\u{03BB}");
+    try testing.expectEqual(@as(u32, 2 | UTF16_TAG), l2.packed_length);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x41, 0x00, 0xBB, 0x03 }, mem[l2.ptr..][0..4]);
 }
 
 test "store/load round-trip: list<u32>" {

--- a/src/wasi/fd.zig
+++ b/src/wasi/fd.zig
@@ -803,12 +803,12 @@ pub fn fdReaddir(host: *Host, mem: []u8, fd: p1.Fd, buf_ptr: u32, buf_len: u32, 
 /// - Open is delegated to `std.Io.Dir{.fd = slot.host_handle}
 ///   .openFile(io, ...)`. Errors map through `mapOpenError`.
 ///
-/// On success, a new `.file` slot is appended to
+/// On success, a new `.file` (or `.dir`) slot is appended to
 /// `host.fd_table`; the new guest fd is written to
-/// `opened_fd_ptr`. The `oflags` / `dirflags` parameters are
-/// accepted but only the bare-open path is honoured for now —
-/// CREAT / EXCL / TRUNC come alongside their consuming
-/// realworld samples.
+/// `opened_fd_ptr`. `oflags` CREAT / TRUNC / EXCL / DIRECTORY are
+/// honoured (see the body). `dirflags` (the symlink-follow bit) is
+/// currently IGNORED — follow-time symlink confinement is the
+/// blocked half of D-315.
 pub fn pathOpen(
     host: *Host,
     mem: []u8,


### PR DESCRIPTION
Component Model域のまとめPR(Batch B)。**D-444 分割は保留**(cap姿勢の決定#1に依存、#119の監査参照)。3-OSゲート1本。

## D-502 — Canonical ABI utf16 / latin1+utf16 string encodings (COMPLETE)
`canon.zig` の `lower`/`lift` が非utf8を `UnsupportedEncoding` で拒否していたのを実装。CanonicalABI.md 準拠、host source は常に validated UTF-8 の3-dest subset。
- **lower** (`69d7c8b`): utf16 は `calcUtf16LeLen` で正確長(worst-case alloc回避)、latin1+utf16 はスキャン先行(仕様の in-place inflate と結果同一・バグ面削減)で latin1 or `UTF16_TAG`(bit31)付き utf16。alignment-safe な byte-wise `writeInt`、supplementary は surrogate pair。
- **lift** (`298444`): `liftString` に `arena` 引数追加 → **常に arena 所有の UTF-8 を返す統一契約**(survey の DIVERGENCE=混在借用/所有の解消)。UTF-16LE デコード+surrogate 復元、lone surrogate / 非2-aligned を trap。呼び出し元5箇所を arena 化し graph/component の冗長 dupe を除去。
- `StringError += InvalidUtf16, OutOfMemory`(LoadError/InvokeStringError へ自動波及)、`stringErrToTrap` 網羅switch更新。
- テスト: utf16 round-trip(supplementary含む)/ latin1+utf16 両経路 / dangling surrogate / unaligned trap。TDD red 確証。
- 残差(別・小): `invokeStringExport` はまだ utf8-gate(encoding を invoke パスに未スレッド)。

## D-504 — wasi_p2 defensive error + doc-rot (`424ee75`)
- `component_wasi_p2` の clock/random 5箇所の `@panic`(host.io 未設定時のホスト abort)を `return WasiP2Error.NoHostIo` に(既存 idiom、guest trap 化。silent fallback ではない)。happy path は既存 fixture でカバー。
- `fd.zig` pathOpen の虚偽 docstring 修正(CREAT/TRUNC/EXCL/DIRECTORY は本体で処理済。`dirflags` は真に未処理=D-315のfollow-time側)。

## 検証
Mac arm64: fmt / `zig build test` 3100+/3112(0 fail, TDD red確証)/ `zig build lint` clean。3-OSゲートはCIで。

---
Batched maintenance series (A #118 · E #119 · **B** · C table64-JIT · D held)。マージはユーザー指示で連鎖実施予定。