### PR TITLE
ci(gate): D-254 — gate the rust-host embedding consumer on the ubuntu leg

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -758,8 +758,20 @@ entries:
     front: B-hardening
   - id: "D-254"
     layer: "process"
-    status: "now"
+    status: "note"
     description: |-
+      **RESOLVED (core, 2026-07-03): run-rust-host is now CI-gated on the ubuntu
+      leg.** `scripts/ci_gate.sh` core runs `zig build run-rust-host` when on Linux
+      with rustc present — the GitHub ubuntu runner ships a gnu-target rustc that is
+      ABI-compatible with zig's native libzwasm.a (clean link, verified locally on
+      Mac: exit 0). It runs on EVERY PR's Linux leg, so rust-host rot shows before
+      merge. This supersedes the old "wire into the local test-host gate" plan
+      (which fought the toolchain-free-test-host invariant): CI is the gate now.
+      RESIDUAL (lower-pri note): macOS + Windows rust-host are NOT CI-gated — macOS
+      needs the SDKROOT dance (fine locally, untested on the macos runner) and
+      Windows has the MSVC-vs-GNU `libzwasm.a` link question. The Linux gate already
+      prevents silent rot; mac/win CI coverage is a demand-driven follow-up.
+
       **PROGRESS 2026-06-05 (ADR-0162): resolution (a) CHOSEN by user — provision native rust on the test hosts.**
       Rust INSTALLED: windowsmini rustc 1.96.0 (winget); ubuntunote via `flake.nix devShells.rust-host` (`a5cf80fb`).
       The "rustc absence" barrier is dissolving. REMAINING (A1-wire, the actionable bit): `build.zig run-rust-host`

--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -25,6 +25,23 @@ zig fmt --check src/
 echo "[ci_gate] (2/2) zig build test-all"
 zig build test-all
 
+# rust-host embedding consumer (D-254): the third independent embedding-ABI
+# consumer (docs/examples/rust_host/hello.rs links the same libzwasm.a the C
+# host uses) — exercise it so it can't rot silently. LINUX-only: the ubuntu
+# runner ships a gnu-target rustc that is ABI-compatible with zig's native
+# libzwasm.a, so the link is clean (the macOS SDK dance + the Windows rust ABI
+# question are out of scope here). Runs on EVERY PR (core), so a break shows on
+# the PR's Linux leg before merge, not post-merge. Skips gracefully where rustc
+# is absent (e.g. a local gate host without the .#rust-host shell).
+if [ "$(uname -s)" = "Linux" ]; then
+    if command -v rustc >/dev/null 2>&1; then
+        echo "[ci_gate] rust-host embedding consumer (zig build run-rust-host, D-254)"
+        zig build run-rust-host
+    else
+        echo "[ci_gate] (skip run-rust-host — rustc not on PATH; needs the .#rust-host shell)"
+    fi
+fi
+
 if [ "${ZWASM_CI_EXTENDED:-0}" = "1" ]; then
     echo "[ci_gate] extended: zig build lint"
     zig build lint


### PR DESCRIPTION
Closes the `D-254` "now" item: the rust-host embedding example (`docs/examples/rust_host/hello.rs` — the 3rd embedding-ABI consumer, links the same `libzwasm.a` as the C host) was a standalone Mac-only `zig build run-rust-host` step — in neither `test-all` nor CI — so it could rot undetected.

## Change
Wire `zig build run-rust-host` into `ci_gate.sh` **core**, Linux-guarded:
- Runs when `uname=Linux && rustc present`. The GitHub ubuntu runner ships a gnu-target rustc that is ABI-compatible with zig's native `libzwasm.a` → clean link (verified locally on Mac: `run-rust-host` exit 0).
- **CORE** (not extended) → runs on EVERY PR's Linux leg, so a break shows on the PR before merge, not post-merge. Skips gracefully where rustc is absent.
- Supersedes the old "wire into the local test-host gate" plan (which fought the toolchain-free-test-host invariant): CI is the authoritative gate now.

## Verification
**Self-verifying**: `scripts/ci_gate.sh` is a non-doc change → this PR runs the 3-host gate, and the ubuntu leg exercises the new `run-rust-host` step. If it's green, the gate works end-to-end.

## Residual (D-254 → note)
macOS (SDKROOT dance, untested on the macos runner) + Windows (MSVC-vs-GNU `libzwasm.a` link) rust-host CI coverage is a demand-driven follow-up — the Linux gate already prevents silent rot.