### PR TITLE
chore(bench): fold per-merge bench record into the feature PR (PR-only main)

### DIFF
--- a/.dev/ROADMAP.md
+++ b/.dev/ROADMAP.md
@@ -2056,11 +2056,13 @@ Instead:
 
 ### 12.4 Cadence
 
-- **Per-merge** (Phase 14+, automated CI): full hyperfine on Mac;
-  Linux and Windows rows recorded by the matrix.
-- **Per-merge** (Phase 0–13, manual): Mac via `bash
-  scripts/record_merge_bench.sh`; Linux + Windows via the analogous
-  remote scripts when results are needed.
+- **Per-merge** (manual, under PR-only `main`): record on the
+  **feature branch** via `bash scripts/record_merge_bench.sh
+  --phase-record --reason=...` and commit `history.yaml` into the
+  **same PR** as the code — never a post-merge follow-up (a
+  ruleset-protected `main` would need its own PR each merge).
+  Linux + Windows rows via the analogous remote scripts when
+  needed. Skip for trivial / doc-only changes.
 - **Manual baselines**: `bash scripts/record_merge_bench.sh
   --arch=...` records on demand.
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -27,7 +27,14 @@ preserved long-term.
   `bench/results/recent.yaml`. Adding `--phase-record
   --reason="<tag>: <gist>"` also appends one row to
   `bench/results/history.yaml`. `scripts/record_merge_bench.sh`
-  is the phase-boundary wrapper.
+  is the wrapper.
+- **Per-merge under PR-only `main`**: record the bench **on the
+  feature branch before opening the PR** and commit
+  `history.yaml` **into the same PR** as the code — NOT as a
+  post-merge follow-up (ruleset-protected `main` would require a
+  separate PR per merge). Put the PR intent in `--reason`; the
+  entry's SHA is the branch tip (cosmetic). Skip for trivial /
+  doc-only changes.
 - **Per-push CI**: [`.github/workflows/bench.yml`](../.github/workflows/bench.yml)
   runs `--quick --phase-record` on every push to
   `main` across `macos-latest` (aarch64-darwin) +

--- a/scripts/record_merge_bench.sh
+++ b/scripts/record_merge_bench.sh
@@ -9,12 +9,14 @@
 # (committed, append-only) tagged with commit + arch + reason. Arch is
 # auto-detected from `uname` ({aarch64-darwin, x86_64-linux, x86_64-windows}).
 #
-# Cadence (ROADMAP §12.4): during Phase 0-13 the per-merge bench is MANUAL —
-# run this on Mac directly, and on ubuntunote / windowsmini for the Linux /
-# Windows rows. Auto-CI (the push-triggered bench.yml) is Phase 14+; its
-# push trigger was disabled 2026-05-25 per user direction (CI was not
-# consumed; auto-runs produced noise). This script is the supported path
-# until then.
+# Cadence (ROADMAP §12.4): the per-merge bench is MANUAL. Under PR-only `main`
+# (ruleset-protected), record ON THE FEATURE BRANCH before opening the PR and
+# commit `bench/results/history.yaml` INTO THE SAME PR — NOT as a post-merge
+# follow-up (that would need its own PR each merge). Put the PR intent in
+# `--reason`; the entry's commit SHA is the branch tip (cosmetic — reason/PR#/
+# date identify it). Run on Mac; ubuntunote / windowsmini for Linux / Windows
+# rows when needed. Auto-CI (push-triggered bench.yml) stays disabled
+# (2026-05-25; CI was not consumed, auto-runs produced noise).
 #
 # Usage:
 #   bash scripts/record_merge_bench.sh                  # recent.yaml only


### PR DESCRIPTION
## Why

The per-merge bench policy was written for direct-push `main`: *"after merge, run `record_merge_bench.sh` and commit `history.yaml` as a follow-up."* Now that `main` is ruleset-protected (PR-only), that follow-up would need **its own PR every merge** — surfaced while recording the D-505 (#125) datapoint.

## Change (user-directed)

Record the bench **on the feature branch before opening the PR** and commit `history.yaml` **into the same PR** as the code — zero extra PRs. Skip for trivial / doc-only changes.

Updated:
- `scripts/record_merge_bench.sh` header
- `bench/README.md` §Cadence
- `.dev/ROADMAP.md` §12.4 Cadence

Also lands the **D-505 (#125)** bench datapoint (recorded on `main` post-merge, so its `commit:` SHA is accurate) as the first entry under the new mechanism.

Data + doc + script-comment only — no code logic changed.