### PR TITLE
docs(debt): open front G-senior-gap (senior-runtime gap analysis, measured)

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -3,6 +3,186 @@
 # Refresh on every /continue resume — .claude/skills/continue/RESUME.md Step 0.5.
 
 entries:
+  - id: "D-507"
+    layer: "code"
+    status: "now"
+    description: |-
+      QUEUE HEAD of front G-senior-gap (2026-07-06 senior-runtime gap analysis,
+      `.dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md`; queue order
+      G1=this, G2=D-508, G3=D-510, then note-class G4+). **Guard-page /
+      signal-based linear-memory bounds-check elision** — the single biggest
+      measured perf lever available WITHIN the single-pass JIT (no optimising
+      tier needed): zwasm emits an explicit CMP+branch per memory access;
+      wasmtime (`Config::memory_reservation`/`memory_guard_size`/
+      `signals_based_traps`, config.rs:1862/1945/3151) and WAMR (Segue) elide
+      it by reserving guard regions and converting the fault to an oob trap.
+      Measured evidence (report §0): shootout fib2 1.75x / matrix 3.9x /
+      heapsort 3.0x vs wasmtime — a substantial slice of the sub-4x band is
+      bounds-check overhead (the >4x outliers are optimising-tier codegen
+      quality, out of scope here → D-513). SHAPE (ADR REQUIRED first — codegen
+      strategy + signal-handler introduction are ADR-grade; also audit
+      `check_libc_boundary` for sigaction/mmap/VirtualAlloc additions):
+      (1) reserve base+4GiB+guard via mmap PROT_NONE (Win: VirtualAlloc
+      MEM_RESERVE + VEH) for i32 memories; commit-on-grow; (2) SIGSEGV/SIGBUS
+      (Win: vectored exception) handler classifies faults inside the guard →
+      route to the existing trap path (trap_kind oob) — must coexist with the
+      interrupt flag + EH unwinder; (3) emit flag drops the explicit CMP when
+      the memory qualifies (i32, guard-covered); memory64 KEEPS explicit
+      checks (wasmtime does the same); (4) interp unchanged (oracle). Fuzz
+      differential (D-510) SHOULD land first or together — it is the safety
+      net for exactly this class of change. 3-host verify mandatory
+      (JIT/ABI-class; Rosetta reproduces linux; windowsmini for VEH).
+    first_raised: "2026-07-06"
+    last_reviewed: "2026-07-06"
+    refs: |-
+      .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §0/§2.2
+      src/engine/codegen/{arm64,x86_64}/op_memory.zig (explicit bounds CMPs)
+      ~/Documents/OSS/wasmtime crates/wasmtime/src/config.rs:1862,1945,3151
+    front: G-senior-gap
+  - id: "D-508"
+    layer: "code"
+    status: "note"
+    description: |-
+      Front G-senior-gap, G2 (after D-507; independently startable). **On-disk
+      compilation cache** — zwasm recompiles every `run` (hello-world: JIT
+      5.2ms vs interp 3.4ms — compile tax visible even on trivial modules; on
+      large modules it dominates cold start). Peers: wasmtime on-disk cache
+      (`Config::cache`, crates/cache/) + wazero
+      `NewCompilationCacheWithDir` (cache.go:34-114, versioned dir key
+      `wazero-<ver>-<arch>-<os>`). SHAPE: key = (module bytes hash, zwasm
+      version, arch, build options affecting codegen); value = the existing
+      `.cwasm` serialization (AOT format reuse — loader already exists);
+      eviction = LRU or size cap; opt-in CLI flag first (`--cache[=dir]`),
+      default-on only after soak; embedding API knob after CLI. Invalidation
+      correctness > hit rate. Small-to-medium bundle; not ADR-grade unless the
+      .cwasm format needs changes.
+    first_raised: "2026-07-06"
+    last_reviewed: "2026-07-06"
+    refs: |-
+      .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §2.4
+      src/engine/codegen/aot/ (serialization to reuse)
+      ~/Documents/OSS/wazero/cache.go:34-114
+    front: G-senior-gap
+  - id: "D-509"
+    layer: "code"
+    status: "note"
+    description: |-
+      Front G-senior-gap (v0.2.0-line, big — schedule as its own campaign, not
+      a /continue drive-by). **Threads proposal multi-agent completion.**
+      Probe-verified 2026-07-06: zwasm ALREADY executes the threads opcodes
+      single-agent (shared-memory parse + i32.atomic.load + memory.atomic.wait32
+      correct via ADR-0168 atomic_* callbacks) — the gap is ACTUAL concurrency:
+      (1) shared Memory objects across instances/threads (today each instance
+      owns its memory; needs refcounted shared backing + coordinated grow —
+      cf. D-199 pointer-sharing precedent); (2) host thread spawn surface
+      (wasi-threads or WASIX-style thread_spawn; peers: WAMR lib-pthread +
+      thread-mgr + lib-wasi-threads, wasmer WASIX futex/thread_spawn);
+      (3) REAL wait/notify blocking semantics cross-thread (current wait
+      returns immediately per single-agent semantics — verify + fix);
+      (4) interp `Diagnostic` is `threadlocal` (existing blocked-by row notes
+      the Phase-14 mapping decision); (5) JIT codegen: atomics must become
+      genuinely atomic under contention (LSE/lock-prefix widths audit).
+      proposal_watch: Threads = Phase 4, zwasm intent v0.2.0. ADR + ROADMAP
+      §9-scope amendment required at kickoff (per §18.2).
+    first_raised: "2026-07-06"
+    last_reviewed: "2026-07-06"
+    refs: |-
+      .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §0/§1
+      .dev/proposal_watch.md (Phase 4 table)
+      src/engine/codegen/shared/jit_abi.zig (atomic_rmw_fn/atomic_wait_fns, ADR-0168)
+    front: G-senior-gap
+  - id: "D-510"
+    layer: "test"
+    status: "note"
+    description: |-
+      Front G-senior-gap, G3 (small; SHOULD land before or with D-507 as its
+      safety net). **Committed differential-fuzz harness (interp oracle vs
+      JIT)** — zwasm ran fuzz CAMPAIGNS (smith_v4, fuzz-loader 1665 modules
+      0-crash) but has no always-runnable in-repo differential target; the
+      campaign tooling lives in gitignored scratch. Peers: wazero
+      `internal/integration_test/fuzz/fuzz_targets/no_diff.rs` (compiler-vs-
+      interp differential + regression corpus `fuzzcases/`), wasmtime
+      fuzz_targets/differential.rs. SHAPE: `zig build fuzz-diff` (or a
+      script) = wasm-tools smith (already provisioned in the gen shell) →
+      run module on interp AND JIT → compare results/traps/memory; committed
+      seed corpus + regression corpus dir; CI-optional (nightly or manual),
+      NOT in ci-required. zwasm's interp-as-oracle design makes this nearly
+      free; it converts the one-off campaigns into a permanent ratchet.
+    first_raised: "2026-07-06"
+    last_reviewed: "2026-07-06"
+    refs: |-
+      .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §3(infra)
+      ~/Documents/OSS/wazero/internal/integration_test/fuzz/
+      test/realworld/diff_runner.zig (existing diff harness to build on)
+    front: G-senior-gap
+  - id: "D-511"
+    layer: "code"
+    status: "note"
+    description: |-
+      Front G-senior-gap (demand-driven; trigger = a real cross-arch deploy
+      consumer). **Cross-arch AOT** (`zwasm compile --target <arch>`): .cwasm
+      is host-arch-only today. The emitters are already arch-parameterized
+      (comptime dispatch arm64/x86_64) — the work is (1) making the emit path
+      target-selectable at RUNTIME instead of comptime (structural: the
+      `builtin.target.cpu.arch` switch in shared/compile.zig becomes a
+      parameter — sizable refactor), (2) target-tagged .cwasm headers +
+      loader rejection (partially exists: arch tag per ADR-0039), (3) NO
+      cross-OS relocation work needed (cwasm is position-based). Peers:
+      wasmtime `compile --target`, wasmer `compile --target <triple>`, WAMR
+      wamrc (down to xtensa/riscv). Do NOT conflate with new-arch backends
+      (riscv etc.) — that is a separate, much larger front nobody asked for.
+    first_raised: "2026-07-06"
+    last_reviewed: "2026-07-06"
+    refs: |-
+      .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §2.7
+      src/engine/codegen/shared/compile.zig:43 (comptime arch dispatch)
+      src/engine/codegen/aot/produce.zig (hostArch tag)
+    front: G-senior-gap
+  - id: "D-512"
+    layer: "code"
+    status: "note"
+    description: |-
+      Front G-senior-gap (demand-driven, embedder-facing). **Observability
+      hooks for embedders**: (a) call listeners (wazero
+      experimental/listener.go Before/After/Abort + StackIterator pattern) —
+      per-call tracing from the Zig/C API; (b) perf jitdump / perf-map emit on
+      Linux so `perf` attributes JIT samples (wasmtime ProfilingStrategy;
+      WAMR WAMR_BUILD_LINUX_PERF); (c) coredump-on-trap artifact (wasmtime
+      coredump_on_trap). zwasm has a strong INTERNAL debug toolkit
+      (debug_jit_auto, trace.*) but exposes nothing to embedders. Start with
+      (b) — cheapest, pure-additive (emit a perf map file keyed by
+      code_map entries which already exist for EH). cljw is the natural
+      first consumer to validate (a).
+    first_raised: "2026-07-06"
+    last_reviewed: "2026-07-06"
+    refs: |-
+      .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §3(debug)
+      src/engine/codegen/shared/code_map.zig (pc→func mapping to reuse)
+      ~/Documents/OSS/wazero/experimental/listener.go:35-96
+    front: G-senior-gap
+  - id: "D-513"
+    layer: ""
+    status: "note"
+    description: |-
+      Front G-senior-gap — DECISION ROW, user-gated (do NOT start work).
+      blocked-by: explicit user ratification of a ROADMAP §-level amendment
+      (the standing pin is single-pass JIT, "no optimising tier", ADR-0153
+      framing). **Optimising-tier question**: measured 2026-07-06 (report §0)
+      — zwasm-jit vs wasmtime on compute-heavy shootout = 1.75x (fib2) to
+      12.5x (base64) slower; wasmer/wazero similarly ahead; AOT shows the
+      same ratio (codegen quality, not compile mode). Startup/lean axis zwasm
+      WINS (hello 5.2ms JIT / 3.4ms interp vs 7.3/9.6/16.4). The decision:
+      (a) re-affirm single-pass (lean/latency identity; close this row);
+      (b) targeted single-pass upgrades only (D-507 guard pages + regalloc
+      quality + branch-hint consumption — no new tier); (c) a second
+      optimising tier (Cranelift-class scope — months). Present the report's
+      numbers when the user wants to decide. Until then D-507/D-508 harvest
+      the tier-free wins.
+    first_raised: "2026-07-06"
+    last_reviewed: "2026-07-06"
+    refs: |-
+      .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §0/§2.1/§4
+    front: G-senior-gap
   - id: "D-506"
     layer: "code"
     status: "note"
@@ -437,6 +617,12 @@ entries:
       REMAINING (design upgrades, demand-driven):
       (a) epoch-COUNTER (per-store deadline ticks) over the v0 binary flag +
           a runtime-level pre-instantiate StoreLimits struct (ADR-0179 draft).
+          PRIORITY NOTE 2026-07-06: the senior-runtime gap analysis
+          (.dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §2.6)
+          confirms epoch interruption is the peer-standard low-overhead
+          deadline mechanism (wasmtime Config::epoch_interruption) — front
+          G-senior-gap ranks it right after D-508; the recipe stays HERE
+          (dedup: no G-row duplicates this item).
       (b) ~~JIT-side table-elements limit~~ DONE 2026-06-15 (`bd355258` initial eager-alloc
           early-reject in runWasiLenient + `fa4678f4` jitTableGrow honors rt.store_table_elements_max,
           set from RunLimits.max_table_elements; CLI `--max-table-elements`). Sandbox triad's table

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -29,19 +29,26 @@ Post-v2.0.0 sweep (see `.dev/meta_audits/2026-07-03-maintenance-scaffolding-audi
   the D-502 note); D-504 discharged (wasi_p2 @panic→NoHostIo + fd.zig doc-rot).
 - **D-254 — rust-host CI gate** — MERGED #122. `run-rust-host` now runs on the ubuntu
   gate leg (Linux-guarded core). Scaffolding-maintenance campaign (A→E→B + D-254) COMPLETE.
-- **Batch C / D-475 — table64-JIT** — DONE (this PR): TableSlice.len/max +
-  JitRuntime.table_size u64 (stride 24→32); per-table idx_type-conditional index
-  widths both arches (table ops + call_indirect/tail-call/subtype); wrap-safe i64
-  bounds (ADDS+B.HS / ADD+JC); JitTable64Unsupported guard removed; elem-offset
-  u64 eval fixed in setup/compile/compile_init; AOT rejects >u32 table64 min.
-  Adversarial review (devil's-advocate) fixed a spilled-i64-grow W-store
-  miscompile + a hostile-offset bounds wrap pre-merge. All 11 distilled table64
-  dirs JIT-native (forced `--engine jit` sweep). windowsmini + Rosetta green.
-- **NEXT (all fresh-context — do NOT grind in a deep loop)**: no `now`-class
-  items. **D-444** = optional design split (cap now advisory). Minor/demand-
-  driven: D-506 (FP spill stage-2 scaffold), D-502 residual (invokeStringExport
-  encoding), mac/win rust-host CI, D-475 residual = spec-harness cross-module
-  register-table wiring (table.12/34, table_grow.6/7 — not table64-specific).
+- **Batch C / D-475 — table64-JIT** — MERGED #127; **v2.1.0 released** (tag
+  @d5d685ad4, Latest). Adversarial-review fixes (spilled-i64-grow W-store,
+  bounds wrap) landed pre-merge; 11 table64 dirs JIT-native; 3-host green.
+
+## Active front — G-senior-gap (2026-07-06, /continue entry point)
+
+Senior-runtime gap analysis (measured; report =
+`.dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md`) opened front
+**G-senior-gap** (debt D-507..D-513, `front: G-senior-gap`). Queue order:
+- **G1 = D-507 (now)** — guard-page/signal bounds-check elision (biggest
+  tier-free perf lever; measured 1.75-3.9x band vs wasmtime). **ADR FIRST**
+  (signal handler + codegen strategy), then TDD cycles; D-510 is its safety net.
+- **G2 = D-508** — on-disk compilation cache (reuse .cwasm serialization).
+- **G3 = D-510** — committed differential-fuzz harness (interp oracle vs JIT);
+  MAY be pulled ahead of D-507 as its safety net — either order is sanctioned.
+- Then: D-314(a) epoch-counter (recipe lives in D-314) · note-class D-509
+  (threads campaign, own kickoff + ADR) · D-511/D-512 (demand-driven) ·
+  **D-513 = optimising-tier DECISION row (user-gated — never self-start)**.
+- Older demand-driven tail unchanged: D-444, D-506, D-502 residual, D-475
+  residual (spec-harness cross-module register-table), mac/win rust-host CI.
 
 ## Operational invariants (keep using)
 

--- a/.dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md
+++ b/.dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md
@@ -1,0 +1,222 @@
+# Senior-runtime gap analysis — zwasm v2.1.0 vs wasmtime/wasmer/WAMR/WasmEdge/wazero/wasm3/extism
+
+> **Doc-state**: ACTIVE — survey report (read-only findings; no code
+> changes). Drives the `G-senior-gap` debt front (D-507..D-513) + the
+> handover NEXT queue. Complements `.dev/proposal_watch.md` (spec-side)
+> with performance + usability lenses, with local measurements.
+
+Date: 2026-07-06. Method: reference clones refreshed to HEAD (wasmtime
+bed982ee 48.0-dev / wasmer dcd3261 7.2.0 / WAMR 9bc0cda 2.4.3 / WasmEdge
+c5883b8 0.17.0 / wazero c0f3a4e 1.12 / wasm3 d77cd81 / extism ea21512),
+4 parallel repo-survey agents with file-level citations, plus LOCAL
+EXPERIMENTS (nix binaries wasmtime 45.0.0 / wasmer 7.1.0 / wazero 1.12.0;
+zwasm v2.1.0 ReleaseSafe; hyperfine; wasm-tools probes). Read-only — no
+zwasm changes. Detailed per-runtime digests: see the agent outputs
+summarized inline; every claim below carries repo-file or measured
+evidence.
+
+## 0. Measured reality (this machine, arm64 macOS, hyperfine)
+
+### Compute-heavy (shootout corpus, mean ms, 5 runs + 2 warmup)
+
+| bench    | zwasm-jit | wasmtime | wasmer | wazero | zwasm/wasmtime |
+|----------|-----------|----------|--------|--------|----------------|
+| base64   | 695       | 55.7     | 57.0   | 80.5   | **12.5x** |
+| heapsort | 1952      | 641      | 655    | 930    | 3.0x |
+| keccak   | 37.3      | 9.2      | 9.3    | 7.5    | 4.1x |
+| matrix   | 381       | 96.9     | 92.8   | 198    | 3.9x |
+| fib2     | 1268      | 723      | 733    | 798    | 1.75x |
+
+### Startup-dominated (c_hello_wasi, 10 runs)
+
+| runtime      | mean ms |
+|--------------|---------|
+| zwasm-interp | **3.4** |
+| zwasm-jit    | **5.2** |
+| wasmtime     | 7.3     |
+| wasmer       | 9.6     |
+| wazero       | 16.4    |
+
+### AOT artifact (matrix, precompiled)
+
+zwasm .cwasm 376ms vs wasmtime .cwasm 88ms — same ~4x ratio as JIT:
+the gap is **codegen quality**, not compile mode.
+
+Interpretation: the optimizing-tier absence costs 1.7–12x on sustained
+compute (base64 = bulk/SIMD-friendly inner loops is worst). zwasm wins
+the latency/lean axis: fastest cold-start of all five configurations,
+and small binary. This is exactly the "lightweight-yet-fast" trade —
+today we have lightweight-and-fast-start, not fast-compute.
+
+### Spec probes (local, wasm-tools-built modules)
+
+- threads opcodes: `(memory 1 1 shared)` + `i32.atomic.load` +
+  `memory.atomic.wait32` RUN on zwasm (both engines; wait32 correctly
+  returned 1/not-equal). wasmtime default REJECTS shared memory
+  (needs `-W threads`). → zwasm has single-agent atomics; the missing
+  piece is MULTI-AGENT execution (spawn, cross-thread wait/notify,
+  shared Memory object across instances), not the opcode set.
+- wide-arithmetic: `i64.add128` computes correctly on zwasm (6/8 halves).
+- custom-page-sizes: `(memory 65536 65536 (pagesize 1))` → memory.size
+  65536 on zwasm, identical to wasmtime `-W custom-page-sizes`.
+
+## 1. Spec/proposal gaps
+
+### zwasm LACKS (with who has it)
+
+| gap | who has it | status there | zwasm posture |
+|-----|-----------|--------------|----------------|
+| Threads multi-agent execution (spawn/shared-Memory-across-instances; wasi-threads; lib-pthread) | wasmtime (flag, tier-2), WAMR (lib-pthread + wasi-threads + thread-mgr), wasmer (WASIX thread_spawn/futex) | shipped/flag | v0.2.0 intent (proposal_watch); opcodes ALREADY implemented single-agent (ADR-0168) |
+| WASI 0.3 / CM-async (streams/futures/async funcs) | wasmtime: in-tree preview (`component-model-async` feature, crates/wasi/src/p3/) | EXPERIMENTAL | post-v0.2.0 (D-335); wasmtime is the only mover |
+| Stack-switching (wasmfx) | wasmtime only (x86_64-linux, tier-3) | EXPERIMENTAL | DEFER (D-300) — correct call, format unstable |
+| Shared-everything-threads | wasmtime knob exists, unimplemented | EXP | watch only |
+| Branch-hinting CONSUMPTION (bias JIT layout) | wasmtime (flag, tier-3), WAMR (`WASM_ENABLE_BRANCH_HINTS`) | flag | zwasm accepts+ignores (conformant); QoI item |
+| Legacy exception-handling (old try/catch opcodes) | wasmtime (legacy knob), WAMR (legacy only!) | shipped | zwasm has modern try_table only — fine unless old toolchains matter |
+
+### zwasm LEADS (verified in their trees — worth knowing)
+
+- **GC + function-references**: wasmer 7.2 has NO GC/func-refs fields in
+  `lib/types/src/features.rs`; wazero has no GC at all; wasm3/zware none.
+  Only wasmtime/WAMR/WasmEdge are peers.
+- **Relaxed-SIMD + modern EH**: WAMR = UNIMPLEMENTED (legacy EH,
+  interp-only) per `doc/stability_wasm_proposals.md`. zwasm ships both.
+- **Multi-memory on all engines**: WAMR interp-only.
+- **WASI 0.2 / Component Model default-ON**: wasmer is WASIX-centric (no
+  CM-first story), wazero preview1-only, WAMR/WasmEdge partial/in-progress.
+  Peer = wasmtime only.
+- **100% Wasm 3.0 incl. memory64+table64 on JIT** (as of v2.1.0/D-475).
+
+## 2. Performance-architecture gaps (all measured or file-cited)
+
+Ranked by measured/likely impact:
+
+1. **No optimizing compiler tier** — wasmtime Cranelift (e-graph/ISLE +
+   regalloc2, `cranelift_opt_level`), wasmer Cranelift/LLVM, wazero
+   wazevo SSA, WAMR LLVM-JIT/AOT + multi-tier (Fast-JIT→LLVM tier-up).
+   Measured cost: 1.7–12x (table above). NOTE: ROADMAP currently pins
+   "single-pass, no optimising tier" — closing this is a §-level
+   ROADMAP/ADR decision, not a task.
+2. **Explicit bounds checks vs guard-page/signal elision** — wasmtime
+   `memory_reservation`/`memory_guard_size`/`signals_based_traps`
+   (config.rs:1862/1945/3151); WAMR Segue (GS-segment base). This is the
+   single biggest *within-single-pass* perf lever zwasm could adopt
+   without an optimizing tier. (Likely a large slice of the fib2 1.75x
+   floor.)
+3. **Copy-on-write memory images + pooling allocator** — wasmtime
+   `memory_init_cow` (config.rs:2218), `PoolingAllocationConfig` (~21
+   knobs) → microsecond-class re-instantiation for serverless density.
+   zwasm has none; matters only if embedding density becomes a target.
+4. **Compilation cache** — wasmtime on-disk cache (`Config::cache`,
+   crates/cache/) + incremental Cranelift cache; wazero
+   `NewCompilationCacheWithDir` (cache.go:34-114). zwasm recompiles every
+   run (visible in hello: 5.2ms JIT vs 3.4 interp — compile is ~2ms even
+   on trivial modules; on big modules it's the whole story). Cheap,
+   high-value, ROADMAP-compatible.
+5. **Parallel compilation** — wasmtime `parallel_compilation`
+   (config.rs:2150); wazero experimental compilation workers. zwasm
+   compiles serially.
+6. **Epoch interruption** — wasmtime `epoch_interruption` (config.rs:765):
+   near-zero-cost deadline vs zwasm's per-poll flag + fuel. zwasm's
+   ADR-0179(a) epoch-counter design note already anticipated this.
+7. **Cross-arch AOT** — wasmtime `compile --target` + `-Ccranelift-*`;
+   wasmer `compile --target <triple>`; WAMR wamrc targets
+   x86/arm/aarch64/thumb/xtensa/mips/riscv{32,64} + XIP + `--cpu-features`.
+   zwasm .cwasm is host-arch only.
+8. **Static PGO** — WAMR `wamrc --enable-llvm-pgo` + `--gen-prof-file`
+   (doc/perf_tune.md:55-81). Requires LLVM tier; N/A short-term.
+9. **Fast-interpreter tier** — WAMR fast-interp (threaded pre-transform,
+   ~2x interp speed); wasm3 M3 MUSTTAIL continuation-passing +
+   register-file + op-fusion (docs/Interpreter.md:44-80). zwasm's interp
+   is a correctness oracle by design — optional learning only.
+10. **Pulley-style portable bytecode backend** — wasmtime's tier-3
+    any-target fallback. Interesting existence proof; not a fit.
+
+## 3. Usability / tooling / ecosystem gaps
+
+### Debugging & observability (zwasm: none of these)
+
+- **DWARF native debugging** (gdb/lldb JIT interface): wasmtime
+  `Config::debug_info` + crates/jit-debug + gdbstub; WAMR full
+  LLDB/GDB-remote debug-engine incl. interp source-debugging
+  (core/iwasm/libraries/debug-engine/).
+- **Profiling**: wasmtime `ProfilingStrategy::{PerfMap,JitDump,VTune}` +
+  guest profiler (samply); WAMR linux-perf integration + memory
+  profiling; wazero FunctionListener (Before/After/Abort + StackIterator,
+  experimental/listener.go:35-96) as a tracing hook surface.
+- **Coredump on trap** (wasmtime `coredump_on_trap`), **wmemcheck**
+  (valgrind-like), `wasmtime explore` (wasm↔disasm HTML), `objdump`.
+- zwasm has a good internal debug toolkit (debug_jit_auto) but exposes
+  nothing to EMBEDDERS/users.
+
+### Serving / cloud (different product tier — deliberate zwasm non-goals so far)
+
+- `wasmtime serve` (wasi:http proxy world) — one-command HTTP host.
+- wasmer: registry (`wasmer run author/pkg`), webc, Edge deploy/app/ssh,
+  binfmt_misc, create-exe (currently disabled upstream), journal/snapshot
+  time-travel for WASIX.
+- WasmEdge: OCI/Kubernetes shims (crun/containerd/runwasi), DB drivers,
+  full plugin ecosystem — wasi-nn with llama.cpp/MLX/Whisper/StableDiffusion
+  /ffmpeg/OpenCV/zlib/eBPF; the LLM-inference runtime story.
+- WAMR: RTOS/embedded matrix (Zephyr/NuttX/ESP-IDF/RT-Thread/VxWorks/SGX),
+  56-85KB footprints, XIP, built-in libc for no-WASI targets.
+
+### Embedding surface
+
+- **Async host functions / async store** — wasmtime `async_support`,
+  `call_async`, ResourceLimiterAsync. zwasm C/Zig APIs are sync-only.
+- **Programmable resource limits** — wasmtime `ResourceLimiter` trait
+  (callbacks on grow) vs zwasm's static caps.
+- **Per-opcode metering** — wasmer metering middleware
+  (`Fn(&Operator)->u64` weights) vs zwasm's coarse fuel units.
+- **Language bindings** — wasmtime: Rust/C/C++ official + Python/Go/.NET/
+  Ruby; wasmer ~10+; WAMR Go/Python/Rust; WasmEdge Rust/Java/JS; extism
+  ~14 host SDKs. zwasm: C + Zig only.
+- **Framework layer (extism pattern)** — manifest (URL/path/data + hash),
+  capability config (allowed_hosts/paths/timeout), built-in host funcs
+  (http/kv/var/log), typed calls, thread-safe CancelHandle. A shell like
+  this sits ABOVE the runtime C API; zwasm has nothing equivalent —
+  though cljw is effectively zwasm's one bespoke framework consumer.
+- **wast runner as user-facing CLI** (`wasmtime wast`), `settings`
+  introspection dump.
+
+### Infra practices
+
+- **In-repo differential fuzz harness** — wazero's Rust libFuzzer with
+  compiler-vs-interp differential oracle (fuzz_targets/no_diff.rs);
+  wasmtime's fuzz/差分 (differential.rs). zwasm ran fuzz CAMPAIGNS
+  (smith_v4, fuzz-loader) but has no committed always-on differential
+  fuzz target; its interp-as-oracle design is a perfect fit for one.
+
+## 4. Recommendation sketch (NOT scheduled work — for user triage)
+
+ROADMAP-compatible (no §-level deviation, clear value):
+1. **Guard-page/signal bounds elision** (perf lever within single-pass;
+   biggest legal speedup available; wasmtime/WAMR precedents).
+2. **On-disk compilation cache** (wazero-style keyed dir; kills the
+   recompile tax; also makes AOT less necessary for CLI users).
+3. **Epoch-based interruption** (ADR-0179(a) already sketches it).
+4. **Threads completion** (v0.2.0 already the stated intent; opcodes done
+   single-agent — remaining = shared Memory across instances + spawn +
+   wasi-threads; Win64/ABI-heavy).
+5. **Embedder observability hooks** (function listeners / trap coredump /
+   perf jitdump emit) — cheap goodwill for the embedding story.
+6. **Differential fuzz target in-repo** (interp oracle vs JIT; wazero
+   pattern) — locks in the correctness plateau.
+7. **Cross-arch AOT targets** (compile --target; the codegen is already
+   arch-parameterized; mostly plumbing + linker/reloc formats).
+
+ROADMAP-§-level decisions (need ADR/user ratification first):
+8. **Optimizing tier** (measured 1.7–12x; contradicts the standing
+   "single-pass only" pin — the numbers above are the evidence base for
+   revisiting or re-affirming it).
+9. **WASI 0.3 / CM-async** (post-v0.2.0 per proposal_watch; wasmtime
+   preview exists to crib from).
+10. Product-tier questions (serve/HTTP, registry, plugins, bindings
+    beyond C/Zig) — scope philosophy, not engineering gaps.
+
+## Appendix: raw artifacts
+
+- hyperfine JSONs: scratchpad bench/ (session-local)
+- probe wat/wasm: /tmp/{threads_probe,wait_probe,cps,wa}.wat
+- agent digests: wasmtime/wasmer/WAMR+WasmEdge/wazero-group (4 agents,
+  file-level citations embedded above)


### PR DESCRIPTION
## Summary

Promotes the 2026-07-06 senior-runtime gap analysis (wasmtime / wasmer / WAMR / WasmEdge / wazero / wasm3 / extism, all refreshed to HEAD; hyperfine measurements + wasm-tools spec probes on this machine) into `.dev/meta_audits/` and wires it into the `/continue` reference chain as a new maintenance front.

**Front G-senior-gap** (D-507..D-513, queue-ordered):

| # | row | what |
|---|-----|------|
| G1 | **D-507 (now)** | guard-page/signal bounds-check elision — biggest tier-free perf lever (measured 1.75–3.9x band vs wasmtime); **ADR-first** |
| G2 | D-508 | on-disk compilation cache (reuse the `.cwasm` serialization) |
| G3 | D-510 | committed differential-fuzz harness (interp oracle vs JIT) — sanctioned to run ahead of G1 as its safety net |
| — | D-509 | threads multi-agent campaign (probe-verified: opcodes already run single-agent; gap = real concurrency) — own kickoff + ADR |
| — | D-511/D-512 | cross-arch AOT / embedder observability hooks (demand-driven) |
| — | **D-513** | optimising-tier **DECISION row** (user-gated, carries the measured evidence: 1.75–12.5x compute vs zwasm-fastest cold-start) |

**Reachability fixes**: D-314(a) epoch-counter was buried in a long note row → priority note + front cross-ref (recipe stays there, no duplicate); handover's dead-end "no now-class items" NEXT replaced with the Active-front queue so a fresh `/continue` session lands on concrete work.

Chain audited end-to-end: SessionStart handover → debt `status: now` sweep (single row = unambiguous queue head) → report Doc-state back-link → src/OSS refs all resolve; `check_debt_yaml` + `check_doc_state` gates green.

Doc-only PR (no code changes — the analysis itself was read-only).