### PR TITLE
feat(jit): D-475 — table64 (i64-indexed tables) compiles natively in the JIT

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -397,31 +397,28 @@ entries:
       read-only imports only; table_grow.6 GROWS an imported table + TableAlias
       value-snapshots refs (stales on cross-module grow), needing *TableInstance
       pointer-sharing (D-199 memory precedent) first. (4) JIT i64 table-bounds
-      codegen — perf/completeness only (interp is the conformant reference; not a
-      correctness-sweep item). SURVEYED 2026-06-20: NOT just a W→X emit flip — it
-      is a STRUCTURAL u32→u64 descriptor change. `jit_abi.TableSlice.len` +
-      `JitRuntime.table_size` (jit_abi.zig:84/163) are u32, and setup.zig:502
-      @intCasts table min to u32 → a table64's size storage is already 32-bit, so
-      flipping the bounds CMP to X-form compares a 64-bit idx against a truncated
-      value. Bounded 4-cycle BUNDLE (Win64-risk — touches the pinned-cohort
-      prologue X25 + all len-load offsets + imm12-budget asserts jit_abi.zig:1456):
-      C1 = widen TableSlice.len→u64 + thread per-table idx_types onto EmitCtx
-      (TableMeta gains idx_type; no behaviour change, guard stays); C2 = table.get/
-      set scalar bounds W→X both arches (sites: arm64 op_table.zig:178/229,
-      x86_64 op_table.zig:253/312; mirror op_memory.zig:88 encCmpRegW→X); C3 =
-      call_indirect (table-0 W25 op_call.zig:420 + multi-table :476) both arches;
-      C4 = remove the guard + distil table64 assert-2.0 fixtures. Bulk ops already
-      use X/.q width. Verify EVERY cycle on arm64 AND -Dtarget=x86_64-macos
-      (JIT-codegen lesson). Do this with FRESH context — a cross-cutting ABI change
-      deserves the deliberate I→II→IV phases, not a maxed-context cram.
+      codegen — **DONE 2026-07-06** (develop/d475-table64-jit, C1-C4): C1 widened
+      TableSlice.len/max→u64 (stride 24→32; tableslice_{len,funcptrs}_off consts)
+      + JitRuntime.table_size→u64 (absorbed _pad0, offsets unchanged) +
+      table_grow_fn (u64 delta / i64 result) + jitCallIndirectResolve (u64 idx) +
+      per-table idx_types threaded onto ZirFunc (tableIdxType accessor); C2/C3
+      idx_type-conditional index widths on BOTH arches (get/set/grow/fill/copy/
+      init + call_indirect/return_call_indirect inline + subtype-trampoline) with
+      ADDS+B.HS / ADD+JC wrap guards on i64 sums (memory64 pattern; i32 tables
+      byte-identical); C4 removed JitTable64Unsupported + fixed two interp-
+      fallback-masked JIT-setup gaps (elem offset evalConstI32Expr→
+      evalConstOffsetU64 in setup.zig; elem offset_expr validated .i32-fixed→
+      per-target-table elemOffsetValType in compile.zig — the @a7609a65b JIT
+      mirrors). Forced `--engine jit` sweep over all 11 distilled table64 dirs
+      clean. REMAINING (unchanged scope, NOT table64-specific): the harness
+      cross-module register-table wiring above (table.12/34, table_grow.6/7).
     first_raised: "2026-06-20"
-    last_reviewed: "2026-06-20"
+    last_reviewed: "2026-07-06"
     refs: |-
-      src/parse/sections.zig (.table import / defined-table readLimits — no idx_type)
-      src/runtime TableType (i32-indexed only)
-      test/spec/wasm-3.0-assert/memory64/raw/table.wast (i64-table spec corpus, not distilled)
-      test/spec/wasm-3.0-assert/memory64/raw/table_copy_mixed.wast
-      test/spec/wasm-3.0-assert/memory64/raw/call_indirect.wast
+      src/engine/codegen/shared/jit_abi.zig (TableSlice u64 len/max; table_size u64)
+      src/engine/codegen/{arm64,x86_64}/{op_table,op_call,op_tail_call}.zig (idx_type widths)
+      src/engine/compile.zig (elemOffsetValType), src/engine/setup.zig (u64 elem offsets)
+      test/spec/wasm-3.0-assert/memory64/ (11 table64 dirs, JIT-native)
   - id: "D-314"
     layer: "code"
     status: "note"

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -29,11 +29,22 @@ Post-v2.0.0 sweep (see `.dev/meta_audits/2026-07-03-maintenance-scaffolding-audi
   the D-502 note); D-504 discharged (wasi_p2 @panic→NoHostIo + fd.zig doc-rot).
 - **D-254 — rust-host CI gate** — MERGED #122. `run-rust-host` now runs on the ubuntu
   gate leg (Linux-guarded core). Scaffolding-maintenance campaign (A→E→B + D-254) COMPLETE.
-- **NEXT (all fresh-context — do NOT grind in a deep loop)**: **D-505 DONE** (PR
-  open on `develop/d505-spill-aware-simd-triage`). No `now`-class items remain.
-  **Batch C / D-475** table64-JIT (Win64-risk) · **D held** · **D-444** = optional
-  design split (cap now advisory). Minor/demand-driven: D-506 (FP spill stage-2
-  scaffold), D-502 residual (invokeStringExport encoding), mac/win rust-host CI.
+- **Batch C / D-475 — table64-JIT** — DONE (this PR): TableSlice.len/max +
+  JitRuntime.table_size u64 (stride 24→32); per-table idx_type-conditional index
+  widths both arches (table ops + call_indirect/tail-call/subtype); wrap-safe i64
+  bounds (ADDS+B.HS / ADD+JC); JitTable64Unsupported guard removed; elem-offset
+  u64 eval fixed in setup/compile/compile_init; AOT rejects >u32 table64 min.
+  Adversarial review (devil's-advocate) fixed a spilled-i64-grow W-store
+  miscompile + a hostile-offset bounds wrap pre-merge. All 11 distilled table64
+  dirs JIT-native (forced `--engine jit` sweep). windowsmini + Rosetta green.
+- **NEXT (all fresh-context — do NOT grind in a deep loop)**: no `now`-class
+  items. **D-444** = optional design split (cap now advisory). Minor/demand-
+  driven: D-506 (FP spill stage-2 scaffold), D-502 residual (invokeStringExport
+  encoding), mac/win rust-host CI, D-475 residual = spec-harness cross-module
+  register-table wiring (table.12/34, table_grow.6/7 — not table64-specific).
+  NOTE: ubuntunote's clone still sits at the retired path
+  `~/Documents/MyProducts/zwasm_from_scratch` — `run_remote_ubuntu.sh` preflight
+  fails until it is renamed to `.../zwasm` (one-line `mv` on the host).
 
 ## Operational invariants (keep using)
 
@@ -60,8 +71,9 @@ Post-v2.0.0 sweep (see `.dev/meta_audits/2026-07-03-maintenance-scaffolding-audi
   D-477. Trigger = a real consumer. SIMD correctness already covered (simd_assert
   25075/0 + fuzz-loader 1665 JIT-compiled clean). **D-478** = JIT FP host-callback
   bridge + funcref `Table.set` panic + proc_exit exit-code.
-- **D-475 table64-JIT** (Batch C): interp is fully conformant; JIT is guarded
-  (`JitTable64Unsupported`). u32→u64 4-cycle bundle, Win64-risk — do with FRESH context.
+- **D-475 residual**: spec-harness cross-module register-table wiring only
+  (applyImportedTablesFromRegistered + TableAlias pointer-sharing); the table64
+  feature itself is COMPLETE on both engines.
 - **D-502** CM utf16/latin1 canonical-ABI string encodings; **D-444** split
   `component_wasi_p2.zig` (2228 > 2000) — both Batch B (Component域).
 - **validator.zig at 3392/3510** — next validator edit extracts per the marker plan first.

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -1710,7 +1710,8 @@ pub export fn wasm_table_size(t: ?*const Table) callconv(.c) u32 {
             if (handle.table_idx >= rt.tables.len) return 0;
             return @intCast(rt.tables[handle.table_idx].refs.len);
         }
-        if (jitOf(inst)) |jit| return jit.tableLen(handle.table_idx) orelse 0; // D-496
+        // D-496; saturate to the u32 wasm-c-api shape (D-475: JIT len is u64).
+        if (jitOf(inst)) |jit| return std.math.cast(u32, jit.tableLen(handle.table_idx) orelse 0) orelse std.math.maxInt(u32);
         return 0;
     }
     return @intCast((handle.tinst orelse return 0).refs.len); // standalone host table

--- a/src/engine/codegen/aot/produce.zig
+++ b/src/engine/codegen/aot/produce.zig
@@ -316,9 +316,13 @@ fn collectTables(allocator: Allocator, wasm_bytes: []const u8, compiled: *const 
         defer tables.deinit();
         if (tables.items.len > 0) {
             st.has_table = true;
-            // table64 min is u64; AOT table0_size is u32 (i64 tables are
-            // JIT/AOT-guarded) — saturate defensively.
-            st.table0_size = std.math.cast(u32, tables.items[0].min) orelse std.math.maxInt(u32);
+            // table64 min is u64 but the .cwasm format's table0_size is
+            // u32. D-475 removed the JIT table64 guard, so a table64
+            // module reaches AOT now; a min that genuinely exceeds u32
+            // can't serialize losslessly → reject loudly (matches the
+            // over-u32 elem-offset posture below). Sub-2^32 table64
+            // mins serialize exactly.
+            st.table0_size = std.math.cast(u32, tables.items[0].min) orelse return Error.UnsupportedTableState;
         }
     }
     if (!st.has_table) return st;

--- a/src/engine/codegen/arm64/emit.zig
+++ b/src/engine/codegen/arm64/emit.zig
@@ -294,7 +294,7 @@ pub fn compile(
     try gpr.writeU32(allocator, &buf, inst.encLdrImm(28, 0, jit_abi.vm_base_off));
     try gpr.writeU32(allocator, &buf, inst.encLdrImm(27, 0, jit_abi.mem_limit_off));
     try gpr.writeU32(allocator, &buf, inst.encLdrImm(26, 0, jit_abi.funcptr_base_off));
-    try gpr.writeU32(allocator, &buf, inst.encLdrImmW(25, 0, jit_abi.table_size_off));
+    try gpr.writeU32(allocator, &buf, inst.encLdrImm(25, 0, jit_abi.table_size_off));
     try gpr.writeU32(allocator, &buf, inst.encLdrImm(24, 0, jit_abi.typeidx_base_off));
     // ADR-0027 prescan: load X23 ← globals_base only when this
     // function actually consults a global. Functions without

--- a/src/engine/codegen/arm64/emit_test_call.zig
+++ b/src/engine/codegen/arm64/emit_test_call.zig
@@ -320,7 +320,7 @@ test "compile: call_indirect — bounds (CMP/B.HS) + sig (LDR/CMP/B.NE) + funcpt
     // between the sig load and the sig CMP):
     //   [32..36] MOVZ W9, #5                   ; idx const
     //   [36..40] ORR W17, WZR, W9              ; zero-extend idx
-    //   [40..44] CMP W17, W25                  ; bounds
+    //   [40..44] CMP X17, X25                  ; bounds (X-width, D-475)
     //   [44..48] B.HS trap_stub                ; placeholder
     //   [48..52] LDR W16, [X24, X17, LSL #2]   ; sig load
     //   [52..56] CMN W16, #1                   ; D-294 null check (W16 == maxInt?)
@@ -333,7 +333,7 @@ test "compile: call_indirect — bounds (CMP/B.HS) + sig (LDR/CMP/B.NE) + funcpt
     //   [80..84] ORR W9, WZR, W0               ; capture
     const body0 = prologue.body_start_offset(false);
     try testing.expectEqual(@as(u32, inst.encOrrRegW(17, 31, 9)), std.mem.readInt(u32, out.bytes[body0 + 4 ..][0..4], .little));
-    try testing.expectEqual(@as(u32, inst.encCmpRegW(17, 25)), std.mem.readInt(u32, out.bytes[body0 + 8 ..][0..4], .little));
+    try testing.expectEqual(@as(u32, inst.encCmpRegX(17, 25)), std.mem.readInt(u32, out.bytes[body0 + 8 ..][0..4], .little));
     const bhs = std.mem.readInt(u32, out.bytes[body0 + 12 ..][0..4], .little);
     try testing.expectEqual(@as(u32, 0x2), bhs & 0xF); // cond=.hs
     try testing.expectEqual(@as(u32, inst.encLdrWRegLsl2(16, 24, 17)), std.mem.readInt(u32, out.bytes[body0 + 16 ..][0..4], .little));
@@ -479,7 +479,7 @@ test "compile: return_call_indirect — bounds + sig + funcptr-to-X16 + frame_te
     const body0 = prologue.body_start_offset(false);
     // After MOVZ W9 #5 (body+0):
     //   [+4]  ORR W17, WZR, W9               ; zero-extend idx
-    //   [+8]  CMP W17, W25                   ; bounds
+    //   [+8]  CMP X17, X25                   ; bounds (X-width, D-475)
     //   [+12] B.HS trap_stub                 ; placeholder
     //   [+16] LDR W16, [X24, X17, LSL #2]    ; sig load
     //   [+20] CMN W16, #1                    ; D-294 null check (W16 == maxInt?)
@@ -491,7 +491,7 @@ test "compile: return_call_indirect — bounds + sig + funcptr-to-X16 + frame_te
     //   [+44] LDP X29, X30, [SP], #16        ; frame_teardown (frame_bytes=0)
     //   [+48] BR X16                         ; tail-jump
     try testing.expectEqual(@as(u32, inst.encOrrRegW(17, 31, 9)), std.mem.readInt(u32, out.bytes[body0 + 4 ..][0..4], .little));
-    try testing.expectEqual(@as(u32, inst.encCmpRegW(17, 25)), std.mem.readInt(u32, out.bytes[body0 + 8 ..][0..4], .little));
+    try testing.expectEqual(@as(u32, inst.encCmpRegX(17, 25)), std.mem.readInt(u32, out.bytes[body0 + 8 ..][0..4], .little));
     const bhs = std.mem.readInt(u32, out.bytes[body0 + 12 ..][0..4], .little);
     try testing.expectEqual(@as(u32, 0x2), bhs & 0xF); // cond=.hs
     try testing.expectEqual(@as(u32, inst.encLdrWRegLsl2(16, 24, 17)), std.mem.readInt(u32, out.bytes[body0 + 16 ..][0..4], .little));
@@ -535,10 +535,11 @@ test "compile: return_call_indirect — multi-table (table_idx > 0) loads size+b
     const body0 = prologue.body_start_offset(false);
     const rt = abi.runtime_ptr_save_gpr;
     // After MOVZ idx (body+0) + ORR W17,WZR,W9 (body+4), the multi-table
-    // tell: load tables_ptr, then table-1 size, then CMP W17,W16 (NOT W25).
+    // tell: load tables_ptr, then table-1 size (u64 X-form, D-475), then
+    // CMP X17,X16 (NOT X25).
     try testing.expectEqual(@as(u32, inst.encLdrImm(16, rt, jit_abi.tables_ptr_off)), std.mem.readInt(u32, out.bytes[body0 + 8 ..][0..4], .little));
-    try testing.expectEqual(@as(u32, inst.encLdrImmW(16, 16, 1 * jit_abi.table_slice_size + 8)), std.mem.readInt(u32, out.bytes[body0 + 12 ..][0..4], .little));
-    try testing.expectEqual(@as(u32, inst.encCmpRegW(17, 16)), std.mem.readInt(u32, out.bytes[body0 + 16 ..][0..4], .little));
+    try testing.expectEqual(@as(u32, inst.encLdrImm(16, 16, 1 * jit_abi.table_slice_size + jit_abi.tableslice_len_off)), std.mem.readInt(u32, out.bytes[body0 + 12 ..][0..4], .little));
+    try testing.expectEqual(@as(u32, inst.encCmpRegX(17, 16)), std.mem.readInt(u32, out.bytes[body0 + 16 ..][0..4], .little));
     // BR X16 (tail-jump) is present in the body (trap stubs follow it, so it
     // is not the final word). End-to-end execution is covered by the
     // runner_test "return_call_indirect on a non-zero table index" case.

--- a/src/engine/codegen/arm64/emit_test_call.zig
+++ b/src/engine/codegen/arm64/emit_test_call.zig
@@ -296,6 +296,74 @@ test "compile: call N — i32 result in spill slot lands STR W0 (spill-aware)" {
     try testing.expect(found);
 }
 
+test "compile: table.grow i64-table — spilled result stores X-form STR X0 (D-475 boundary)" {
+    // D-475 boundary fixture: an i64 table's grow result is a full i64
+    // in X0; a spilled result vreg MUST be stored X-form (STR X0), or
+    // the X-form spill reload picks up stale upper 32 bits (the -1
+    // failure sentinel becomes a garbage positive). The i32 twin below
+    // pins the byte-identical W-form fast path.
+    const sig: zir.FuncType = .{ .params = &.{}, .results = &.{.i64} };
+    var f = ZirFunc.init(0, sig, &.{});
+    defer f.deinit(testing.allocator);
+    f.table_idx_types = &.{.i64};
+    try f.instrs.append(testing.allocator, .{ .op = .@"i64.const", .payload = 0, .extra = 0 }); // init ref (null)
+    try f.instrs.append(testing.allocator, .{ .op = .@"i64.const", .payload = 5, .extra = 0 }); // delta
+    try f.instrs.append(testing.allocator, .{ .op = .@"table.grow", .payload = 0 });
+    try f.instrs.append(testing.allocator, .{ .op = .end });
+    f.liveness = .{ .ranges = &[_]zir.LiveRange{
+        .{ .def_pc = 0, .last_use_pc = 2 },
+        .{ .def_pc = 1, .last_use_pc = 2 },
+        .{ .def_pc = 2, .last_use_pc = 3 },
+    } };
+    // Result vreg → slot 8 = first spill slot (max_reg_slots_gpr = 8).
+    const slots = [_]u16{ 0, 1, 8 };
+    const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 9 };
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    defer deinit(testing.allocator, out);
+    const expected_x = inst.encStrImm(0, 31, 0); // STR X0, [SP, #0]
+    const wrong_w = inst.encStrImmW(0, 31, 0); // the D-475 F1 bug shape
+    var found_x = false;
+    var found_w = false;
+    var i: usize = 0;
+    while (i + 4 <= out.bytes.len) : (i += 4) {
+        const word = std.mem.readInt(u32, out.bytes[i..][0..4], .little);
+        if (word == expected_x) found_x = true;
+        if (word == wrong_w) found_w = true;
+    }
+    try testing.expect(found_x);
+    try testing.expect(!found_w);
+}
+
+test "compile: table.grow i32-table — spilled result keeps W-form STR W0 (byte-identical fast path)" {
+    const sig: zir.FuncType = .{ .params = &.{}, .results = &.{.i32} };
+    var f = ZirFunc.init(0, sig, &.{});
+    defer f.deinit(testing.allocator);
+    // No table_idx_types → tableIdxType defaults .i32.
+    try f.instrs.append(testing.allocator, .{ .op = .@"i64.const", .payload = 0, .extra = 0 });
+    try f.instrs.append(testing.allocator, .{ .op = .@"i32.const", .payload = 5 });
+    try f.instrs.append(testing.allocator, .{ .op = .@"table.grow", .payload = 0 });
+    try f.instrs.append(testing.allocator, .{ .op = .end });
+    f.liveness = .{ .ranges = &[_]zir.LiveRange{
+        .{ .def_pc = 0, .last_use_pc = 2 },
+        .{ .def_pc = 1, .last_use_pc = 2 },
+        .{ .def_pc = 2, .last_use_pc = 3 },
+    } };
+    const slots = [_]u16{ 0, 1, 8 };
+    const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 9 };
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    defer deinit(testing.allocator, out);
+    const expected_w = inst.encStrImmW(0, 31, 0); // STR W0, [SP, #0]
+    var found_w = false;
+    var i: usize = 0;
+    while (i + 4 <= out.bytes.len) : (i += 4) {
+        if (std.mem.readInt(u32, out.bytes[i..][0..4], .little) == expected_w) {
+            found_w = true;
+            break;
+        }
+    }
+    try testing.expect(found_w);
+}
+
 test "compile: call_indirect — bounds (CMP/B.HS) + sig (LDR/CMP/B.NE) + funcptr (LDR-LSL3/BLR)" {
     const sig: zir.FuncType = .{ .params = &.{}, .results = &.{.i32} };
     var f = ZirFunc.init(0, sig, &.{});

--- a/src/engine/codegen/arm64/op_call.zig
+++ b/src/engine/codegen/arm64/op_call.zig
@@ -414,10 +414,13 @@ pub fn emitCallIndirect(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     if (expected_typeidx >= 4096) return Error.UnsupportedOp;
 
     if (table_idx == 0) {
-        // Table-0 fast path: bounds via W25, sig via X24, funcptr via X26.
+        // Table-0 fast path: bounds via X25, sig via X24, funcptr via X26.
 
-        // Bounds: CMP W17, W25 ; B.HS trap.
-        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegW(17, 25));
+        // Bounds: CMP X17, X25 ; B.HS trap. X-width (D-475): the
+        // pinned table_size is u64; the i32-table idx in X17 is
+        // zero-extended by its W-form stage, so the wider compare
+        // is byte-identical in outcome.
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(17, 25));
         {
             const fixup_at: u32 = @intCast(ctx.buf.items.len);
             try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));
@@ -462,18 +465,18 @@ pub fn emitCallIndirect(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
 
         // TODO: table storage shape — see D-126 / ADR-0068.
         // Bounds: load size from tables_ptr[table_idx].len (TableSlice
-        // offset 8 within the `table_slice_size` stride — 16 pre-ADR-
-        // 0068, 24 after). Reject if table_idx exceeds the per-call
-        // imm12 budget; the @intCast on the encoded W-form imm12
+        // len offset within the `table_slice_size` stride; u64 X-form
+        // load per D-475). Reject if table_idx exceeds the per-call
+        // imm12 budget; the @intCast on the encoded X-form imm12
         // catches out-of-range at codegen time.
-        const tbl_slice_byte_off: u32 = (table_idx * jit_abi.table_slice_size) + 8;
-        if (tbl_slice_byte_off > 16380) return Error.UnsupportedOp;
+        const tbl_slice_byte_off: u32 = (table_idx * jit_abi.table_slice_size) + jit_abi.tableslice_len_off;
+        if (tbl_slice_byte_off > 32760) return Error.UnsupportedOp;
         // LDR X16, [rt, #tables_ptr_off]
         try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(16, rt_reg, jit_abi.tables_ptr_off));
-        // LDR W16, [X16, #(table_idx*table_slice_size + 8)]
-        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(16, 16, @intCast(tbl_slice_byte_off)));
-        // CMP W17, W16
-        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegW(17, 16));
+        // LDR X16, [X16, #(table_idx*table_slice_size + len_off)]
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(16, 16, @intCast(tbl_slice_byte_off)));
+        // CMP X17, X16 (X-width, D-475: len is u64)
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(17, 16));
         {
             const fixup_at: u32 = @intCast(ctx.buf.items.len);
             try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));

--- a/src/engine/codegen/arm64/op_call.zig
+++ b/src/engine/codegen/arm64/op_call.zig
@@ -300,11 +300,14 @@ fn emitCallIndirectSubtype(
     // read between here and the reload (marshalCallArgs reads temps).
     try spillHomedCallerSaved(ctx);
 
-    // Trampoline args: X0=rt, W1=table_idx, W2=idx, W3=expected_raw. Read idx
-    // into W2 first; its home reg is never X0..X3 (those aren't in the regalloc
+    // Trampoline args: X0=rt, W1=table_idx, X2=idx (u64 per D-475 —
+    // an i32 table's idx stages W-form zero-extended; an i64 table's
+    // full 64 bits via X-form), W3=expected_raw. Read idx into X2
+    // first; its home reg is never X0..X3 (those aren't in the regalloc
     // pool), so the later arg-reg writes can't clobber it.
+    const idx64 = ctx.func.tableIdxType(table_idx) == .i64;
     const w_idx = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, idx_vreg, 0);
-    if (w_idx != 2) try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(2, 31, w_idx));
+    if (w_idx != 2) try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encOrrReg(2, 31, w_idx) else inst.encOrrRegW(2, 31, w_idx));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(table_idx)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(3, @intCast(expected_raw)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(0, 31, abi.runtime_ptr_save_gpr));
@@ -403,9 +406,11 @@ pub fn emitCallIndirect(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
 
     // Bounds + sig check using the trap-stub at function tail
     // (shared with memory bounds — single trap reason today;
-    // Diagnostic M3 / D-022 splits them later).
+    // Diagnostic M3 / D-022 splits them later). D-475: an i64 table
+    // pops a full 64-bit index (X-form ORR into X17).
+    const ci_idx64 = ctx.func.tableIdxType(table_idx) == .i64;
     const w_idx = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, idx_vreg, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(17, 31, w_idx));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (ci_idx64) inst.encOrrReg(17, 31, w_idx) else inst.encOrrRegW(17, 31, w_idx));
 
     const expected_typeidx: u32 = canonical_type.canonicalTypeidx(ctx.module_types, @intCast(ins.payload));
     // Skeleton restricts expected typeidx to imm12 range

--- a/src/engine/codegen/arm64/op_table.zig
+++ b/src/engine/codegen/arm64/op_table.zig
@@ -13,10 +13,10 @@
 //!
 //!   table.get x:
 //!     LDR  X10, [X19, #tables_ptr_off]        ; tables_ptr
-//!     LDR  X11, [X10, #(tableidx*16)]         ; refs ptr
-//!     LDR  W12, [X10, #(tableidx*16)+8]       ; len
+//!     LDR  X11, [X10, #(tableidx*32)]         ; refs ptr
+//!     LDR  X12, [X10, #(tableidx*32)+8]       ; len (u64, D-475)
 //!     ORR  W17, WZR, W_idx                    ; zero-ext idx into ip1
-//!     CMP  W17, W12                           ; idx vs len
+//!     CMP  X17, X12                           ; idx vs len (X-width)
 //!     B.HS trap_stub                          ; bounds_fixups
 //!     LDR  Xresult, [X11, X17, LSL #3]        ; refs[idx]
 //!     (store back to spill slot if needed)
@@ -27,7 +27,7 @@
 //!
 //!   table.size x:
 //!     LDR  X14, [X19, #tables_ptr_off]
-//!     LDR  W_result, [X14, #(tableidx*16)+8]  ; push len as i32
+//!     LDR  X_result, [X14, #(tableidx*32)+8]  ; push len
 //!
 //! Intra-op scratch convention (D-132/D-133): table.get /
 //! table.set / table.size use X14
@@ -147,10 +147,10 @@ fn emitDeriveTypeidxFromFuncref(
 pub fn emitTableGet(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     const tableidx: u32 = @intCast(ins.payload);
     // TODO: table storage shape — see D-126 / ADR-0068.
-    // imm12 budget reshaped by stride 16 → 24: W-form len/max
-    // (byte_off ≤ 16380, scaled by 4) caps tableidx at (16380-12)/24
-    // = 682. Cap 512 leaves comfortable margin while remaining far
-    // above any realistic Wasm module's table count.
+    // imm12 budget with stride 32 (D-475 u64 len/max): X-form
+    // descriptor loads (byte_off ≤ 32760, scaled by 8) cap tableidx
+    // at (32760-24)/32 = 1023. Cap 512 keeps comfortable margin
+    // while remaining far above any realistic module's table count.
     if (tableidx >= 512) return Error.UnsupportedOp;
     const tbl_off: u15 = @intCast(@as(u32, tableidx) * jit_abi.table_slice_size);
 
@@ -171,11 +171,11 @@ pub fn emitTableGet(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     // range crossed a table.get / table.set. The fix re-targets
     // the intra-op scratch to the non-allocatable pool.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(14, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(15, 14, @intCast(@as(u32, tbl_off) + 8)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(15, 14, @intCast(@as(u32, tbl_off) + jit_abi.tableslice_len_off)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(14, 14, tbl_off));
 
-    // Step C: CMP W17, W15 ; B.HS trap.
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegW(17, 15));
+    // Step C: CMP X17, X15 ; B.HS trap. X-width (D-475): len is u64.
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(17, 15));
     {
         const fixup_at: u32 = @intCast(ctx.buf.items.len);
         try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));
@@ -222,11 +222,11 @@ pub fn emitTableSet(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     // live range crossed the op. See emitTableGet for the
     // detailed rationale.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(14, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(15, 14, @intCast(@as(u32, tbl_off) + 8)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(15, 14, @intCast(@as(u32, tbl_off) + jit_abi.tableslice_len_off)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(14, 14, tbl_off));
 
-    // Step C: CMP W17, W15 ; B.HS trap.
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegW(17, 15));
+    // Step C: CMP X17, X15 ; B.HS trap. X-width (D-475): len is u64.
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(17, 15));
     {
         const fixup_at: u32 = @intCast(ctx.buf.items.len);
         try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));
@@ -243,7 +243,7 @@ pub fn emitTableSet(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     // discipline), so CBZ skips both mirrors. For funcref tables,
     // derive funcptr/typeidx from val (X16) and STR to both views.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(14, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(14, 14, @intCast(@as(u32, tbl_off) + 16)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(14, 14, @intCast(@as(u32, tbl_off) + jit_abi.tableslice_funcptrs_off)));
     const skip_at: u32 = @intCast(ctx.buf.items.len);
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCbz(14, 0));
     try emitDeriveFuncptrFromFuncref(ctx, 15, 16);
@@ -274,7 +274,7 @@ pub fn emitTableSet(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
 pub fn emitTableSize(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     const tableidx: u32 = @intCast(ins.payload);
     if (tableidx >= 512) return Error.UnsupportedOp;
-    const len_off: u14 = @intCast(@as(u32, tableidx) * jit_abi.table_slice_size + 8);
+    const len_off: u15 = @intCast(@as(u32, tableidx) * jit_abi.table_slice_size + jit_abi.tableslice_len_off);
 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(14, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off));
 
@@ -283,7 +283,10 @@ pub fn emitTableSize(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     if (result >= ctx.alloc.slots.len) return Error.SlotOverflow;
     const wd = try gpr.gprDefSpilled(ctx.alloc, result, 0);
 
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(wd, 14, len_off));
+    // X-form load (D-475: len is u64). For an i32 table len < 2^32,
+    // so the value matches the old W-load zero-extension; an i64
+    // table pushes the full u64 size.
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(wd, 14, len_off));
     try gpr.gprStoreSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, result, 0);
     try ctx.pushed_vregs.append(ctx.allocator, result);
 }
@@ -342,14 +345,14 @@ pub fn emitTableGrow(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     try ctx.pushed_vregs.append(ctx.allocator, result);
 
     // D-497 (ADR-0201): a grow of table 0 changes the entry count cached in the
-    // X25 reserved reg (call_indirect's table-0 bounds check reads W25, not the
+    // X25 reserved reg (call_indirect's table-0 bounds check reads X25, not the
     // fresh TableSlice.len). X25 is callee-saved, so it survives the BLR with the
     // STALE pre-grow value; reload it so a grown slot is reachable from a
     // call_indirect later in THIS function. Cross-function calls re-establish X25
     // at the callee prologue; x86_64 reads rt.table_size fresh from R15 each time,
     // so this reload is arm64-only.
     if (tableidx == 0)
-        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(25, abi.runtime_ptr_save_gpr, jit_abi.table_size_off));
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(25, abi.runtime_ptr_save_gpr, jit_abi.table_size_off));
 }
 
 /// Wasm spec §4.4.14 (table.fill x) — pop n (i32), val (reftype),
@@ -383,12 +386,12 @@ pub fn emitTableFill(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(14, 31, w_n_src));
 
     // Step B: read TableSlice[tableidx]. Safe to clobber X10..X12.
-    //   X10 = tables_ptr; X11 = refs; W12 = len; X9 = funcptrs base.
+    //   X10 = tables_ptr; X11 = refs; X12 = len (u64, D-475); X9 = funcptrs base.
     // TODO: table storage shape — see D-126 / ADR-0068.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx10, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx11, 10, tbl_off));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(sx12, 10, @intCast(@as(u32, tbl_off) + 8)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx9, 10, @intCast(@as(u32, tbl_off) + 16)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx12, 10, @intCast(@as(u32, tbl_off) + jit_abi.tableslice_len_off)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx9, 10, @intCast(@as(u32, tbl_off) + jit_abi.tableslice_funcptrs_off)));
 
     // Step C: bounds check — trap if dst + n > len.
     //   X13 = X17 + X14  (both upper-bits zero → result fits in u33)
@@ -503,7 +506,7 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
 
     // Step C1: bounds check dst_idx + n vs tables[x].len.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx11, 10, dst_tbl_off));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(sx13, 10, @intCast(@as(u32, dst_tbl_off) + 8)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, 10, @intCast(@as(u32, dst_tbl_off) + jit_abi.tableslice_len_off)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(15, 17, 14));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(15, 13));
     {
@@ -515,7 +518,7 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
 
     // Step C2: bounds check src_idx + n vs tables[y].len.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx12, 10, src_tbl_off));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(sx13, 10, @intCast(@as(u32, src_tbl_off) + 8)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, 10, @intCast(@as(u32, src_tbl_off) + jit_abi.tableslice_len_off)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(15, 16, 14));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(15, 13));
     {
@@ -530,8 +533,8 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     // writes. X9 = dst_funcptrs, X13 = src_funcptrs. Both alive
     // through the loop (W13 was bounds-scratch — last use was the
     // CMP above; X10 still holds tables_ptr).
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx9, 10, @intCast(@as(u32, dst_tbl_off) + 16)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, 10, @intCast(@as(u32, src_tbl_off) + 16)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx9, 10, @intCast(@as(u32, dst_tbl_off) + jit_abi.tableslice_funcptrs_off)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, 10, @intCast(@as(u32, src_tbl_off) + jit_abi.tableslice_funcptrs_off)));
 
     // Also mirror the typeidx view (TableJitCallInfo stride 16,
     // typeidx_base at offset 8). Cross-table copy MUST update the
@@ -705,10 +708,10 @@ pub fn emitTableInit(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     const w_n_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, n_v, 0);
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(14, 31, w_n_src));
 
-    // Step B1: read tables[x] descriptor — X11 = dst_refs, W13 = dst_len.
+    // Step B1: read tables[x] descriptor — X11 = dst_refs, X13 = dst_len (u64, D-475).
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx10, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx11, 10, tbl_off));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(sx13, 10, @intCast(@as(u32, tbl_off) + 8)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, 10, @intCast(@as(u32, tbl_off) + jit_abi.tableslice_len_off)));
 
     // Step B2: read elems[y] descriptor — X12 = elem_refs, W15 = elem_len.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx10, abi.runtime_ptr_save_gpr, jit_abi.elem_segments_ptr_off));
@@ -752,7 +755,7 @@ pub fn emitTableInit(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     // currently holds elem_dropped_ptr from Step B3). X9/X13 are
     // bounds-scratch from Step C1/C2 but free here.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx9, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx9, 9, @intCast(@as(u32, tbl_off) + 16)));
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx9, 9, @intCast(@as(u32, tbl_off) + jit_abi.tableslice_funcptrs_off)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, abi.runtime_ptr_save_gpr, jit_abi.tables_jit_ci_ptr_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, 13, @intCast(@as(u32, tableidx) * jit_abi.table_jit_ci_size + 8)));
 

--- a/src/engine/codegen/arm64/op_table.zig
+++ b/src/engine/codegen/arm64/op_table.zig
@@ -348,7 +348,11 @@ pub fn emitTableGrow(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
         },
         .spill => |off| {
             const abs_off: u32 = ctx.spill_base_off + off;
-            try gpr.frameStrGpr(ctx.allocator, ctx.buf, 0, abs_off, true, abi.spill_stage_gprs[0]);
+            // X-form store for an i64 table (D-475): a W-store would
+            // leave stale upper bits in the slot, which the X-form
+            // spill reload of an i64 result then picks up (the -1
+            // failure sentinel becomes garbage). i32 keeps the W-store.
+            try gpr.frameStrGpr(ctx.allocator, ctx.buf, 0, abs_off, !idx64, abi.spill_stage_gprs[0]);
         },
     }
     try ctx.pushed_vregs.append(ctx.allocator, result);

--- a/src/engine/codegen/arm64/op_table.zig
+++ b/src/engine/codegen/arm64/op_table.zig
@@ -157,10 +157,12 @@ pub fn emitTableGet(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     if (ctx.pushed_vregs.items.len < 1) return Error.AllocationMissing;
     const idx_v = ctx.pushed_vregs.pop().?;
 
-    // Step A: snapshot idx into W17 (intra-procedure scratch, never
-    // in the regalloc pool).
+    // Step A: snapshot idx into W17/X17 (intra-procedure scratch, never
+    // in the regalloc pool). D-475: an i64 table pops a full 64-bit
+    // index (X-form ORR); an i32 table keeps the zero-extending W-form.
+    const idx64 = ctx.func.tableIdxType(tableidx) == .i64;
     const w_idx_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, idx_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(17, 31, w_idx_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encOrrReg(17, 31, w_idx_src) else inst.encOrrRegW(17, 31, w_idx_src));
 
     // Step B: read TableSlice[tableidx]. Use X14 / X15 (spill-
     // stage regs, non-allocatable) as scratch — they are free
@@ -208,10 +210,11 @@ pub fn emitTableSet(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     const idx_v = ctx.pushed_vregs.pop().?;
 
     // Step A: snapshot operands into intra-procedure scratch
-    // (X16/X17, never in the regalloc pool). idx → W17; val →
-    // X16 (full 64-bit ref).
+    // (X16/X17, never in the regalloc pool). idx → W17 (X17 for an
+    // i64 table, D-475); val → X16 (full 64-bit ref).
+    const idx64 = ctx.func.tableIdxType(tableidx) == .i64;
     const w_idx_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, idx_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(17, 31, w_idx_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encOrrReg(17, 31, w_idx_src) else inst.encOrrRegW(17, 31, w_idx_src));
     const x_val_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, val_v, 1);
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(16, 31, x_val_src));
 
@@ -314,9 +317,12 @@ pub fn emitTableGrow(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
 
     // Stage operands into AAPCS64 arg slots BEFORE clobbering X0/X1
     // with marshaling MOVs. Use ORR-ZR (alias for MOV) so partial
-    // and full-width transfers share the same encoder.
+    // and full-width transfers share the same encoder. D-475: an i64
+    // table's delta is a full u64 (X3); i32 keeps the zero-extending
+    // W-form (the callback takes u64, so W-staging is transparent).
+    const idx64 = ctx.func.tableIdxType(tableidx) == .i64;
     const w_delta_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, delta_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(3, 31, w_delta_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encOrrReg(3, 31, w_delta_src) else inst.encOrrRegW(3, 31, w_delta_src));
     const x_init_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, init_v, 1);
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(2, 31, x_init_src));
 
@@ -328,14 +334,17 @@ pub fn emitTableGrow(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(16, abi.runtime_ptr_save_gpr, jit_abi.table_grow_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(16));
 
-    // Capture W0 → result vreg as i32 (mirror op_call captureCallResult).
+    // Capture W0/X0 → result vreg (mirror op_call captureCallResult).
+    // D-475: an i64 table's grow result is a full i64 (X-form ORR);
+    // the callback returns i64, so the i32 W-capture truncates -1 /
+    // the sub-2^32 old size to the correct i32 bit pattern.
     const result = ctx.next_vreg.*;
     ctx.next_vreg.* += 1;
     if (result >= ctx.alloc.slots.len) return Error.SlotOverflow;
     switch (ctx.alloc.slot(result, .gpr)) {
         .reg => |id| {
             const wd = abi.slotToReg(id) orelse return Error.SlotOverflow;
-            if (wd != 0) try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(wd, 31, 0));
+            if (wd != 0) try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encOrrReg(wd, 31, 0) else inst.encOrrRegW(wd, 31, 0));
         },
         .spill => |off| {
             const abs_off: u32 = ctx.spill_base_off + off;
@@ -375,15 +384,16 @@ pub fn emitTableFill(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     const dst_v = ctx.pushed_vregs.pop().?;
 
     // Step A: snapshot operands into private holders.
-    //   W17 ← dst (zero-ext from i32 home)
-    //   X16 ← val (full 64-bit ref)
-    //   W14 ← n   (zero-ext from i32 home, used as loop counter)
+    //   W17/X17 ← dst (zero-ext from i32 home; full X for an i64 table, D-475)
+    //   X16     ← val (full 64-bit ref)
+    //   W14/X14 ← n   (same width rule as dst; used as loop counter)
+    const idx64 = ctx.func.tableIdxType(tableidx) == .i64;
     const w_dst_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, dst_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(17, 31, w_dst_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encOrrReg(17, 31, w_dst_src) else inst.encOrrRegW(17, 31, w_dst_src));
     const x_val_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, val_v, 1);
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(16, 31, x_val_src));
     const w_n_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, n_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(14, 31, w_n_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encOrrReg(14, 31, w_n_src) else inst.encOrrRegW(14, 31, w_n_src));
 
     // Step B: read TableSlice[tableidx]. Safe to clobber X10..X12.
     //   X10 = tables_ptr; X11 = refs; X12 = len (u64, D-475); X9 = funcptrs base.
@@ -394,10 +404,20 @@ pub fn emitTableFill(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx9, 10, @intCast(@as(u32, tbl_off) + jit_abi.tableslice_funcptrs_off)));
 
     // Step C: bounds check — trap if dst + n > len.
-    //   X13 = X17 + X14  (both upper-bits zero → result fits in u33)
+    //   X13 = X17 + X14  (i32 table: both upper-bits zero → fits u33,
+    //   plain ADD; i64 table: raw u64 operands can wrap past 2^64, so
+    //   ADDS + B.HS traps the wrap — the memory64 ea+size pattern.)
     //   CMP X13, X12
     //   B.HI trap
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(sx13, 17, 14));
+    if (idx64) {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddsReg(sx13, 17, 14));
+        const wrap_fixup_at: u32 = @intCast(ctx.buf.items.len);
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));
+        try ctx.cind_bounds_fixups.append(ctx.allocator, wrap_fixup_at); // D-293 oob_table (code 2)
+        trace.writeBounds(ctx.func.func_idx, wrap_fixup_at);
+    } else {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(sx13, 17, 14));
+    }
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(sx13, 12));
     {
         const fixup_at: u32 = @intCast(ctx.buf.items.len);
@@ -423,18 +443,19 @@ pub fn emitTableFill(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
         std.mem.writeInt(u32, ctx.buf.items[skip_setup_at..][0..4], inst.encCbz(sx9, disp), .little);
     }
 
-    // Step D: if n == 0, skip the loop entirely.
+    // Step D: if n == 0, skip the loop entirely. X-width test for an
+    // i64 table (W-CBZ would read only the low 32 bits of n).
     const skip_at: u32 = @intCast(ctx.buf.items.len);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCbzW(14, 0));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encCbz(14, 0) else inst.encCbzW(14, 0));
 
     // Step E: forward loop. Each iteration:
     //   STR X16, [X11, X17, LSL #3]   ; refs[dst] = val
     //   CBZ X9, .skip_fp              ; externref → skip funcptrs mirror
     //   STR X15, [X9, X17, LSL #3]    ; funcptrs[dst] = derived  (ADR-0068)
     //   .skip_fp:
-    //   ADD W17, W17, #1
-    //   SUB W14, W14, #1
-    //   CBNZ W14, .loop
+    //   ADD X17, X17, #1              ; (X-form; upper bits stay zero for i32)
+    //   SUB X14, X14, #1
+    //   CBNZ W14, .loop               ; (X-form for an i64 table)
     const loop_start: u32 = @intCast(ctx.buf.items.len);
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encStrXRegLsl3(16, 11, 17));
     const fill_skip_at: u32 = @intCast(ctx.buf.items.len);
@@ -452,7 +473,7 @@ pub fn emitTableFill(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
         @as(i32, @intCast(loop_start)) - @as(i32, @intCast(ctx.buf.items.len)),
         4,
     );
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCbnzW(14, back_disp_words));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (idx64) inst.encCbnz(14, back_disp_words) else inst.encCbnzW(14, back_disp_words));
 
     // Step F: patch the n==0 skip target.
     const end_byte: u32 = @intCast(ctx.buf.items.len);
@@ -460,7 +481,7 @@ pub fn emitTableFill(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
         @as(i32, @intCast(end_byte)) - @as(i32, @intCast(skip_at)),
         4,
     ));
-    std.mem.writeInt(u32, ctx.buf.items[skip_at..][0..4], inst.encCbzW(14, skip_disp_words), .little);
+    std.mem.writeInt(u32, ctx.buf.items[skip_at..][0..4], if (idx64) inst.encCbz(14, skip_disp_words) else inst.encCbzW(14, skip_disp_words), .little);
 }
 
 /// Wasm spec §4.4.15 (table.copy x y) — pop n / src / dst; copy n
@@ -493,21 +514,36 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     const src_v = ctx.pushed_vregs.pop().?;
     const dst_v = ctx.pushed_vregs.pop().?;
 
-    // Step A: snapshot operands into private holders.
+    // Step A: snapshot operands into private holders. D-475 widths per
+    // table (validator §3.3.6 table64): dst uses the DST table's
+    // idx_type, src the SRC table's, n the narrower of the two.
+    const dst64 = ctx.func.tableIdxType(dst_tbl) == .i64;
+    const src64 = ctx.func.tableIdxType(src_tbl) == .i64;
+    const n64 = dst64 and src64;
     const w_dst_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, dst_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(17, 31, w_dst_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (dst64) inst.encOrrReg(17, 31, w_dst_src) else inst.encOrrRegW(17, 31, w_dst_src));
     const w_src_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, src_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(16, 31, w_src_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (src64) inst.encOrrReg(16, 31, w_src_src) else inst.encOrrRegW(16, 31, w_src_src));
     const w_n_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, n_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(14, 31, w_n_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (n64) inst.encOrrReg(14, 31, w_n_src) else inst.encOrrRegW(14, 31, w_n_src));
 
     // Step B: load tables_ptr → X10.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx10, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off));
 
-    // Step C1: bounds check dst_idx + n vs tables[x].len.
+    // Step C1: bounds check dst_idx + n vs tables[x].len. A 64-bit dst
+    // can wrap the sum → ADDS + B.HS (memory64 pattern); i32 keeps the
+    // plain ADD (operands zero-extended, sum fits u33).
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx11, 10, dst_tbl_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, 10, @intCast(@as(u32, dst_tbl_off) + jit_abi.tableslice_len_off)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(15, 17, 14));
+    if (dst64) {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddsReg(15, 17, 14));
+        const wrap_fixup_at: u32 = @intCast(ctx.buf.items.len);
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));
+        try ctx.cind_bounds_fixups.append(ctx.allocator, wrap_fixup_at); // D-293 oob_table (code 2)
+        trace.writeBounds(ctx.func.func_idx, wrap_fixup_at);
+    } else {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(15, 17, 14));
+    }
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(15, 13));
     {
         const fixup_at: u32 = @intCast(ctx.buf.items.len);
@@ -516,10 +552,18 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
         trace.writeBounds(ctx.func.func_idx, fixup_at);
     }
 
-    // Step C2: bounds check src_idx + n vs tables[y].len.
+    // Step C2: bounds check src_idx + n vs tables[y].len (same wrap rule).
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx12, 10, src_tbl_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(sx13, 10, @intCast(@as(u32, src_tbl_off) + jit_abi.tableslice_len_off)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(15, 16, 14));
+    if (src64) {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddsReg(15, 16, 14));
+        const wrap_fixup_at: u32 = @intCast(ctx.buf.items.len);
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));
+        try ctx.cind_bounds_fixups.append(ctx.allocator, wrap_fixup_at); // D-293 oob_table (code 2)
+        trace.writeBounds(ctx.func.func_idx, wrap_fixup_at);
+    } else {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(15, 16, 14));
+    }
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(15, 13));
     {
         const fixup_at: u32 = @intCast(ctx.buf.items.len);
@@ -547,14 +591,15 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(8, 10, @intCast(@as(u32, dst_tbl) * jit_abi.table_jit_ci_size + 8)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(7, 10, @intCast(@as(u32, src_tbl) * jit_abi.table_jit_ci_size + 8)));
 
-    // Step D: if n == 0, skip the loop entirely.
+    // Step D: if n == 0, skip the loop entirely (X-width for i64-n).
     const skip_at: u32 = @intCast(ctx.buf.items.len);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCbzW(14, 0));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (n64) inst.encCbz(14, 0) else inst.encCbzW(14, 0));
 
     if (same_table) {
-        // Step E (same-table): direction switch.
+        // Step E (same-table): direction switch. Same table → same
+        // idx_type, so the compare width follows dst64.
         //   CMP W17, W16 ; B.LS .fwd  (dst <= src → forward safe)
-        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegW(17, 16));
+        try gpr.writeU32(ctx.allocator, ctx.buf, if (dst64) inst.encCmpRegX(17, 16) else inst.encCmpRegW(17, 16));
         const fwd_at: u32 = @intCast(ctx.buf.items.len);
         try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.ls, 0));
 
@@ -586,7 +631,7 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
                 @as(i32, @intCast(bwd_loop_start)) - @as(i32, @intCast(ctx.buf.items.len)),
                 4,
             );
-            try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCbnzW(14, back));
+            try gpr.writeU32(ctx.allocator, ctx.buf, if (n64) inst.encCbnz(14, back) else inst.encCbnzW(14, back));
         }
         const bwd_end_jmp_at: u32 = @intCast(ctx.buf.items.len);
         try gpr.writeU32(ctx.allocator, ctx.buf, inst.encB(0));
@@ -623,7 +668,7 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
                 @as(i32, @intCast(fwd_loop_start)) - @as(i32, @intCast(ctx.buf.items.len)),
                 4,
             );
-            try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCbnzW(14, back));
+            try gpr.writeU32(ctx.allocator, ctx.buf, if (n64) inst.encCbnz(14, back) else inst.encCbnzW(14, back));
         }
 
         // Patch the bwd→end jump.
@@ -660,7 +705,7 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
                 @as(i32, @intCast(fwd_loop_start)) - @as(i32, @intCast(ctx.buf.items.len)),
                 4,
             );
-            try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCbnzW(14, back));
+            try gpr.writeU32(ctx.allocator, ctx.buf, if (n64) inst.encCbnz(14, back) else inst.encCbnzW(14, back));
         }
     }
 
@@ -670,7 +715,7 @@ pub fn emitTableCopy(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
         @as(i32, @intCast(end_byte)) - @as(i32, @intCast(skip_at)),
         4,
     ));
-    std.mem.writeInt(u32, ctx.buf.items[skip_at..][0..4], inst.encCbzW(14, skip_disp), .little);
+    std.mem.writeInt(u32, ctx.buf.items[skip_at..][0..4], if (n64) inst.encCbz(14, skip_disp) else inst.encCbzW(14, skip_disp), .little);
 }
 
 /// Wasm spec §4.4.16 (table.init x y) — pop n / src / dst; copy n
@@ -700,9 +745,12 @@ pub fn emitTableInit(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
     const src_v = ctx.pushed_vregs.pop().?;
     const dst_v = ctx.pushed_vregs.pop().?;
 
-    // Step A: snapshot operands.
+    // Step A: snapshot operands. D-475: dst uses the table's idx_type
+    // (X-form for i64); src + n are ALWAYS i32 (elem segments are
+    // 32-bit-indexed, validator §3.3.6).
+    const dst64 = ctx.func.tableIdxType(tableidx) == .i64;
     const w_dst_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, dst_v, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(17, 31, w_dst_src));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (dst64) inst.encOrrReg(17, 31, w_dst_src) else inst.encOrrRegW(17, 31, w_dst_src));
     const w_src_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, src_v, 0);
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(16, 31, w_src_src));
     const w_n_src = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, n_v, 0);
@@ -739,8 +787,17 @@ pub fn emitTableInit(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
         trace.writeBounds(ctx.func.func_idx, fixup_at);
     }
 
-    // Step C2: bounds dst+n > tables[x].len → trap.
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(sx9, 17, 14));
+    // Step C2: bounds dst+n > tables[x].len → trap. A 64-bit dst can
+    // wrap the sum (n is zero-extended u32) → ADDS + B.HS (D-475).
+    if (dst64) {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddsReg(sx9, 17, 14));
+        const wrap_fixup_at: u32 = @intCast(ctx.buf.items.len);
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));
+        try ctx.cind_bounds_fixups.append(ctx.allocator, wrap_fixup_at); // D-293 oob_table (code 2)
+        trace.writeBounds(ctx.func.func_idx, wrap_fixup_at);
+    } else {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(sx9, 17, 14));
+    }
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(sx9, 13));
     {
         const fixup_at: u32 = @intCast(ctx.buf.items.len);

--- a/src/engine/codegen/arm64/op_tail_call.zig
+++ b/src/engine/codegen/arm64/op_tail_call.zig
@@ -249,10 +249,10 @@ pub fn emitIndirectReturnCall(
     if (expected_typeidx >= 4096) return ctx_mod.Error.UnsupportedOp;
 
     if (table_idx == 0) {
-        // Table-0 fast path: bounds via W25, sig via X24, funcptr via X26
+        // Table-0 fast path: bounds via X25, sig via X24, funcptr via X26
         // (the pinned per-call cohort) — mirrors emitCallIndirect.
-        // Bounds: CMP W17, W25 ; B.HS trap.
-        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegW(17, 25));
+        // Bounds: CMP X17, X25 ; B.HS trap (X-width, D-475: table_size u64).
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(17, 25));
         {
             const fixup_at: u32 = @intCast(ctx.buf.items.len);
             try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));
@@ -284,12 +284,12 @@ pub fn emitIndirectReturnCall(
         // funcptr lands in tail_target_gpr (X16) for the BR.
         if (jit_abi.table_jit_ci_size != 16) @compileError("multi-table tail-call assumes TableJitCallInfo stride 16");
         const rt_reg: inst.Xn = abi.runtime_ptr_save_gpr;
-        // Bounds: len = tables_ptr[table_idx].len (TableSlice +8).
-        const tbl_slice_byte_off: u32 = (table_idx * jit_abi.table_slice_size) + 8;
-        if (tbl_slice_byte_off > 16380) return ctx_mod.Error.UnsupportedOp;
+        // Bounds: len = tables_ptr[table_idx].len (u64 X-form, D-475).
+        const tbl_slice_byte_off: u32 = (table_idx * jit_abi.table_slice_size) + jit_abi.tableslice_len_off;
+        if (tbl_slice_byte_off > 32760) return ctx_mod.Error.UnsupportedOp;
         try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(16, rt_reg, jit_abi.tables_ptr_off));
-        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImmW(16, 16, @intCast(tbl_slice_byte_off)));
-        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegW(17, 16));
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(16, 16, @intCast(tbl_slice_byte_off)));
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(17, 16));
         {
             const fixup_at: u32 = @intCast(ctx.buf.items.len);
             try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hs, 0));

--- a/src/engine/codegen/arm64/op_tail_call.zig
+++ b/src/engine/codegen/arm64/op_tail_call.zig
@@ -242,8 +242,10 @@ pub fn emitIndirectReturnCall(
 
     try op_call.marshalCallArgs(ctx, callee_sig);
 
+    // D-475: an i64 table pops a full 64-bit index (X-form ORR into X17).
+    const ci_idx64 = ctx.func.tableIdxType(table_idx) == .i64;
     const w_idx = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, idx_vreg, 0);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrRegW(17, 31, w_idx));
+    try gpr.writeU32(ctx.allocator, ctx.buf, if (ci_idx64) inst.encOrrReg(17, 31, w_idx) else inst.encOrrRegW(17, 31, w_idx));
 
     const expected_typeidx: u32 = canonical_type.canonicalTypeidx(ctx.module_types, @intCast(ins.payload));
     if (expected_typeidx >= 4096) return ctx_mod.Error.UnsupportedOp;

--- a/src/engine/codegen/shared/compile.zig
+++ b/src/engine/codegen/shared/compile.zig
@@ -150,6 +150,11 @@ pub fn compileOne(
     /// the `jitCallIndirectSubtypeOk` trampoline (the inline D-111 structural
     /// compare is finality/subtype-blind). `false` for non-subtyping modules.
     uses_type_subtyping: bool,
+    /// D-475 (table64) — per-table index types (imports-first wasm table
+    /// index space). Attached to the produced `ZirFunc` so the table-op /
+    /// call_indirect emitters pick 32- vs 64-bit index widths per table.
+    /// `&.{}` for modules without tables (emitters default to `.i32`).
+    table_idx_types: []const zir.IdxType,
 ) Error!FuncResult {
     var func = ZirFunc.init(func_idx, sig, locals);
     errdefer func.deinit(allocator);
@@ -162,6 +167,8 @@ pub fn compileOne(
     // operands (so they survive the in-op subtype trampoline) + the
     // per-arch subtype emit path.
     func.uses_type_subtyping = uses_type_subtyping;
+    // D-475 — per-table idx_type widths for the table-op emitters.
+    func.table_idx_types = table_idx_types;
 
     // Per-pass diagnostic records (per ADR-0033).
     // Builds in-flight; transferred to `func.pass_diagnostics` at
@@ -363,7 +370,7 @@ test "compileOne: pass_diagnostics records all 6 passes when trace enabled" {
     // Pure instruction bytes: `i32.const 7` (0x41 0x07) + `end` (0x0B).
     const body = [_]u8{ 0x41, 0x07, 0x0B };
     const sig: FuncType = .{ .params = &.{}, .results = &.{.i32} };
-    var r = try compileOne(testing.allocator, 42, sig, &body, &.{}, &.{}, &.{sig}, 0, &.{}, &.{}, &.{}, .register_write, .i32, &.{}, &.{}, &.{}, &.{}, false);
+    var r = try compileOne(testing.allocator, 42, sig, &body, &.{}, &.{}, &.{sig}, 0, &.{}, &.{}, &.{}, .register_write, .i32, &.{}, &.{}, &.{}, &.{}, false, &.{});
     defer deinitFuncResult(testing.allocator, &r);
 
     // Per-function slot populated with 6 records, in pipeline order.
@@ -401,7 +408,7 @@ test "compileOne: tiny straight-line module — (func (result i32) i32.const 7 e
     const body = [_]u8{ 0x41, 0x07, 0x0B };
     const sig: FuncType = .{ .params = &.{}, .results = &.{.i32} };
 
-    var r = try compileOne(testing.allocator, 0, sig, &body, &.{}, &.{}, &.{sig}, 0, &.{}, &.{}, &.{}, .register_write, .i32, &.{}, &.{}, &.{}, &.{}, false);
+    var r = try compileOne(testing.allocator, 0, sig, &body, &.{}, &.{}, &.{sig}, 0, &.{}, &.{}, &.{}, .register_write, .i32, &.{}, &.{}, &.{}, &.{}, false, &.{});
     defer deinitFuncResult(testing.allocator, &r);
 
     const bodies = [_]linker.FuncBody{

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -195,7 +195,7 @@ pub const EhReifyCtx = jit_abi.EhReifyCtx;
 pub const reifyExnref = jit_abi.reifyExnref;
 pub const SegmentSlice = jit_abi.SegmentSlice;
 pub const TableSlice = jit_abi.TableSlice;
-pub const table_no_max: u32 = jit_abi.table_no_max;
+pub const table_no_max: u64 = jit_abi.table_no_max;
 pub const ElemSlice = jit_abi.ElemSlice;
 pub const TableJitCallInfo = jit_abi.TableJitCallInfo;
 

--- a/src/engine/codegen/shared/jit_abi.zig
+++ b/src/engine/codegen/shared/jit_abi.zig
@@ -9,7 +9,7 @@
 //!   X28 ← vm_base       (linear-memory base ptr)
 //!   X27 ← mem_limit     (linear-memory size in bytes)
 //!   X26 ← funcptr_base  (table 0 funcptr array)
-//!   X25 ← table_size    (table 0 entry count, W-width)
+//!   X25 ← table_size    (table 0 entry count, X-width u64 — D-475 table64)
 //!   X24 ← typeidx_base  (parallel u32 typeidx side-array)
 //!
 //! `extern struct` keeps the layout deterministic across Zig
@@ -64,7 +64,7 @@ pub const segment_slice_size: u32 = @sizeOf(SegmentSlice);
 /// Per-table slice descriptor (per ADR-0058)
 /// exposed to JIT `table.get` / `table.set` / `table.size`,
 /// `table.grow` / `table.fill`, `table.copy` / `table.init`.
-/// Layout is a fixed 16-byte stride so the JIT body indexes
+/// Layout is a fixed 32-byte stride so the JIT body indexes
 /// the `tables_ptr` array with `tableidx * table_slice_size`.
 ///
 /// `refs` points to the table's storage as `[*]u64` raw Value bits
@@ -81,8 +81,14 @@ pub const segment_slice_size: u32 = @sizeOf(SegmentSlice);
 /// max-cap check.
 pub const TableSlice = extern struct {
     refs: [*]u64,
-    len: u32,
-    max: u32,
+    /// Entry count. u64 per D-475 (table64): an i64-indexed table's
+    /// length is spec-u64; JIT bounds checks compare the (possibly
+    /// 64-bit) index against this at X/.q width on both arches.
+    len: u64,
+    /// Declared upper bound for `table.grow` (u64 per D-475; a
+    /// table64 declares u64 limits, spec §5.3.5). `table_no_max`
+    /// sentinel when the type has no explicit max.
+    max: u64,
     /// TODO(audit): table storage shape — see D-126 / ADR-0068.
     /// Parallel funcptr-view for the same table slot. `refs[i]` carries
     /// the FuncEntity-ptr encoding (per reftype semantics); `funcptrs[i]`
@@ -92,9 +98,11 @@ pub const TableSlice = extern struct {
     /// same logical entry in two shapes; ADR-0068's `mirrorWrite`
     /// helper keeps them in sync after every table-mutating op
     /// (`table.set` / `table.copy` / `table.init` / `table.grow` /
-    /// `table.fill`). Stride changed from 16 → 24 bytes; all JIT
-    /// `tables_ptr` indexers (op_table.zig / op_call.zig per-arch)
-    /// dereference via `table_slice_size` rather than a literal.
+    /// `table.fill`). Stride changed 16 → 24 (ADR-0068) → 32
+    /// (D-475 u64 len/max); all JIT `tables_ptr` indexers
+    /// (op_table.zig / op_call.zig per-arch) dereference via
+    /// `table_slice_size` + the `tableslice_*_off` field constants
+    /// rather than literals.
     ///
     /// `allowzero` carve-out: externref tables have no funcptr view,
     /// so setup writes the zero sentinel here. JIT mirror code's
@@ -104,10 +112,17 @@ pub const TableSlice = extern struct {
 
 pub const table_slice_size: u32 = @sizeOf(TableSlice);
 
+/// Field byte-offsets within `TableSlice` for the per-arch emitters
+/// (D-475: `len` widened to u64 moved `funcptrs` 16 → 24; emitted
+/// descriptor loads reference these instead of literals).
+pub const tableslice_len_off: u32 = @offsetOf(TableSlice, "len");
+pub const tableslice_funcptrs_off: u32 = @offsetOf(TableSlice, "funcptrs");
+
 /// Sentinel for `TableSlice.max` indicating "no explicit max" (per
 /// Wasm spec §3.2.1: tables without an explicit max field accept
-/// growth up to u32 range). Mirrors interp's `?u32` `null` arm.
-pub const table_no_max: u32 = std.math.maxInt(u32);
+/// growth up to the index-type range). Mirrors interp's `?u64`
+/// `null` arm (u64 per D-475 table64).
+pub const table_no_max: u64 = std.math.maxInt(u64);
 
 /// Per-element-segment slice descriptor (per ADR-0058 amendment)
 /// exposed to JIT `table.init`. Each entry stores
@@ -159,10 +174,10 @@ pub const JitRuntime = extern struct {
     /// Indexed by `call_indirect`'s computed table index.
     funcptr_base: [*]const u64,
     /// Table 0 entry count. JIT body's call_indirect bounds
-    /// check rejects `idx >= table_size` with a trap.
-    table_size: u32,
-    /// Padding to keep `typeidx_base` 8-byte-aligned.
-    _pad0: u32 = 0,
+    /// check rejects `idx >= table_size` with a trap. u64 per
+    /// D-475 (table64) — absorbs the former `_pad0`, so every
+    /// subsequent field offset is unchanged.
+    table_size: u64,
     /// Parallel array of u32 typeidx values for table 0;
     /// indexed identically to `funcptr_base`. JIT body's
     /// call_indirect sig check compares `typeidx_base[idx]`
@@ -337,8 +352,12 @@ pub const JitRuntime = extern struct {
     _pad11: u32 = 0,
     /// (D-122 / D-125): `table.grow tableidx`
     /// callout. Args: `(rt: *JitRuntime, tableidx: u32, init: u64,
-    /// delta: u32)` → previous entry count on success (widened to
-    /// i32), `-1` on failure. The fn MUST update the per-table
+    /// delta: u64)` → previous entry count on success (as i64),
+    /// `-1` on failure (D-475: u64 delta / i64 result so an i64
+    /// table's grow marshals at X/.q width; i32 tables stage the
+    /// delta W-form — zero-extended — and capture the low 32 result
+    /// bits, so the wider signature is transparent to them). The
+    /// fn MUST update the per-table
     /// `tables_ptr[tableidx].len` (and `refs` if reallocated) in
     /// place when growth succeeds. Calling convention is C-ABI
     /// (SysV/AAPCS64); callee-saved registers MUST be preserved.
@@ -346,7 +365,7 @@ pub const JitRuntime = extern struct {
     /// Defaults to `defaultTableGrowReject` (always returns -1)
     /// so JIT-emitted BLR/CALL through this slot is SEGV-safe out
     /// of the box. Spec runners override with `growableTableGrowFn`.
-    table_grow_fn: *const fn (rt: *JitRuntime, tableidx: u32, init: u64, delta: u32) callconv(.c) i32 = defaultTableGrowReject,
+    table_grow_fn: *const fn (rt: *JitRuntime, tableidx: u32, init: u64, delta: u64) callconv(.c) i64 = defaultTableGrowReject,
     /// ADR-0105 D1 — JIT-prologue stack-probe threshold. Set at
     /// entry-helper construction time via
     /// `platform.stack_limit.computeStackLimit(STACK_GUARD_HEADROOM)`;
@@ -654,7 +673,7 @@ pub fn defaultMemoryGrowReject(rt: *JitRuntime, delta_pages: u32) callconv(.c) i
 /// returning the spec sentinel `-1`. Spec-conformant for any host
 /// that opts to disallow runtime table growth (per Wasm 2.0
 /// §4.4.10.1).
-pub fn defaultTableGrowReject(rt: *JitRuntime, tableidx: u32, init: u64, delta: u32) callconv(.c) i32 {
+pub fn defaultTableGrowReject(rt: *JitRuntime, tableidx: u32, init: u64, delta: u64) callconv(.c) i64 {
     _ = rt;
     _ = tableidx;
     _ = init;
@@ -1319,11 +1338,11 @@ pub fn jitGcRefCast(rt: *JitRuntime, ref: u64, ht: u32) callconv(.c) u64 {
 /// arg marshal in a reserved scratch reg), x86_64 re-derives the funcptr inline
 /// (its idx survives in the all-callee-saved regalloc pool). gti null is
 /// impossible here (the module uses subtyping) but is handled as 0 for safety.
-pub fn jitCallIndirectResolve(rt: *JitRuntime, table_idx: u32, idx: u32, expected_typeidx: u32) callconv(.c) u64 {
+pub fn jitCallIndirectResolve(rt: *JitRuntime, table_idx: u32, idx: u64, expected_typeidx: u32) callconv(.c) u64 {
     const gti: *const gc_type_info.GcTypeInfos = if (rt.gc_type_infos_ptr) |p| @ptrCast(@alignCast(p)) else return 0;
     var funcptr_base: [*]const u64 = undefined;
     var typeidx_base: [*]const u32 = undefined;
-    var size: u32 = undefined;
+    var size: u64 = undefined;
     if (table_idx == 0) {
         funcptr_base = rt.funcptr_base;
         typeidx_base = rt.typeidx_base;
@@ -1471,9 +1490,9 @@ comptime {
     if ((interrupt_ptr_off & 7) != 0) @compileError("interrupt_ptr_off not 8-aligned");
     if ((fuel_metered_off & 3) != 0) @compileError("fuel_metered_off not 4-aligned");
     if ((fuel_cell_off & 7) != 0) @compileError("fuel_cell_off not 8-aligned");
-    // table_size is W-form (4 bytes); imm12 scales by 4. Must
-    // be 4-aligned.
-    if ((table_size_off & 3) != 0) @compileError("table_size_off not 4-aligned");
+    // table_size is X-form (u64 per D-475 table64); imm12 scales
+    // by 8. Must be 8-aligned.
+    if ((table_size_off & 7) != 0) @compileError("table_size_off not 8-aligned");
     if ((trap_flag_off & 3) != 0) @compileError("trap_flag_off not 4-aligned");
     // imm12 budget. With current 6 fields all near offset 0, this
     // is comfortable; future tail-extensions could exceed it.
@@ -1481,7 +1500,7 @@ comptime {
     if (mem_limit_off > 32760) @compileError("mem_limit_off exceeds X-form imm12 budget");
     if (funcptr_base_off > 32760) @compileError("funcptr_base_off exceeds X-form imm12 budget");
     if (typeidx_base_off > 32760) @compileError("typeidx_base_off exceeds X-form imm12 budget");
-    if (table_size_off > 16380) @compileError("table_size_off exceeds W-form imm12 budget");
+    if (table_size_off > 32760) @compileError("table_size_off exceeds X-form imm12 budget");
     if (trap_flag_off > 16380) @compileError("trap_flag_off exceeds W-form imm12 budget");
     // ADR-0027: globals_base + globals_count alignment + budget.
     if ((globals_base_off & 7) != 0) @compileError("globals_base_off not 8-aligned");
@@ -1525,17 +1544,17 @@ comptime {
     if (tables_ptr_off > 32760) @compileError("tables_ptr_off exceeds X-form imm12 budget");
     if (tables_count_off > 16380) @compileError("tables_count_off exceeds W-form imm12 budget");
     // TODO(audit): table storage shape — see D-126 / ADR-0068.
-    // TableSlice layout: 24 bytes after ADR-0068 stride extension
-    // (refs ptr + u32 len + u32 max + funcptrs ptr). JIT relies on
-    // `LDR Xn, [tbl_base, #(idx*24)+0]` (refs),
-    // `LDR Wn, [tbl_base, #(idx*24)+8]` (len),
-    // `LDR Wn, [tbl_base, #(idx*24)+12]` (max),
-    // `LDR Xn, [tbl_base, #(idx*24)+16]` (funcptrs).
-    if (@sizeOf(TableSlice) != 24) @compileError("TableSlice size != 24; JIT table.get stride assumption broken");
+    // TableSlice layout: 32 bytes after the D-475 u64 len/max widen
+    // (refs ptr + u64 len + u64 max + funcptrs ptr). JIT relies on
+    // `LDR Xn, [tbl_base, #(idx*32)+0]` (refs),
+    // `LDR Xn, [tbl_base, #(idx*32)+8]` (len),
+    // `LDR Xn, [tbl_base, #(idx*32)+16]` (max),
+    // `LDR Xn, [tbl_base, #(idx*32)+24]` (funcptrs).
+    if (@sizeOf(TableSlice) != 32) @compileError("TableSlice size != 32; JIT table.get stride assumption broken");
     if (@offsetOf(TableSlice, "refs") != 0) @compileError("TableSlice.refs offset != 0");
     if (@offsetOf(TableSlice, "len") != 8) @compileError("TableSlice.len offset != 8");
-    if (@offsetOf(TableSlice, "max") != 12) @compileError("TableSlice.max offset != 12");
-    if (@offsetOf(TableSlice, "funcptrs") != 16) @compileError("TableSlice.funcptrs offset != 16");
+    if (@offsetOf(TableSlice, "max") != 16) @compileError("TableSlice.max offset != 16");
+    if (@offsetOf(TableSlice, "funcptrs") != 24) @compileError("TableSlice.funcptrs offset != 24");
     // elem_segments_ptr is X-form; count is W-form.
     if ((elem_segments_ptr_off & 7) != 0) @compileError("elem_segments_ptr_off not 8-aligned");
     if ((elem_segments_count_off & 3) != 0) @compileError("elem_segments_count_off not 4-aligned");
@@ -1836,12 +1855,14 @@ test "JitRuntime: new field offsets" {
     try testing.expectEqual(@as(u12, 176), elem_segments_count_off);
 }
 
-test "TableSlice: layout is 24 bytes with refs/len/max/funcptrs at expected offsets (ADR-0068)" {
-    try testing.expectEqual(@as(u32, 24), table_slice_size);
+test "TableSlice: layout is 32 bytes with refs/len/max/funcptrs at expected offsets (ADR-0068 + D-475 u64 widen)" {
+    try testing.expectEqual(@as(u32, 32), table_slice_size);
     try testing.expectEqual(@as(usize, 0), @offsetOf(TableSlice, "refs"));
     try testing.expectEqual(@as(usize, 8), @offsetOf(TableSlice, "len"));
-    try testing.expectEqual(@as(usize, 12), @offsetOf(TableSlice, "max"));
-    try testing.expectEqual(@as(usize, 16), @offsetOf(TableSlice, "funcptrs"));
+    try testing.expectEqual(@as(usize, 16), @offsetOf(TableSlice, "max"));
+    try testing.expectEqual(@as(usize, 24), @offsetOf(TableSlice, "funcptrs"));
+    try testing.expectEqual(@as(usize, 8), tableslice_len_off);
+    try testing.expectEqual(@as(usize, 24), tableslice_funcptrs_off);
 }
 
 test "ElemSlice: layout is 16 bytes with refs/len at expected offsets" {
@@ -1869,7 +1890,7 @@ test "JitRuntime: round-trip construction + field reads" {
         .host_dispatch_count = dispatch.len,
     };
     try testing.expectEqual(@as(u64, 16), rt.mem_limit);
-    try testing.expectEqual(@as(u32, 1), rt.table_size);
+    try testing.expectEqual(@as(u64, 1), rt.table_size);
     try testing.expectEqual(@as(u8, 0xDE), rt.vm_base[0]);
     try testing.expectEqual(@as(u64, 0xCAFE0000), rt.funcptr_base[0]);
     try testing.expectEqual(@as(u32, 7), rt.typeidx_base[0]);

--- a/src/engine/codegen/x86_64/emit_test_int.zig
+++ b/src/engine/codegen/x86_64/emit_test_int.zig
@@ -1597,7 +1597,7 @@ test "compile: call_indirect — bounds + sig (JAE+JNE → trap stub) + CALL RAX
     // Slot 0 = RBX → no REX.R/B for the idx; encodings shrink vs the
     // pre-13b R10 layout.
     //   [13..18]  MOV EBX, 5              (i32.const, 5 bytes)
-    //   [18..25]  MOV EAX, [R15 + 24]     (load table_size, 7 bytes)
+    //   [18..25]  MOV RAX, [R15 + 24]     (load table_size, u64 D-475, 7 bytes)
     //   [25..27]  CMP EBX, EAX            (bounds compare, 2 bytes)
     //   [27..33]  JAE rel32 placeholder   (bounds fixup, 6 bytes)
     //   [33..40]  MOV RAX, [R15 + 32]     (load typeidx_base, 7 bytes)
@@ -1613,7 +1613,7 @@ test "compile: call_indirect — bounds + sig (JAE+JNE → trap stub) + CALL RAX
     // All assertions use body_start_offset() so they survive
     // future +7 prologue shift from JIT-execution sentinel injection.
     const body_start = prologue.body_start_offset(true, 8);
-    const expected_table_size_load = inst.encMovR32FromMemDisp32(.rax, .r15, 24);
+    const expected_table_size_load = inst.encMovR64FromMemDisp32(.rax, .r15, 24);
     const table_size_off = body_start + 5;
     try testing.expectEqualSlices(u8, expected_table_size_load.slice(), out.bytes[table_size_off .. table_size_off + expected_table_size_load.len]);
     // JAE/JE/JNE rel32 disp32 is patched at function-tail to point at the

--- a/src/engine/codegen/x86_64/op_call.zig
+++ b/src/engine/codegen/x86_64/op_call.zig
@@ -167,6 +167,8 @@ pub fn emitCallIndirectCtx(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Erro
         @as(u32, @intCast(ins.payload)),
         ins.extra,
         ctx.uses_type_subtyping,
+        // D-475: table_idx = ins.extra; i64 tables pop a 64-bit index.
+        ctx.func.tableIdxType(ins.extra) == .i64,
     );
     try reloadHomedCallerSaved(ctx);
     try op_control.emitPostCallTrapCheck(ctx);
@@ -464,6 +466,9 @@ pub fn emitCallIndirect(
     /// `jitCallIndirectResolve` trampoline (vs the finality/subtype-blind
     /// inline D-111 CMP). `false` keeps the byte-identical inline path.
     uses_type_subtyping: bool,
+    /// D-475 (table64) — the target table is i64-indexed: stage/compare
+    /// the popped index at .q width instead of the i32 .d fast path.
+    ci_idx64: bool,
 ) Error!void {
     if (type_idx >= module_types.len) return Error.AllocationMissing;
     const callee_sig = module_types[type_idx];
@@ -488,7 +493,7 @@ pub fn emitCallIndirect(
         // args: ag[0]=rt, ag[1]=table_idx, ag[2]=idx, ag[3]=expected_raw.
         // idx_r0 ∉ arg_gprs (it is callee-saved pool or a stage reg), so the
         // arg-reg writes can't clobber it.
-        if (idx_r0 != ag[2]) try buf.appendSlice(allocator, inst.encMovRR(.d, ag[2], idx_r0).slice());
+        if (idx_r0 != ag[2]) try buf.appendSlice(allocator, inst.encMovRR(if (ci_idx64) .q else .d, ag[2], idx_r0).slice());
         try buf.appendSlice(allocator, inst.encMovRR(.q, ag[0], abi.runtime_ptr_save_gpr).slice());
         try buf.appendSlice(allocator, inst.encMovImm32W(ag[1], table_idx).slice());
         try buf.appendSlice(allocator, inst.encMovImm32W(ag[3], expected_raw).slice());
@@ -537,12 +542,11 @@ pub fn emitCallIndirect(
         // resolve trampoline above → skip the inline bounds + sig (the inline
         // D-111 CMP is finality/subtype-blind). funcptr re-derived below.
         if (!uses_type_subtyping) {
-            // Bounds: MOV RAX, [R15 + table_size_off] ; CMP idx_r, EAX ; JAE trap.
-            // 64-bit load (D-475: table_size is u64); the CMP stays .d for the
-            // i32-table fast path (low half == len while the table is i32-indexed;
-            // the i64-table path widens the compare per idx_type — C3).
+            // Bounds: MOV RAX, [R15 + table_size_off] ; CMP idx_r, RAX/EAX ; JAE trap.
+            // 64-bit load (D-475: table_size is u64); the CMP is .q for an
+            // i64 table (full 64-bit index) and stays .d on the i32 fast path.
             try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.table_size_off).slice());
-            try buf.appendSlice(allocator, inst.encCmpRR(.d, idx_r, .rax).slice());
+            try buf.appendSlice(allocator, inst.encCmpRR(if (ci_idx64) .q else .d, idx_r, .rax).slice());
             {
                 const fixup_at: u32 = @intCast(buf.items.len);
                 try buf.appendSlice(allocator, inst.encJccRel32(.ae, 0).slice());
@@ -601,10 +605,10 @@ pub fn emitCallIndirect(
         if (!uses_type_subtyping) {
             // Bounds: MOV RAX, [R15 + tables_ptr_off]
             //         MOV RAX, [RAX + (table_idx*table_slice_size + len_off)]  ; TableSlice.len (u64, D-475)
-            //         CMP idx_r, EAX ; JAE trap (.d for the i32-table path; C3 widens per idx_type).
+            //         CMP idx_r, RAX/EAX ; JAE trap (.q for an i64 table).
             try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
             try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, .rax, tbl_slice_disp).slice());
-            try buf.appendSlice(allocator, inst.encCmpRR(.d, idx_r, .rax).slice());
+            try buf.appendSlice(allocator, inst.encCmpRR(if (ci_idx64) .q else .d, idx_r, .rax).slice());
             {
                 const fixup_at: u32 = @intCast(buf.items.len);
                 try buf.appendSlice(allocator, inst.encJccRel32(.ae, 0).slice());

--- a/src/engine/codegen/x86_64/op_call.zig
+++ b/src/engine/codegen/x86_64/op_call.zig
@@ -537,8 +537,11 @@ pub fn emitCallIndirect(
         // resolve trampoline above → skip the inline bounds + sig (the inline
         // D-111 CMP is finality/subtype-blind). funcptr re-derived below.
         if (!uses_type_subtyping) {
-            // Bounds: MOV EAX, [R15 + table_size_off] ; CMP idx_r, EAX ; JAE trap.
-            try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.table_size_off).slice());
+            // Bounds: MOV RAX, [R15 + table_size_off] ; CMP idx_r, EAX ; JAE trap.
+            // 64-bit load (D-475: table_size is u64); the CMP stays .d for the
+            // i32-table fast path (low half == len while the table is i32-indexed;
+            // the i64-table path widens the compare per idx_type — C3).
+            try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.table_size_off).slice());
             try buf.appendSlice(allocator, inst.encCmpRR(.d, idx_r, .rax).slice());
             {
                 const fixup_at: u32 = @intCast(buf.items.len);
@@ -587,10 +590,9 @@ pub fn emitCallIndirect(
         if (jit_abi.table_jit_ci_size != 16) @compileError("multi-table x86_64 emit assumes TableJitCallInfo stride 16");
 
         // TODO(9.12-audit): table storage shape — see D-126 / ADR-0068.
-        // TableSlice stride is `table_slice_size` (= 16 pre-ADR-0068,
-        // 24 after the dual-view extension). TableJitCallInfo stride
-        // stays 16 (no extension yet).
-        const tbl_slice_disp: i32 = @intCast((table_idx * jit_abi.table_slice_size) + 8);
+        // TableSlice stride is `table_slice_size` (32 after the D-475
+        // u64 len/max widen). TableJitCallInfo stride stays 16.
+        const tbl_slice_disp: i32 = @intCast((table_idx * jit_abi.table_slice_size) + jit_abi.tableslice_len_off);
         const ci_funcptr_disp: i32 = @intCast(table_idx * 16);
         const ci_typeidx_disp: i32 = @intCast((table_idx * 16) + 8);
 
@@ -598,10 +600,10 @@ pub fn emitCallIndirect(
         // resolve trampoline above → skip the inline bounds + sig.
         if (!uses_type_subtyping) {
             // Bounds: MOV RAX, [R15 + tables_ptr_off]
-            //         MOV EAX, [RAX + (table_idx*table_slice_size + 8)]  ; TableSlice.len
-            //         CMP idx_r, EAX ; JAE trap.
+            //         MOV RAX, [RAX + (table_idx*table_slice_size + len_off)]  ; TableSlice.len (u64, D-475)
+            //         CMP idx_r, EAX ; JAE trap (.d for the i32-table path; C3 widens per idx_type).
             try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
-            try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(.rax, .rax, tbl_slice_disp).slice());
+            try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, .rax, tbl_slice_disp).slice());
             try buf.appendSlice(allocator, inst.encCmpRR(.d, idx_r, .rax).slice());
             {
                 const fixup_at: u32 = @intCast(buf.items.len);

--- a/src/engine/codegen/x86_64/op_table.zig
+++ b/src/engine/codegen/x86_64/op_table.zig
@@ -66,6 +66,7 @@ pub fn emitTableGetCtx(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Error!vo
         ctx.spill_base_off,
         ctx.func_idx,
         @as(u32, @intCast(ins.payload)),
+        ctx.func.tableIdxType(@intCast(ins.payload)) == .i64,
     );
 }
 
@@ -79,6 +80,7 @@ pub fn emitTableSetCtx(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Error!vo
         ctx.spill_base_off,
         ctx.func_idx,
         @as(u32, @intCast(ins.payload)),
+        ctx.func.tableIdxType(@intCast(ins.payload)) == .i64,
     );
 }
 
@@ -104,6 +106,7 @@ pub fn emitTableGrowCtx(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Error!v
         ctx.spill_base_off,
         ctx.outgoing_max_bytes,
         @as(u32, @intCast(ins.payload)),
+        ctx.func.tableIdxType(@intCast(ins.payload)) == .i64,
     );
 }
 
@@ -117,6 +120,7 @@ pub fn emitTableFillCtx(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Error!v
         ctx.spill_base_off,
         ctx.func_idx,
         @as(u32, @intCast(ins.payload)),
+        ctx.func.tableIdxType(@intCast(ins.payload)) == .i64,
     );
 }
 
@@ -131,6 +135,8 @@ pub fn emitTableCopyCtx(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Error!v
         ctx.func_idx,
         @as(u32, @intCast(ins.payload)),
         ins.extra,
+        ctx.func.tableIdxType(@intCast(ins.payload)) == .i64,
+        ctx.func.tableIdxType(ins.extra) == .i64,
     );
 }
 
@@ -145,6 +151,8 @@ pub fn emitTableInitCtx(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Error!v
         ctx.func_idx,
         @as(u32, @intCast(ins.payload)),
         ins.extra,
+        // ins.extra = tableidx (dst); ins.payload = elemidx.
+        ctx.func.tableIdxType(ins.extra) == .i64,
     );
 }
 const func_mod = @import("../../../runtime/instance/func.zig");
@@ -229,11 +237,11 @@ pub fn emitTableGet(
     spill_base_off: u32,
     func_idx: u32,
     tableidx: u32,
+    idx64: bool,
 ) Error!void {
     // TODO(9.12-audit): table storage shape — see D-126 / ADR-0068.
     // Encoding-budget guard. disp32 always suffices; cap matches
-    // arm64's 512 (lowered from 1024 when TableSlice stride moved
-    // from 16 → 24 per ADR-0068).
+    // arm64's 512 (stride 24 per ADR-0068, 32 after D-475).
     if (tableidx >= 512) return Error.UnsupportedOp;
     const tbl_disp: i32 = @intCast(tableidx * jit_abi.table_slice_size);
 
@@ -245,9 +253,10 @@ pub fn emitTableGet(
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r11, .rax, tbl_disp).slice());
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r10, .rax, tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
 
-    // Stage idx in EDX (32-bit MOV zero-extends to RDX implicitly).
+    // Stage idx in EDX (32-bit MOV zero-extends to RDX implicitly);
+    // an i64 table stages the full 64-bit index (.q, D-475).
     const idx_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, idx_v, 0);
-    try buf.appendSlice(allocator, inst.encMovRR(.d, .rdx, idx_r).slice());
+    try buf.appendSlice(allocator, inst.encMovRR(if (idx64) .q else .d, .rdx, idx_r).slice());
 
     // CMP RDX, R10 ; JAE trap. .q width (D-475: len is u64).
     try buf.appendSlice(allocator, inst.encCmpRR(.q, .rdx, .r10).slice());
@@ -281,6 +290,7 @@ pub fn emitTableSet(
     spill_base_off: u32,
     func_idx: u32,
     tableidx: u32,
+    idx64: bool,
 ) Error!void {
     if (tableidx >= 512) return Error.UnsupportedOp;
     const tbl_disp: i32 = @intCast(tableidx * jit_abi.table_slice_size);
@@ -299,7 +309,7 @@ pub fn emitTableSet(
     // R9 is not allocatable, not a spill stage, untouched by the descriptor
     // loads and the funcptr/typeidx mirror below).
     const idx_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, idx_v, 0);
-    try buf.appendSlice(allocator, inst.encMovRR(.d, .rdx, idx_r).slice());
+    try buf.appendSlice(allocator, inst.encMovRR(if (idx64) .q else .d, .rdx, idx_r).slice());
     const val_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, val_v, 1);
     try buf.appendSlice(allocator, inst.encMovRR(.q, .r9, val_r).slice());
 
@@ -386,6 +396,7 @@ pub fn emitTableGrow(
     spill_base_off: u32,
     outgoing_max_bytes: u32,
     tableidx: u32,
+    idx64: bool,
 ) Error!void {
     if (tableidx >= 512) return Error.UnsupportedOp;
 
@@ -399,9 +410,11 @@ pub fn emitTableGrow(
 
     // Stage delta into arg3 (Cc-dependent). gprLoadSpilled may park
     // it in R10 (spill-stage); MOV to arg3 if needed.
+    // D-475: an i64 table's delta is a full u64 (.q); i32 keeps the
+    // zero-extending .d (the callback takes u64 — transparent).
     const delta_src = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, delta_v, 0);
     if (delta_src != arg3) {
-        try buf.appendSlice(allocator, inst.encMovRR(.d, arg3, delta_src).slice());
+        try buf.appendSlice(allocator, inst.encMovRR(if (idx64) .q else .d, arg3, delta_src).slice());
     }
 
     // Stage init into arg2 (full 8-byte ref). Stage 1 to avoid
@@ -424,13 +437,15 @@ pub fn emitTableGrow(
     try buf.appendSlice(allocator, inst.encCallReg(.rax).slice());
     try emitShadowFree(allocator, buf, outgoing_max_bytes);
 
-    // Capture EAX → result vreg.
+    // Capture EAX/RAX → result vreg. D-475: an i64 table's grow result
+    // is a full i64 (.q); the i32 .d capture truncates -1 / the
+    // sub-2^32 old size to the correct i32 bit pattern.
     const result_v = next_vreg.*;
     next_vreg.* += 1;
     if (result_v >= alloc.slots.len) return Error.SlotOverflow;
     const dst_r = try gpr.gprDefSpilled(alloc, result_v, 0);
     if (dst_r != abi.return_gpr) {
-        try buf.appendSlice(allocator, inst.encMovRR(.d, dst_r, abi.return_gpr).slice());
+        try buf.appendSlice(allocator, inst.encMovRR(if (idx64) .q else .d, dst_r, abi.return_gpr).slice());
     }
     try gpr.gprStoreSpilled(allocator, buf, alloc, spill_base_off, result_v, 0);
     try pushed_vregs.append(allocator, result_v);
@@ -453,6 +468,7 @@ pub fn emitTableFill(
     spill_base_off: u32,
     func_idx: u32,
     tableidx: u32,
+    idx64: bool,
 ) Error!void {
     if (tableidx >= 512) return Error.UnsupportedOp;
     const tbl_disp: i32 = @intCast(tableidx * jit_abi.table_slice_size);
@@ -468,11 +484,11 @@ pub fn emitTableFill(
     // this snapshot pass is technically unnecessary for safety;
     // doing it explicitly mirrors the arm64 path's invariant.
     const dst_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, dst_v, 0);
-    try buf.appendSlice(allocator, inst.encMovRR(.d, .rdx, dst_r).slice());
+    try buf.appendSlice(allocator, inst.encMovRR(if (idx64) .q else .d, .rdx, dst_r).slice());
     const val_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, val_v, 1);
     try buf.appendSlice(allocator, inst.encMovRR(.q, .r8, val_r).slice());
     const n_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, n_v, 0);
-    try buf.appendSlice(allocator, inst.encMovRR(.d, .r10, n_r).slice());
+    try buf.appendSlice(allocator, inst.encMovRR(if (idx64) .q else .d, .r10, n_r).slice());
 
     // Step B: read TableSlice[tableidx]. RAX = tables_ptr; R11 = refs;
     // R9 = len (u64, D-475; using R9 since R10/R11/RDX/R8 are already in use).
@@ -487,6 +503,14 @@ pub fn emitTableFill(
     //   JA   trap_stub
     try buf.appendSlice(allocator, inst.encMovRR(.q, .rax, .rdx).slice());
     try buf.appendSlice(allocator, inst.encAddRR(.q, .rax, .r10).slice());
+    if (idx64) {
+        // D-475: raw u64 dst+n can wrap past 2^64 — JC (carry) traps
+        // the wrap before the length compare (memory64 pattern).
+        const wrap_fixup_at: u32 = @intCast(buf.items.len);
+        try buf.appendSlice(allocator, inst.encJccRel32(.b, 0).slice());
+        try oobtable_fixups.append(allocator, wrap_fixup_at);
+        trace.writeBounds(func_idx, wrap_fixup_at);
+    }
     try buf.appendSlice(allocator, inst.encCmpRR(.q, .rax, .r9).slice());
     {
         const fixup_at: u32 = @intCast(buf.items.len);
@@ -573,6 +597,8 @@ pub fn emitTableCopy(
     func_idx: u32,
     dst_tbl: u32,
     src_tbl: u32,
+    dst64: bool,
+    src64: bool,
 ) Error!void {
     if (dst_tbl >= 512 or src_tbl >= 512) return Error.UnsupportedOp;
     const dst_tbl_disp: i32 = @intCast(dst_tbl * jit_abi.table_slice_size);
@@ -584,13 +610,16 @@ pub fn emitTableCopy(
     const src_v = pushed_vregs.pop().?;
     const dst_v = pushed_vregs.pop().?;
 
-    // Step A: capture operands into private holders.
+    // Step A: capture operands into private holders. D-475 widths per
+    // table (validator §3.3.6 table64): dst uses the DST table's
+    // idx_type, src the SRC table's, n the narrower of the two.
+    const n64 = dst64 and src64;
     const dst_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, dst_v, 0);
-    try buf.appendSlice(allocator, inst.encMovRR(.d, .rdx, dst_r).slice());
+    try buf.appendSlice(allocator, inst.encMovRR(if (dst64) .q else .d, .rdx, dst_r).slice());
     const src_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, src_v, 0);
-    try buf.appendSlice(allocator, inst.encMovRR(.d, .r8, src_r).slice());
+    try buf.appendSlice(allocator, inst.encMovRR(if (src64) .q else .d, .r8, src_r).slice());
     const n_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, n_v, 0);
-    try buf.appendSlice(allocator, inst.encMovRR(.d, .r10, n_r).slice());
+    try buf.appendSlice(allocator, inst.encMovRR(if (n64) .q else .d, .r10, n_r).slice());
 
     // Step B: load tables_ptr → RAX.
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
@@ -602,6 +631,13 @@ pub fn emitTableCopy(
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r9, .rax, dst_tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
     try buf.appendSlice(allocator, inst.encMovRR(.q, .rdi, .rdx).slice());
     try buf.appendSlice(allocator, inst.encAddRR(.q, .rdi, .r10).slice());
+    if (dst64) {
+        // D-475: raw u64 dst+n can wrap — JC traps the wrap.
+        const wrap_fixup_at: u32 = @intCast(buf.items.len);
+        try buf.appendSlice(allocator, inst.encJccRel32(.b, 0).slice());
+        try oobtable_fixups.append(allocator, wrap_fixup_at);
+        trace.writeBounds(func_idx, wrap_fixup_at);
+    }
     try buf.appendSlice(allocator, inst.encCmpRR(.q, .rdi, .r9).slice());
     {
         const fixup_at: u32 = @intCast(buf.items.len);
@@ -616,6 +652,13 @@ pub fn emitTableCopy(
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r9, .rax, src_tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
     try buf.appendSlice(allocator, inst.encMovRR(.q, .rdi, .r8).slice());
     try buf.appendSlice(allocator, inst.encAddRR(.q, .rdi, .r10).slice());
+    if (src64) {
+        // D-475: raw u64 src+n can wrap — JC traps the wrap.
+        const wrap_fixup_at: u32 = @intCast(buf.items.len);
+        try buf.appendSlice(allocator, inst.encJccRel32(.b, 0).slice());
+        try oobtable_fixups.append(allocator, wrap_fixup_at);
+        trace.writeBounds(func_idx, wrap_fixup_at);
+    }
     try buf.appendSlice(allocator, inst.encCmpRR(.q, .rdi, .r9).slice());
     {
         const fixup_at: u32 = @intCast(buf.items.len);
@@ -780,8 +823,9 @@ pub fn emitTableInit(
     func_idx: u32,
     elemidx: u32,
     tableidx: u32,
+    dst64: bool,
 ) Error!void {
-    // tableidx cap = 512 (TableSlice stride 24 per ADR-0068);
+    // tableidx cap = 512 (TableSlice stride 32 per D-475);
     // elemidx cap stays 1024 (ElemSlice stride still 16).
     if (elemidx >= 1024 or tableidx >= 512) return Error.UnsupportedOp;
     const tbl_disp: i32 = @intCast(tableidx * jit_abi.table_slice_size);
@@ -792,9 +836,11 @@ pub fn emitTableInit(
     const src_v = pushed_vregs.pop().?;
     const dst_v = pushed_vregs.pop().?;
 
-    // Step A: capture operands.
+    // Step A: capture operands. D-475: dst uses the table's idx_type
+    // (.q for i64); src + n are ALWAYS i32 (elem segments are
+    // 32-bit-indexed, validator §3.3.6).
     const dst_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, dst_v, 0);
-    try buf.appendSlice(allocator, inst.encMovRR(.d, .rdx, dst_r).slice());
+    try buf.appendSlice(allocator, inst.encMovRR(if (dst64) .q else .d, .rdx, dst_r).slice());
     const src_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, src_v, 0);
     try buf.appendSlice(allocator, inst.encMovRR(.d, .r8, src_r).slice());
     const n_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, n_v, 0);
@@ -835,9 +881,16 @@ pub fn emitTableInit(
         trace.writeBounds(func_idx, fixup_at);
     }
 
-    // Step C2: bounds dst+n > dst_len (R9).
+    // Step C2: bounds dst+n > dst_len (R9). A 64-bit dst can wrap the
+    // sum (n is zero-extended u32) — JC traps the wrap (D-475).
     try buf.appendSlice(allocator, inst.encMovRR(.q, .rdi, .rdx).slice());
     try buf.appendSlice(allocator, inst.encAddRR(.q, .rdi, .r10).slice());
+    if (dst64) {
+        const wrap_fixup_at: u32 = @intCast(buf.items.len);
+        try buf.appendSlice(allocator, inst.encJccRel32(.b, 0).slice());
+        try oobtable_fixups.append(allocator, wrap_fixup_at);
+        trace.writeBounds(func_idx, wrap_fixup_at);
+    }
     try buf.appendSlice(allocator, inst.encCmpRR(.q, .rdi, .r9).slice());
     {
         const fixup_at: u32 = @intCast(buf.items.len);

--- a/src/engine/codegen/x86_64/op_table.zig
+++ b/src/engine/codegen/x86_64/op_table.zig
@@ -11,10 +11,10 @@
 //!
 //!   table.get x:
 //!     MOV  RAX, [R15 + tables_ptr_off]            ; tables_ptr
-//!     MOV  R11, [RAX + (tableidx*16)]             ; refs ptr
-//!     MOV  R10d, [RAX + (tableidx*16)+8]          ; len (zero-ext to 64)
+//!     MOV  R11, [RAX + (tableidx*32)]             ; refs ptr
+//!     MOV  R10, [RAX + (tableidx*32)+8]           ; len (u64, D-475)
 //!     MOV  EDX, W_idx                              ; stage idx in EDX
-//!     CMP  EDX, R10d
+//!     CMP  RDX, R10                                ; .q width (D-475)
 //!     JAE  trap_stub                               ; oobtable_fixups
 //!     MOV  Rdst, [R11 + RDX*8]                     ; refs[idx]
 //!     (store back to spill slot if needed)
@@ -25,7 +25,7 @@
 //!
 //!   table.size x:
 //!     MOV  RAX, [R15 + tables_ptr_off]
-//!     MOV  Rdst_d, [RAX + (tableidx*16)+8]         ; push len as i32
+//!     MOV  Rdst, [RAX + (tableidx*32)+8]           ; push len
 //!
 //! RAX / R10 / R11 / RDX are private scratch within the handler
 //! (RAX is global scratch outside the regalloc pool; R10/R11 are
@@ -240,17 +240,17 @@ pub fn emitTableGet(
     if (pushed_vregs.items.len < 1) return Error.AllocationMissing;
     const idx_v = pushed_vregs.pop().?;
 
-    // Load tables_ptr → RAX; refs → R11; len → R10d.
+    // Load tables_ptr → RAX; refs → R11; len → R10 (u64, D-475).
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r11, .rax, tbl_disp).slice());
-    try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(.r10, .rax, tbl_disp + 8).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r10, .rax, tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
 
     // Stage idx in EDX (32-bit MOV zero-extends to RDX implicitly).
     const idx_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, idx_v, 0);
     try buf.appendSlice(allocator, inst.encMovRR(.d, .rdx, idx_r).slice());
 
-    // CMP EDX, R10d ; JAE trap.
-    try buf.appendSlice(allocator, inst.encCmpRR(.d, .rdx, .r10).slice());
+    // CMP RDX, R10 ; JAE trap. .q width (D-475: len is u64).
+    try buf.appendSlice(allocator, inst.encCmpRR(.q, .rdx, .r10).slice());
     {
         const fixup_at: u32 = @intCast(buf.items.len);
         try buf.appendSlice(allocator, inst.encJccRel32(.ae, 0).slice());
@@ -303,13 +303,13 @@ pub fn emitTableSet(
     const val_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, val_v, 1);
     try buf.appendSlice(allocator, inst.encMovRR(.q, .r9, val_r).slice());
 
-    // Load tables_ptr → RAX; refs → R11; len → R10d (r10/r11 free now).
+    // Load tables_ptr → RAX; refs → R11; len → R10 (u64, D-475; r10/r11 free now).
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r11, .rax, tbl_disp).slice());
-    try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(.r10, .rax, tbl_disp + 8).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r10, .rax, tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
 
-    // CMP EDX, R10d ; JAE trap.
-    try buf.appendSlice(allocator, inst.encCmpRR(.d, .rdx, .r10).slice());
+    // CMP RDX, R10 ; JAE trap. .q width (D-475: len is u64).
+    try buf.appendSlice(allocator, inst.encCmpRR(.q, .rdx, .r10).slice());
     {
         const fixup_at: u32 = @intCast(buf.items.len);
         try buf.appendSlice(allocator, inst.encJccRel32(.ae, 0).slice());
@@ -326,7 +326,7 @@ pub fn emitTableSet(
     // derive into RCX; STR. Then derive typeidx into RCX and STR
     // to typeidx_base from tables_jit_ci_ptr.
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
-    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, .rax, tbl_disp + 16).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, .rax, tbl_disp + @as(i32, @intCast(jit_abi.tableslice_funcptrs_off))).slice());
     try buf.appendSlice(allocator, inst.encTestRR(.q, .rax, .rax).slice());
     const skip_at: u32 = @intCast(buf.items.len);
     try buf.appendSlice(allocator, inst.encJccRel32(.e, 0).slice());
@@ -354,7 +354,7 @@ pub fn emitTableSize(
     tableidx: u32,
 ) Error!void {
     if (tableidx >= 512) return Error.UnsupportedOp;
-    const len_disp: i32 = @intCast(tableidx * jit_abi.table_slice_size + 8);
+    const len_disp: i32 = @intCast(tableidx * jit_abi.table_slice_size + jit_abi.tableslice_len_off);
 
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
 
@@ -363,8 +363,9 @@ pub fn emitTableSize(
     if (result_v >= alloc.slots.len) return Error.SlotOverflow;
     const dst_r = try gpr.gprDefSpilled(alloc, result_v, 0);
 
-    // MOV Rdst_d, [RAX + len_disp] (32-bit, zero-ext to 64).
-    try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(dst_r, .rax, len_disp).slice());
+    // MOV Rdst, [RAX + len_disp] (64-bit, D-475: len is u64; an i32
+    // table's len < 2^32 so the value matches the old 32-bit load).
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(dst_r, .rax, len_disp).slice());
     try gpr.gprStoreSpilled(allocator, buf, alloc, spill_base_off, result_v, 0);
     try pushed_vregs.append(allocator, result_v);
 }
@@ -474,10 +475,10 @@ pub fn emitTableFill(
     try buf.appendSlice(allocator, inst.encMovRR(.d, .r10, n_r).slice());
 
     // Step B: read TableSlice[tableidx]. RAX = tables_ptr; R11 = refs;
-    // R9d = len (using R9 since R10/R11/RDX/R8 are already in use).
+    // R9 = len (u64, D-475; using R9 since R10/R11/RDX/R8 are already in use).
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r11, .rax, tbl_disp).slice());
-    try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(.r9, .rax, tbl_disp + 8).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r9, .rax, tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
 
     // Step C: bounds check — RAX = dst + n; CMP RAX, R9; JA trap.
     //   MOV  RAX, RDX
@@ -499,7 +500,7 @@ pub fn emitTableFill(
     // For funcref tables, derive funcptr from R8 (val) into RCX,
     // derive typeidx into RSI, and load typeidx_base into RDI.
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
-    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r9, .rax, tbl_disp + 16).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r9, .rax, tbl_disp + @as(i32, @intCast(jit_abi.tableslice_funcptrs_off))).slice());
     try buf.appendSlice(allocator, inst.encTestRR(.q, .r9, .r9).slice());
     const derive_skip_at: u32 = @intCast(buf.items.len);
     try buf.appendSlice(allocator, inst.encJccRel32(.e, 0).slice());
@@ -595,10 +596,10 @@ pub fn emitTableCopy(
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
 
     // Step C1: bounds dst_idx + n vs tables[x].len.
-    // R11 = dst_refs ; R9d = dst_len ; bounds via R12 scratch (use
-    // RDI which is not in the regalloc pool — caller-side scratch).
+    // R11 = dst_refs ; R9 = dst_len (u64, D-475) ; bounds via RDI
+    // scratch (not in the regalloc pool — caller-side scratch).
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r11, .rax, dst_tbl_disp).slice());
-    try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(.r9, .rax, dst_tbl_disp + 8).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r9, .rax, dst_tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
     try buf.appendSlice(allocator, inst.encMovRR(.q, .rdi, .rdx).slice());
     try buf.appendSlice(allocator, inst.encAddRR(.q, .rdi, .r10).slice());
     try buf.appendSlice(allocator, inst.encCmpRR(.q, .rdi, .r9).slice());
@@ -610,9 +611,9 @@ pub fn emitTableCopy(
     }
 
     // Step C2: bounds src_idx + n vs tables[y].len.
-    // RCX = src_refs ; R9d = src_len (reused).
+    // RCX = src_refs ; R9 = src_len (u64, reused).
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rcx, .rax, src_tbl_disp).slice());
-    try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(.r9, .rax, src_tbl_disp + 8).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r9, .rax, src_tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
     try buf.appendSlice(allocator, inst.encMovRR(.q, .rdi, .r8).slice());
     try buf.appendSlice(allocator, inst.encAddRR(.q, .rdi, .r10).slice());
     try buf.appendSlice(allocator, inst.encCmpRR(.q, .rdi, .r9).slice());
@@ -628,9 +629,9 @@ pub fn emitTableCopy(
     // (long-lived). For different-tables case also RDI =
     // src_funcptrs_base. RAX still holds tables_ptr from Step B.
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
-    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rsi, .rax, dst_tbl_disp + 16).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rsi, .rax, dst_tbl_disp + @as(i32, @intCast(jit_abi.tableslice_funcptrs_off))).slice());
     if (!same_table) {
-        try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rdi, .rax, src_tbl_disp + 16).slice());
+        try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rdi, .rax, src_tbl_disp + @as(i32, @intCast(jit_abi.tableslice_funcptrs_off))).slice());
     }
 
     // Step D: if n == 0, skip.
@@ -799,10 +800,10 @@ pub fn emitTableInit(
     const n_r = try gpr.gprLoadSpilled(allocator, buf, alloc, spill_base_off, n_v, 0);
     try buf.appendSlice(allocator, inst.encMovRR(.d, .r10, n_r).slice());
 
-    // Step B1: tables[x] descriptor — R11 = dst_refs, R9d = dst_len.
+    // Step B1: tables[x] descriptor — R11 = dst_refs, R9 = dst_len (u64, D-475).
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r11, .rax, tbl_disp).slice());
-    try buf.appendSlice(allocator, inst.encMovR32FromMemDisp32(.r9, .rax, tbl_disp + 8).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.r9, .rax, tbl_disp + @as(i32, @intCast(jit_abi.tableslice_len_off))).slice());
 
     // Step B2: elems[y] descriptor — RCX = elem_refs, RSI = elem_len.
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.elem_segments_ptr_off).slice());
@@ -850,7 +851,7 @@ pub fn emitTableInit(
     // (RAX currently holds elem_dropped_ptr from Step B3; reload
     // tables_ptr first.)
     try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
-    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rdi, .rax, tbl_disp + 16).slice());
+    try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rdi, .rax, tbl_disp + @as(i32, @intCast(jit_abi.tableslice_funcptrs_off))).slice());
 
     // Step D: if n == 0, skip.
     try buf.appendSlice(allocator, inst.encTestRR(.q, .r10, .r10).slice());

--- a/src/engine/codegen/x86_64/op_tail_call.zig
+++ b/src/engine/codegen/x86_64/op_tail_call.zig
@@ -257,6 +257,9 @@ pub fn emitIndirectReturnCall(
     // Load idx AFTER marshalCallArgs (D-097 d-18 mirror — marshalling
     // stages spilled args through R10/scratch; loading idx before
     // would risk clobber).
+    // D-475: an i64 table pops a 64-bit index — the bounds CMPs below
+    // widen to .q per the table's idx_type.
+    const ci_idx64 = ctx.func.tableIdxType(table_idx) == .i64;
     const idx_r = try gpr.gprLoadSpilled(ctx.allocator, ctx.buf, ctx.alloc, ctx.spill_base_off, idx_vreg, 0);
 
     const expected_typeidx: u32 = canonical_type.canonicalTypeidx(ctx.module_types, @intCast(ins.payload));
@@ -264,11 +267,11 @@ pub fn emitIndirectReturnCall(
     if (table_idx == 0) {
         // Table-0 fast path: scalar JitRuntime fields (table_size_off /
         // typeidx_base_off / funcptr_base_off) back table 0.
-        // Bounds: MOV RAX, [R15+table_size_off] ; CMP idx_r, EAX ; JAE trap.
-        // 64-bit load (D-475: table_size is u64); CMP stays .d for the
-        // i32-table path (low half == len; i64 tables widen per idx_type — C3).
+        // Bounds: MOV RAX, [R15+table_size_off] ; CMP idx_r, RAX/EAX ; JAE trap.
+        // 64-bit load (D-475: table_size is u64); the CMP is .q for an
+        // i64 table and stays .d on the i32 fast path.
         try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.table_size_off).slice());
-        try ctx.buf.appendSlice(ctx.allocator, inst.encCmpRR(.d, idx_r, .rax).slice());
+        try ctx.buf.appendSlice(ctx.allocator, inst.encCmpRR(if (ci_idx64) .q else .d, idx_r, .rax).slice());
         {
             const fixup_at: u32 = @intCast(ctx.buf.items.len);
             try ctx.buf.appendSlice(ctx.allocator, inst.encJccRel32(.ae, 0).slice());
@@ -310,10 +313,10 @@ pub fn emitIndirectReturnCall(
         const ci_typeidx_disp: i32 = @intCast((table_idx * 16) + 8);
 
         // Bounds: MOV RAX, [R15+tables_ptr_off] ; MOV RAX, [RAX+tbl_slice_disp] (len, u64 D-475)
-        //         CMP idx_r, EAX ; JAE trap (.d for the i32-table path; C3 widens per idx_type).
+        //         CMP idx_r, RAX/EAX ; JAE trap (.q for an i64 table).
         try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
         try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(.rax, .rax, tbl_slice_disp).slice());
-        try ctx.buf.appendSlice(ctx.allocator, inst.encCmpRR(.d, idx_r, .rax).slice());
+        try ctx.buf.appendSlice(ctx.allocator, inst.encCmpRR(if (ci_idx64) .q else .d, idx_r, .rax).slice());
         {
             const fixup_at: u32 = @intCast(ctx.buf.items.len);
             try ctx.buf.appendSlice(ctx.allocator, inst.encJccRel32(.ae, 0).slice());

--- a/src/engine/codegen/x86_64/op_tail_call.zig
+++ b/src/engine/codegen/x86_64/op_tail_call.zig
@@ -264,8 +264,10 @@ pub fn emitIndirectReturnCall(
     if (table_idx == 0) {
         // Table-0 fast path: scalar JitRuntime fields (table_size_off /
         // typeidx_base_off / funcptr_base_off) back table 0.
-        // Bounds: MOV EAX, [R15+table_size_off] ; CMP idx_r, EAX ; JAE trap.
-        try ctx.buf.appendSlice(ctx.allocator, inst.encMovR32FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.table_size_off).slice());
+        // Bounds: MOV RAX, [R15+table_size_off] ; CMP idx_r, EAX ; JAE trap.
+        // 64-bit load (D-475: table_size is u64); CMP stays .d for the
+        // i32-table path (low half == len; i64 tables widen per idx_type — C3).
+        try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.table_size_off).slice());
         try ctx.buf.appendSlice(ctx.allocator, inst.encCmpRR(.d, idx_r, .rax).slice());
         {
             const fixup_at: u32 = @intCast(ctx.buf.items.len);
@@ -303,14 +305,14 @@ pub fn emitIndirectReturnCall(
         // scratch, so each base load reloads the array pointer; the funcptr
         // lands in tail_target_gpr (R11) for the JMP.
         if (jit_abi.table_jit_ci_size != 16) @compileError("multi-table tail-call assumes TableJitCallInfo stride 16");
-        const tbl_slice_disp: i32 = @intCast((table_idx * jit_abi.table_slice_size) + 8);
+        const tbl_slice_disp: i32 = @intCast((table_idx * jit_abi.table_slice_size) + jit_abi.tableslice_len_off);
         const ci_funcptr_disp: i32 = @intCast(table_idx * 16);
         const ci_typeidx_disp: i32 = @intCast((table_idx * 16) + 8);
 
-        // Bounds: MOV RAX, [R15+tables_ptr_off] ; MOV EAX, [RAX+tbl_slice_disp] (len)
-        //         CMP idx_r, EAX ; JAE trap.
+        // Bounds: MOV RAX, [R15+tables_ptr_off] ; MOV RAX, [RAX+tbl_slice_disp] (len, u64 D-475)
+        //         CMP idx_r, EAX ; JAE trap (.d for the i32-table path; C3 widens per idx_type).
         try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.tables_ptr_off).slice());
-        try ctx.buf.appendSlice(ctx.allocator, inst.encMovR32FromMemDisp32(.rax, .rax, tbl_slice_disp).slice());
+        try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(.rax, .rax, tbl_slice_disp).slice());
         try ctx.buf.appendSlice(ctx.allocator, inst.encCmpRR(.d, idx_r, .rax).slice());
         {
             const fixup_at: u32 = @intCast(ctx.buf.items.len);

--- a/src/engine/compile.zig
+++ b/src/engine/compile.zig
@@ -1300,7 +1300,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
 /// D-475 (table64) — expected offset type of an ACTIVE elem segment =
 /// the target table's idx_type (imports-first wasm table index space;
 /// mirrors the D-219 `data_off_vt` treatment for memory64 data
-/// segments). Missing/uknown table → `.i32` (the validator rejects the
+/// segments). Missing/unknown table → `.i32` (the validator rejects the
 /// out-of-range tableidx separately).
 fn elemOffsetValType(imports_buf: anytype, tables_buf: anytype, tableidx: u32) zir.ValType {
     var k: u32 = tableidx;

--- a/src/engine/compile.zig
+++ b/src/engine/compile.zig
@@ -790,6 +790,14 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
     // instead of silently miscompiling a large index. The interp path supports
     // table64 fully and does not route through compileWasm.
     for (validator_tables) |t| if (t.idx_type == .i64) return Error.JitTable64Unsupported;
+    // D-475 — per-table idx_type slice for the emitters (imports-first
+    // wasm table index space, same source as `validator_tables`).
+    const table_idx_types: []const zir.IdxType = blk: {
+        if (validator_tables.len == 0) break :blk &.{};
+        const out = try a.alloc(zir.IdxType, validator_tables.len);
+        for (validator_tables, 0..) |t, i| out[i] = t.idx_type;
+        break :blk out;
+    };
     const validator_data_count: u32 = if (datas_buf) |d| @intCast(d.items.len) else 0;
     const validator_elem_count: u32 = if (elems_buf) |e| @intCast(e.items.len) else 0;
 
@@ -1155,6 +1163,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
             array_elem_valtypes,
             struct_field_valtypes,
             uses_type_subtyping,
+            table_idx_types,
         ) catch |err| {
             std.debug.print("compileWasm: func[{d}] params={d} results={d} → {s}\n", .{
                 wasm_idx,

--- a/src/engine/compile.zig
+++ b/src/engine/compile.zig
@@ -455,9 +455,15 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
         if (module.find(.element)) |es| {
             var es_buf = try sections.decodeElement(a, es.body);
             defer es_buf.deinit();
+            // D-475: a table64 elem offset is i64-typed (§3.3.6) — decode
+            // the table section for the per-table expected offset type.
+            var empty_tables_buf: ?sections.Tables = null;
+            defer if (empty_tables_buf) |*t| t.deinit();
+            if (module.find(.table)) |ts| empty_tables_buf = try sections.decodeTables(a, ts.body);
             for (es_buf.items) |seg| {
                 if (seg.kind == .active) {
-                    try rv.validateGlobalInitExpr(seg.offset_expr, .i32, num_global_imports_empty, imports_buf, total_funcs_empty_for_init);
+                    const off_vt = elemOffsetValType(imports_buf, empty_tables_buf, seg.tableidx);
+                    try rv.validateGlobalInitExpr(seg.offset_expr, off_vt, num_global_imports_empty, imports_buf, total_funcs_empty_for_init);
                 }
             }
         }
@@ -713,7 +719,9 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
     if (elems_buf) |e| {
         for (e.items) |seg| {
             if (seg.kind == .active) {
-                try rv.validateGlobalInitExpr(seg.offset_expr, .i32, num_global_imports_main, imports_buf, total_funcs);
+                // D-475: a table64 elem offset is i64-typed (§3.3.6).
+                const off_vt = elemOffsetValType(imports_buf, tables_buf, seg.tableidx);
+                try rv.validateGlobalInitExpr(seg.offset_expr, off_vt, num_global_imports_main, imports_buf, total_funcs);
             }
         }
     }
@@ -785,13 +793,11 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
         }
         break :blk out;
     };
-    // D-475 — the JIT cannot yet index tables at i64 width (slice 4); reject an
-    // i64-indexed table here so a table64 module fails cleanly under the JIT
-    // instead of silently miscompiling a large index. The interp path supports
-    // table64 fully and does not route through compileWasm.
-    for (validator_tables) |t| if (t.idx_type == .i64) return Error.JitTable64Unsupported;
     // D-475 — per-table idx_type slice for the emitters (imports-first
-    // wasm table index space, same source as `validator_tables`).
+    // wasm table index space, same source as `validator_tables`). The
+    // former JitTable64Unsupported guard is gone: the emitters index
+    // tables at their declared width (C2/C3) and the descriptors are
+    // u64 (C1), so i64-indexed tables compile natively.
     const table_idx_types: []const zir.IdxType = blk: {
         if (validator_tables.len == 0) break :blk &.{};
         const out = try a.alloc(zir.IdxType, validator_tables.len);
@@ -1291,6 +1297,26 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
 /// CompiledWasm arena), so they share the module's lifetime. Returns an
 /// empty slice when there is no export section. Out-of-range targets are
 /// skipped defensively (the validator already rejects them upstream).
+/// D-475 (table64) — expected offset type of an ACTIVE elem segment =
+/// the target table's idx_type (imports-first wasm table index space;
+/// mirrors the D-219 `data_off_vt` treatment for memory64 data
+/// segments). Missing/uknown table → `.i32` (the validator rejects the
+/// out-of-range tableidx separately).
+fn elemOffsetValType(imports_buf: anytype, tables_buf: anytype, tableidx: u32) zir.ValType {
+    var k: u32 = tableidx;
+    if (imports_buf) |ib| {
+        for (ib.items) |imp| {
+            if (imp.kind != .table) continue;
+            if (k == 0) return if (imp.payload.table.idx_type == .i64) .i64 else .i32;
+            k -= 1;
+        }
+    }
+    if (tables_buf) |t| {
+        if (k < t.items.len) return if (t.items[k].idx_type == .i64) .i64 else .i32;
+    }
+    return .i32;
+}
+
 fn collectFuncExports(a: Allocator, module: anytype, total_funcs: u32) Error![]const runner_mod.FuncExport {
     const es = module.find(.@"export") orelse return &.{};
     var exports = try sections.decodeExports(a, es.body);

--- a/src/engine/compile_init.zig
+++ b/src/engine/compile_init.zig
@@ -200,10 +200,11 @@ pub fn applyTableInitForTableCtx(
     for (elems.items) |seg| {
         if (seg.kind != .active) continue;
         if (seg.tableidx != tableidx) continue;
-        const off = rv.evalConstI32ExprCtx(seg.offset_expr, ctx) catch return Error.UnsupportedEntrySignature;
-        if (off < 0) return Error.UnsupportedEntrySignature;
-        const base: usize = @intCast(off);
-        if (base + seg.funcidxs.len > funcptrs_buf.len) return Error.UnsupportedEntrySignature;
+        // D-475: a table64 elem offset is an `i64.const` (or i64 global.get)
+        // — evaluate at u64 width; guard `base` first so the sum can't wrap.
+        const off_u = rv.evalConstOffsetU64Ctx(seg.offset_expr, ctx) catch return Error.UnsupportedEntrySignature;
+        const base: usize = std.math.cast(usize, off_u) orelse return Error.UnsupportedEntrySignature;
+        if (base > funcptrs_buf.len or base + seg.funcidxs.len > funcptrs_buf.len) return Error.UnsupportedEntrySignature;
         for (seg.funcidxs, 0..) |fidx, i| {
             if (fidx == std.math.maxInt(u32)) continue; // ref.null funcref
             // Close-plan §6 (j) Step B cohort 6 — global.get N marker:
@@ -258,9 +259,11 @@ pub fn patchTableImportFuncptrsCtx(allocator: Allocator, wasm_bytes: []const u8,
     defer elems.deinit();
     for (elems.items) |seg| {
         if (seg.kind != .active or seg.tableidx != tableidx) continue;
-        const off = rv.evalConstI32ExprCtx(seg.offset_expr, ctx) catch return Error.UnsupportedEntrySignature;
-        if (off < 0) return Error.UnsupportedEntrySignature;
-        const base: usize = @intCast(off);
+        // D-475: u64-width offset eval + wrap-safe base guard (a huge
+        // base would wrap `base + i` back into bounds otherwise).
+        const off_u = rv.evalConstOffsetU64Ctx(seg.offset_expr, ctx) catch return Error.UnsupportedEntrySignature;
+        const base: usize = std.math.cast(usize, off_u) orelse return Error.UnsupportedEntrySignature;
+        if (base >= funcptrs_buf.len) continue;
         for (seg.funcidxs, 0..) |fidx, i| {
             if (fidx >= num_imports or fidx >= dispatch.len or base + i >= funcptrs_buf.len) continue;
             funcptrs_buf[base + i] = dispatch[fidx];

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -1192,7 +1192,8 @@ pub const JitInstance = struct {
 
     /// D-496 — slot count of table `idx` (full index space, matching
     /// `JitRuntime.tables_ptr`), backing C-API `wasm_table_size`. Null if OOB.
-    pub fn tableLen(self: *JitInstance, idx: u32) ?u32 {
+    /// u64 per D-475 (table64); the u32-shaped wasm-c-api boundary saturates.
+    pub fn tableLen(self: *JitInstance, idx: u32) ?u64 {
         if (idx >= self.owned.rt.tables_count) return null;
         return self.owned.rt.tables_ptr[idx].len;
     }
@@ -1271,7 +1272,7 @@ pub const JitInstance = struct {
     /// fail-safe (the host `init` may be a forged ref, never dereferenced) — a
     /// callable grown funcref slot then needs `wasm_table_set` (mirror-aware). Grow
     /// is bounded by the pre-allocated capacity (a no-max table has no headroom).
-    pub fn growTable(self: *JitInstance, tableidx: u32, init_ref: u64, delta: u32) ?u32 {
+    pub fn growTable(self: *JitInstance, tableidx: u32, init_ref: u64, delta: u32) ?u64 {
         if (tableidx >= self.owned.rt.tables_count) return null;
         const old = setup_mod.jitTableGrowHost(&self.owned.rt, tableidx, init_ref, delta);
         if (old < 0) return null;

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -159,13 +159,6 @@ pub const Error = error{
     /// called. An unsatisfied import MUST fail instantiation regardless
     /// of whether it is reached at runtime (D-451).
     ImportUnsatisfied,
-    /// D-475 — a module declares an i64-indexed table (table64, the memory64
-    /// proposal's table extension). The validator + interp runtime support
-    /// these, but the JIT codegen still indexes tables at i32 width, so
-    /// compiling one would silently miscompile a >2^32 index. The JIT compile
-    /// path rejects it (clean failure) until the i64 table-bounds codegen lands
-    /// (D-475 slice 4); the interp path runs table64 modules correctly.
-    JitTable64Unsupported,
 } || compile_func.Error || parser.Error || sections.Error || linker.Error || entry.Error || validator_mod.Error || rv.Error;
 // `InvalidGlobalInitExpr` / `UnsupportedEntrySignature` /
 // `UnsupportedConstExpr` originate in `runner_validate.zig`

--- a/src/engine/runner_test.zig
+++ b/src/engine/runner_test.zig
@@ -2209,6 +2209,31 @@ test "jitTableGrow: no host cap → table.grow within descriptor max succeeds (D
     try testing.expectEqual(@as(u32, 1), try entry.callI32NoArgs(compiled.module, 0, &owned.rt));
 }
 
+test "jitTableGrow: D-475 table64 — i64 grow on an i64-indexed table returns the i64 prior size" {
+    // (module (table i64 1 10 externref)
+    //         (func (export "g") (result i64) ref.null extern i64.const 5 table.grow 0))
+    // End-to-end JIT path for table64: parse (0x04 limits bit) → u64
+    // TableMeta/TableSlice → X-form delta staging → jitTableGrow(u64) →
+    // i64 result capture. Expected: prior size 1 as i64.
+    const wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7e, 0x03,
+        0x02, 0x01, 0x00,
+        0x04, 0x05, 0x01, 0x6f, 0x05, 0x01, 0x0a, // table externref i64 {1, 10}
+        0x07, 0x05, 0x01, 0x01, 0x67, 0x00, 0x00,
+        0x0a, 0x0b, 0x01, 0x09, 0x00, 0xd0, 0x6f,
+        0x42, 0x05, 0xfc, 0x0f, 0x00, 0x0b, // ref.null extern; i64.const 5; table.grow 0; end
+    };
+    var compiled = try compileWasm(testing.allocator, &wasm);
+    defer compiled.deinit(testing.allocator);
+    var owned = try setupRuntime(testing.allocator, &compiled, &wasm);
+    defer owned.deinit(testing.allocator);
+    try testing.expectEqual(@as(u64, 1), try entry.callI64NoArgs(compiled.module, 0, &owned.rt));
+    // The grow bumped the u64 descriptor + the pinned table-0 scalar.
+    try testing.expectEqual(@as(u64, 6), owned.rt.tables_ptr[0].len);
+    try testing.expectEqual(@as(u64, 6), owned.rt.table_size);
+}
+
 test "jitTableGrow: D-497 guest funcref table.grow + call_indirect grown slot (ADR-0201)" {
     // (module (type (func (result i32)))
     //   (func (result i32) i32.const 42)                 ;; func 0 — target

--- a/src/engine/runner_validate.zig
+++ b/src/engine/runner_validate.zig
@@ -353,6 +353,47 @@ pub fn evalConstI32ExprCtx(expr: []const u8, ctx: ?GlobalsCtx) Error!i32 {
     return v;
 }
 
+/// Context-aware u64 offset evaluator (D-475 table64). Mirrors
+/// `evalConstI32ExprCtx`'s single-op shape but returns u64: accepts
+/// `i32.const` (zero-extended), `i64.const` (table64 / memory64), and
+/// `global.get N` of an imported immutable i32 (zero-extended) or i64
+/// global when `ctx` is non-null.
+pub fn evalConstOffsetU64Ctx(expr: []const u8, ctx: ?GlobalsCtx) Error!u64 {
+    if (expr.len < 2) return Error.UnsupportedConstExpr;
+    var pos: usize = 1;
+    const v: u64 = switch (expr[0]) {
+        0x41 => blk: { // i32.const — zero-extend
+            const n = leb128.readSleb128(i32, expr, &pos) catch return Error.UnsupportedConstExpr;
+            break :blk @as(u32, @bitCast(n));
+        },
+        0x42 => blk: { // i64.const (table64 / memory64)
+            const n = leb128.readSleb128(i64, expr, &pos) catch return Error.UnsupportedConstExpr;
+            break :blk @bitCast(n);
+        },
+        0x23 => blk: { // global.get N (imported i32 / i64)
+            const idx = leb128.readUleb128(u32, expr, &pos) catch return Error.UnsupportedConstExpr;
+            const c = ctx orelse return Error.UnsupportedConstExpr;
+            if (idx >= c.num_imports) return Error.UnsupportedConstExpr;
+            if (idx >= c.offsets.len or idx >= c.valtypes.len) return Error.UnsupportedConstExpr;
+            const off = c.offsets[idx];
+            switch (c.valtypes[idx]) {
+                .i32 => {
+                    if (off + 4 > c.buf.len) return Error.UnsupportedConstExpr;
+                    break :blk std.mem.readInt(u32, c.buf[off..][0..4], .little);
+                },
+                .i64 => {
+                    if (off + 8 > c.buf.len) return Error.UnsupportedConstExpr;
+                    break :blk std.mem.readInt(u64, c.buf[off..][0..8], .little);
+                },
+                else => return Error.UnsupportedConstExpr,
+            }
+        },
+        else => return Error.UnsupportedConstExpr,
+    };
+    if (pos >= expr.len or expr[pos] != 0x0B) return Error.UnsupportedConstExpr;
+    return v;
+}
+
 /// Evaluate an active-segment offset const-expr to a u64. Accepts
 /// `i32.const` (mem32 / table — zero-extended) and `i64.const`
 /// (memory64), each followed by `end`. An offset is unsigned; the

--- a/src/engine/setup.zig
+++ b/src/engine/setup.zig
@@ -905,9 +905,12 @@ pub fn setupRuntimeLinked(
         for (elems.items) |seg| {
             if (seg.kind != .active) continue;
             if (seg.tableidx >= tables_descs.len) continue;
-            const off = rv.evalConstI32Expr(seg.offset_expr) catch return Error.UnsupportedEntrySignature;
-            if (off < 0) return Error.UnsupportedEntrySignature;
-            const base: usize = @intCast(off);
+            // D-475: a table64 active elem offset is an `i64.const` expr —
+            // evaluate at u64 width (mirrors the interp fix @a7609a65b; the
+            // i32-only eval rejected it → the .auto path silently fell back
+            // to the interp). i32 offsets arrive zero-extended.
+            const off = rv.evalConstOffsetU64(seg.offset_expr) catch return Error.UnsupportedEntrySignature;
+            const base: usize = std.math.cast(usize, off) orelse return Error.UnsupportedEntrySignature;
             const tbl = tables_descs[seg.tableidx];
             if (base + seg.funcidxs.len > tbl.len) return Error.UnsupportedEntrySignature;
             // Wasm 3.0 GC (D-221 + D-218): an i31ref/eqref/anyref active elem

--- a/src/engine/setup.zig
+++ b/src/engine/setup.zig
@@ -230,14 +230,16 @@ pub fn jitMemoryGrow(rt: *entry.JitRuntime, delta_pages: u32) callconv(.c) i32 {
 /// a real `*FuncEntity`) read `fe.funcptr`/`fe.typeidx` (matching `emitTableSet`'s LDR
 /// mirror), else (HOST path: `init` may be a forged ref) clear to the sentinel
 /// (fail-safe, mirrors `tableSetRef`; a callable grown slot then needs `wasm_table_set`).
-fn jitTableGrowCore(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u32, resolve: bool) i32 {
+fn jitTableGrowCore(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u64, resolve: bool) i64 {
     const FuncEntity = @import("../runtime/instance/func.zig").FuncEntity;
     const Value = @import("../runtime/value.zig").Value;
     if (tableidx >= rt.tables_count) return -1;
     const descs: [*]entry.TableSlice = @constCast(rt.tables_ptr);
     const d = &descs[tableidx];
     const old_len = d.len;
-    const new_len: u64 = @as(u64, old_len) + @as(u64, delta);
+    // Overflow-safe (D-475): a table64 delta is a raw u64 from the
+    // wasm stack, so `old_len + delta` can wrap.
+    const new_len: u64 = std.math.add(u64, old_len, delta) catch return -1;
     if (new_len > d.max) return -1; // exceeds pre-allocated capacity (= .max)
     // D-314(b): host sandbox cap on total table elements — a guest cannot
     // grow past `store_table_elements_max` even within the static descriptor
@@ -250,8 +252,8 @@ fn jitTableGrowCore(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u32,
         @constCast(rt.tables_jit_ci_ptr[tableidx].typeidx_base)
     else
         null;
-    var i: u32 = old_len;
-    while (i < old_len + delta) : (i += 1) {
+    var i: u64 = old_len;
+    while (i < new_len) : (i += 1) {
         d.refs[i] = init;
         if (!is_funcref) continue;
         var fp: u64 = 0;
@@ -264,23 +266,23 @@ fn jitTableGrowCore(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u32,
         d.funcptrs[i] = fp;
         if (typeidx_base) |tb| tb[i] = ti;
     }
-    d.len = @intCast(new_len);
+    d.len = new_len;
     // D-497: table 0's `call_indirect` fast path bounds-checks against the scalar
     // `rt.table_size` snapshot (not `d.len`); bump it so a grown table-0 slot is
     // reachable. Tables k>0 read `tables_ptr[k].len` directly (jit_abi helper).
-    if (tableidx == 0) rt.table_size = @intCast(new_len);
+    if (tableidx == 0) rt.table_size = new_len;
     return @bitCast(old_len);
 }
 
 /// GUEST `table_grow_fn` (replaces `defaultTableGrowReject`) — `init` from the wasm
 /// stack is a real funcref/externref, so funcref native-entry resolution is safe.
-pub fn jitTableGrow(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u32) callconv(.c) i32 {
+pub fn jitTableGrow(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u64) callconv(.c) i64 {
     return jitTableGrowCore(rt, tableidx, init, delta, true);
 }
 
 /// HOST C-API `table.grow` (`growTable` facade) — `init` is a host `*Ref` whose
 /// payload may be forged, so never dereference it as a `*FuncEntity` (fail-safe).
-pub fn jitTableGrowHost(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u32) i32 {
+pub fn jitTableGrowHost(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u64) i64 {
     return jitTableGrowCore(rt, tableidx, init, delta, false);
 }
 
@@ -561,23 +563,22 @@ pub fn setupRuntimeLinked(
     // table-0-only specialisations); the new `tables_descs` array
     // generalises this to all declared tables for `table.get` /
     // `table.set` / `table.size` (m-2a) and later m-2b/c ops.
-    var table_size: u32 = 0;
+    var table_size: u64 = 0;
     // `init_expr` (D-225): Wasm 3.0 table-with-explicit-init-expr
     // (`0x40 0x00 reftype limits constexpr`) — raw const-expr bytes for the
     // initial element value (empty = default null fill). Slices into the
     // table section body (ta-owned, outlives `tables_buf.deinit`).
-    const TableMeta = struct { min: u32, max: ?u32, is_funcref: bool, init_expr: []const u8 };
+    // min/max are u64 per D-475: a table64 declares u64 limits (spec §5.3.5).
+    const TableMeta = struct { min: u64, max: ?u64, is_funcref: bool, init_expr: []const u8 };
     var table_metas: []TableMeta = &.{};
     if (module.find(.table)) |s| {
         var tables_buf = try sections.decodeTables(ta, s.body);
         defer tables_buf.deinit();
         if (tables_buf.items.len > 0) {
-            // table64 is rejected at compileWasm (Error.JitTable64Unsupported),
-            // so every table reaching the JIT setup is i32 (min/max ≤ u32).
-            table_size = @intCast(tables_buf.items[0].min);
+            table_size = tables_buf.items[0].min;
             table_metas = try ta.alloc(TableMeta, tables_buf.items.len);
             for (tables_buf.items, 0..) |t, i| {
-                table_metas[i] = .{ .min = @intCast(t.min), .max = if (t.max) |m| @as(u32, @intCast(m)) else null, .is_funcref = (t.elem_type.isFuncref()), .init_expr = t.init_expr };
+                table_metas[i] = .{ .min = t.min, .max = t.max, .is_funcref = (t.elem_type.isFuncref()), .init_expr = t.init_expr };
             }
         }
     }
@@ -730,14 +731,14 @@ pub fn setupRuntimeLinked(
     // gets a synthesized cap `max(min*2, 1024)` (1024 mirrors WAMR's
     // WASM_TABLE_MAX_SIZE), bounded by `grow_cap`. Unbounded no-max grow would
     // need per-access base reload (D-501 tier 2, build-on-demand).
-    const grow_cap: u32 = 65536;
+    const grow_cap: u64 = 65536;
     const growCapacity = struct {
-        fn f(tm: anytype, cap: u32) u32 {
-            const eff_max = tm.max orelse @max(tm.min *| 2, @as(u32, 1024));
+        fn f(tm: anytype, cap: u64) u64 {
+            const eff_max = tm.max orelse @max(tm.min *| 2, @as(u64, 1024));
             return @max(tm.min, @min(eff_max, cap));
         }
     }.f;
-    const table0_cap: u32 = if (table_metas.len > 0) growCapacity(table_metas[0], grow_cap) else table_size;
+    const table0_cap: u64 = if (table_metas.len > 0) growCapacity(table_metas[0], grow_cap) else table_size;
 
     const funcptrs_buf = try allocator.alloc(u64, if (table0_cap == 0) 1 else table0_cap);
     errdefer allocator.free(funcptrs_buf);
@@ -817,7 +818,7 @@ pub fn setupRuntimeLinked(
             // offset in the extern union) holds the ref-encoded u64.
             const raw: u64 = v.ref;
             const d = tables_descs[i];
-            var k: u32 = 0;
+            var k: u64 = 0;
             while (k < tm.min) : (k += 1) d.refs[k] = raw;
         }
     }

--- a/src/engine/setup.zig
+++ b/src/engine/setup.zig
@@ -912,7 +912,10 @@ pub fn setupRuntimeLinked(
             const off = rv.evalConstOffsetU64(seg.offset_expr) catch return Error.UnsupportedEntrySignature;
             const base: usize = std.math.cast(usize, off) orelse return Error.UnsupportedEntrySignature;
             const tbl = tables_descs[seg.tableidx];
-            if (base + seg.funcidxs.len > tbl.len) return Error.UnsupportedEntrySignature;
+            // Overflow-safe (D-475): `base` is a guest-chosen u64 —
+            // check it against len FIRST so `base + funcidxs.len`
+            // cannot wrap (mirrors the D-219 data-segment check above).
+            if (base > tbl.len or base + seg.funcidxs.len > tbl.len) return Error.UnsupportedEntrySignature;
             // Wasm 3.0 GC (D-221 + D-218): an i31ref/eqref/anyref active elem
             // segment carries i31-ENCODED values in `funcidxs` (decoder:
             // i32ToI31Truncate == runtime Value.fromI31Truncate), NOT funcidxs.

--- a/src/ir/zir.zig
+++ b/src/ir/zir.zig
@@ -751,6 +751,17 @@ pub const ZirFunc = struct {
     /// `compileOne`; arena lifetime n/a (scalar).
     uses_type_subtyping: bool = false,
 
+    /// D-475 (table64) — per-table index types in the full wasm table
+    /// index space (imports first, defined after; mirrors
+    /// `validator_tables` in `compileWasm`). The table-op /
+    /// call_indirect emitters consult this to pick 32- vs 64-bit index
+    /// widths per table. Arena-allocated by `compileWasm` (referenced,
+    /// not owned — same lifetime posture as `gc_array_elem_valtypes`).
+    /// Empty for modules without tables; `tableIdxType` defaults
+    /// out-of-range indices to `.i32` so emit-level unit tests that
+    /// don't populate it keep the legacy width.
+    table_idx_types: []const IdxType = &.{},
+
     // Phase 8+ — optimisation passes.
     hoisted_constants: ?[]HoistedConst = null,
     /// Synthetic locals appended by post-lowering passes (notably
@@ -812,6 +823,14 @@ pub const ZirFunc = struct {
         const orig_len: u32 = @intCast(self.locals.len);
         if (decl_idx < orig_len) return self.locals[@intCast(decl_idx)];
         return self.synthetic_locals.?[@intCast(decl_idx - orig_len)];
+    }
+
+    /// D-475 (table64) — index type of table `tableidx`, defaulting to
+    /// `.i32` when the slice is unpopulated (emit-level unit tests) or
+    /// the index is out of range (validator pre-rejects those).
+    pub fn tableIdxType(self: *const ZirFunc, tableidx: u32) IdxType {
+        if (tableidx >= self.table_idx_types.len) return .i32;
+        return self.table_idx_types[tableidx];
     }
 
     /// 10.G GC-on-JIT (D-212) — the array element's spec valtype byte

--- a/src/zwasm/table.zig
+++ b/src/zwasm/table.zig
@@ -37,7 +37,9 @@ pub const Table = struct {
     pub fn size(self: Table) u32 {
         return switch (self.backing) {
             .interp => |rt| @intCast(rt.tables[self.table_idx].refs.len),
-            .jit => |jit| jit.owned.rt.tables_ptr[self.table_idx].len,
+            // D-475: JIT len is u64; the u32-shaped facade narrows (matches
+            // the interp arm's @intCast posture).
+            .jit => |jit| @intCast(jit.owned.rt.tables_ptr[self.table_idx].len),
         };
     }
 

--- a/test/spec/spec_assert_runner_base.zig
+++ b/test/spec/spec_assert_runner_base.zig
@@ -2332,11 +2332,12 @@ pub fn extractStartFunc(allocator: std.mem.Allocator, wasm_bytes: []const u8) ?u
 /// growth past `SCRATCH_EXTRA_TABLE_CAPACITY` returns -1 per Wasm
 /// 2.0 spec §4.4.10.1 host-refuses-growth semantics. Also returns
 /// -1 when growth would exceed the descriptor's declared `max`.
-pub fn growableTableGrowFn(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u32) callconv(.c) i32 {
+pub fn growableTableGrowFn(rt: *entry.JitRuntime, tableidx: u32, init: u64, delta: u64) callconv(.c) i64 {
     if (tableidx >= active_table_count) return -1;
     const desc = &scratch_tables_descriptor[tableidx];
     const old_len = desc.len;
-    const new_len: u64 = @as(u64, old_len) + @as(u64, delta);
+    // Overflow-safe (D-475): a table64 delta is a raw u64.
+    const new_len: u64 = std.math.add(u64, old_len, delta) catch return -1;
     if (new_len > SCRATCH_EXTRA_TABLE_CAPACITY) return -1;
     if (desc.max != entry.table_no_max and new_len > desc.max) return -1;
     const arena = &scratch_table_refs[tableidx];
@@ -2363,7 +2364,7 @@ pub fn growableTableGrowFn(rt: *entry.JitRuntime, tableidx: u32, init: u64, delt
         const ti_const = scratch_table_jit_ci[tableidx].typeidx_base;
         break :blk @constCast(ti_const);
     } else undefined;
-    var i: u32 = 0;
+    var i: u64 = 0;
     while (i < delta) : (i += 1) {
         arena[old_len + i] = init;
         if (fp_base_ptr != 0) {
@@ -2372,7 +2373,7 @@ pub fn growableTableGrowFn(rt: *entry.JitRuntime, tableidx: u32, init: u64, delt
         }
     }
     desc.refs = arena;
-    desc.len = @intCast(new_len);
+    desc.len = new_len;
     _ = rt;
     return @intCast(old_len);
 }


### PR DESCRIPTION
## Summary

Closes the last engine-parity gap for table64 (the memory64 proposal's table extension): i64-indexed tables now JIT-compile natively on both arches instead of falling back to the interp via the `JitTable64Unsupported` guard.

- **C1 — u64 descriptors**: `TableSlice.len`/`max` u32→u64 (stride 24→32; emitters reference new `tableslice_{len,funcptrs}_off` consts instead of literals), `JitRuntime.table_size` u32→u64 (absorbs `_pad0` — every subsequent field offset unchanged, `table_grow_fn_off==216` intact), `table_grow_fn` widens to `(delta: u64) → i64` with overflow-safe add, `jitCallIndirectResolve` takes the index at u64. Prologue pins X25 as the full u64 table-0 size.
- **C2/C3 — idx_type-conditional index widths**: per-table `idx_types` threaded `compileWasm → compileOne → ZirFunc.tableIdxType`; emitters mirror the validator's table64 typing (§3.3.6) — `table.get/set` idx, `table.grow` delta/result, `table.fill` dst/n, `table.copy` dst/src per side + n = narrower of the two, `table.init` dst (src/n stay i32), `call_indirect`/`return_call_indirect` inline + subtype-trampoline. i64 sums that can wrap past 2^64 get the memory64 guard (arm64 `ADDS`+`B.HS` / x86_64 `ADD`+`JC` → oob_table). i32 tables keep the zero-extending W/.d fast path byte-identical.
- **C4 — guard removal**: also fixed two interp-fallback-masked JIT-setup gaps (both the JIT mirror of interp fix `a7609a65b`): active-elem offsets evaluated i32-only in `setup.zig`/`compile_init.zig` (now `evalConstOffsetU64{,Ctx}`), and elem `offset_expr` validated as `.i32`-fixed in `compile.zig` (now per-target-table `elemOffsetValType`, the memory64 `data_off_vt` mirror).
- **Adversarial review (devil's-advocate, independent agent) before PR** — two real defects fixed: a spilled i64 `table.grow` result was W-stored (stale upper bits on X-form reload; the `-1` sentinel became a garbage positive) — pinned by new emit boundary fixtures + an e2e runner test; a guest-chosen u64 elem offset could wrap the instantiate-time bounds sum (ReleaseSafe panic / wrap-past-check OOB write) — `base`-first guards per the D-219 pattern. AOT now rejects a `>u32` table64 min loudly instead of silently saturating.

## Verification

- `zig build test-all`: green on **arm64-macos** and **x86_64-macos (Rosetta)** — 25539 spec asserts, 0 failed.
- **windowsmini** remote gate (`run_remote_windows.sh --branch … test-all`) on the final code tip: `[run_remote_windows] OK`, 25539/0 (the Win64-risk named in the debt recipe — pinned-cohort X25, len-load offsets, imm12 budgets — exercised on real hardware).
- Forced `--engine jit` sweep over all 11 distilled table64 spec dirs: every self-contained module compiles + instantiates; `assert_trap` fixtures trap `oob_table` as specified; spot invokes `size-t64=42`, `call_indirect type-i32-t64=306`, `type-index=100`.
- ubuntu leg: local pre-flight currently blocked by the host clone's retired path name (noted in handover) — the authoritative CI `ci-required` ubuntu leg covers it on this PR.
- Per-merge bench recorded on the branch (`bench/results/history.yaml` in this PR); D-475 ledger + handover synced.

## Residual (documented in D-475)

Spec-harness cross-module register-table wiring (`table.12/34`, `table_grow.6/7`) — a harness-coverage gap, not table64-specific; zwasm's linker already supports it.