### PR TITLE
D-507 phase 3: bounds-check elision flip + AOT soundness guard (ADR-0202 D4/D5) — completes D-507

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -210,24 +210,29 @@ entries:
     layer: "code"
     status: "note"
     description: |-
-      Front G-senior-gap follow-on to D-507. **Run the full spec corpus under
-      bounds elision.** The spec-assert harness backs JIT linear memory with
-      bespoke non-guarded buffers (`scratch_memory` heap + static
-      `growable_memory` array), so it forces `.explicit` (no elision) to keep
-      the D4/D5 binding-time soundness invariant (elided code MUST bind guarded
-      memory). The elided codegen path is currently validated by the guarded
-      `runner_trap_test` OOB tests + the `test-oob-elision` CLI build step, NOT
-      by the comprehensive spec corpus. Close by EITHER (a) guard-backing the
-      harness's memory provisioning (route `scratch_memory`/`growable_memory`
-      through `memory_backing`/`guarded_mem` when qualifying — invasive to
-      critical infra) OR (b) folding it into the D-510 differential-fuzz harness
-      (diff elided-JIT vs interp oracle over the corpus — the natural home; the
-      `.explicit` knob exists precisely for the elided-vs-checked axis).
+      Front G-senior-gap follow-on to D-507. TWO deferred elision-coverage /
+      soundness items, both currently held by forcing `.explicit`:
+      (1) **AOT `.cwasm` elision** — ADR-0202 D5's five AOT clauses are unbuilt
+      (elision bit in the format, trap-registry func_table serialise +
+      load-register, non-D1-host reject, guarded run-memory in `aot/run.zig`
+      which today binds PLAIN HEAP). Held safe by `produceFromCompiledWasm`
+      HARD-REFUSING an elided module (`Error.ElidedBoundsNotAotSerializable`) +
+      `compileWasmForAot` forcing `.explicit`; implement the D5 clauses to let
+      AOT artifacts elide.
+      (2) **Full spec corpus under elision** — the spec-assert harnesses
+      (spec_assert_runner / simd / wasm_3_0 / non_simd) back JIT memory with
+      bespoke non-guarded buffers (`scratch_memory` / static `growable_memory`),
+      so each forces `.explicit`. The elided path is validated by the guarded
+      `runner_trap_test` OOB tests + the `test-oob-elision` CLI step, NOT the
+      comprehensive corpus. Close by EITHER guard-backing the harness memory
+      provisioning OR folding into the D-510 differential-fuzz harness (diff
+      elided-JIT vs interp oracle — the natural home; `.explicit` is its axis).
     first_raised: "2026-07-07"
     last_reviewed: "2026-07-07"
     refs: |-
-      test/spec/spec_assert_runner_base.zig::installSigsegvHandler (setBoundsChecks .explicit)
-      src/engine/runner.zig (setBoundsChecks re-export)
+      src/engine/codegen/aot/produce.zig (ElidedBoundsNotAotSerializable guard)
+      src/cli/compile.zig + src/engine/compile.zig::compileWasmForAot
+      test/spec/{spec_assert_runner,simd_assert_runner,spec_assert_runner_wasm_3_0}.zig (setBoundsChecks .explicit)
       .dev/decisions/0202_guard_page_bounds_elision.md D5
     front: G-senior-gap
   - id: "D-506"

--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -183,6 +183,53 @@ entries:
     refs: |-
       .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §0/§2.1/§4
     front: G-senior-gap
+  - id: "D-514"
+    layer: "code"
+    status: "note"
+    description: |-
+      Front G-senior-gap follow-on to D-507 (guard-page elision). **Symmetric
+      SIMD bounds-check elision.** D-507 phase 3 elides the memory0 SCALAR
+      bounds check on both arches (the measured shootout band — fib2/matrix/
+      heapsort/base64 — is scalar-loop-bound). v128 load/store still emit the
+      explicit CMP: arm64 `op_simd.zig` is ctx-threaded (a one-line gate away),
+      but x86_64's ~12 v128 handlers + `v128MemPrologue` take raw params (no
+      ctx), so eliding there needs either threading `bounds_elided` through all
+      of them or converting them to ctx-based. Kept symmetric-explicit this
+      phase to avoid the churn + an arch asymmetry. Same guard machinery
+      (v128's 16-byte access is inside the reservation); pure perf refinement,
+      not a correctness gap. Recipe: gate the `!ctx.bounds_elided` block in
+      arm64 op_simd + thread the flag through x86_64 op_simd handlers.
+    first_raised: "2026-07-07"
+    last_reviewed: "2026-07-07"
+    refs: |-
+      src/engine/codegen/arm64/op_simd.zig (ctx-threaded, one-line gate)
+      src/engine/codegen/x86_64/op_simd.zig (v128MemPrologue + ~12 handlers, param-threaded)
+      .dev/decisions/0202_guard_page_bounds_elision.md D4
+    front: G-senior-gap
+  - id: "D-515"
+    layer: "code"
+    status: "note"
+    description: |-
+      Front G-senior-gap follow-on to D-507. **Run the full spec corpus under
+      bounds elision.** The spec-assert harness backs JIT linear memory with
+      bespoke non-guarded buffers (`scratch_memory` heap + static
+      `growable_memory` array), so it forces `.explicit` (no elision) to keep
+      the D4/D5 binding-time soundness invariant (elided code MUST bind guarded
+      memory). The elided codegen path is currently validated by the guarded
+      `runner_trap_test` OOB tests + the `test-oob-elision` CLI build step, NOT
+      by the comprehensive spec corpus. Close by EITHER (a) guard-backing the
+      harness's memory provisioning (route `scratch_memory`/`growable_memory`
+      through `memory_backing`/`guarded_mem` when qualifying — invasive to
+      critical infra) OR (b) folding it into the D-510 differential-fuzz harness
+      (diff elided-JIT vs interp oracle over the corpus — the natural home; the
+      `.explicit` knob exists precisely for the elided-vs-checked axis).
+    first_raised: "2026-07-07"
+    last_reviewed: "2026-07-07"
+    refs: |-
+      test/spec/spec_assert_runner_base.zig::installSigsegvHandler (setBoundsChecks .explicit)
+      src/engine/runner.zig (setBoundsChecks re-export)
+      .dev/decisions/0202_guard_page_bounds_elision.md D5
+    front: G-senior-gap
   - id: "D-506"
     layer: "code"
     status: "note"

--- a/.dev/decisions/0202_guard_page_bounds_elision.md
+++ b/.dev/decisions/0202_guard_page_bounds_elision.md
@@ -152,8 +152,23 @@ them); sandbox caps (`store_memory_pages_max`, fuel, interrupt); EH unwinder
 
 - **+** Removes exactly `ADD ip1 / CMP / B.HI` (3 instructions, arm64) / the
   mem_limit reload + CMP + JA (x86_64; the vm_base reload stays — it feeds the
-  access itself) per memory access — the biggest tier-free lever toward the
-  1.75–3.9x measured band. Bench recorded on this branch per per-merge policy.
+  access itself) per memory access. Code-size + icache win; foundational for
+  the guard-fault infra D-509 (threads) needs.
+- **⚠ MEASURED PERF (retrospective, correcting the pre-impl hypothesis):** the
+  arm64 shootout delta is ~noise-level, NOT the "large slice of the 1.75x
+  floor" this ADR's Context hypothesised (aarch64 macOS, hyperfine, D-507 phase
+  1 baseline vs phase 3): matrix 348.9→344.7 (~1%), base64 710.5→700.5 (~1.5%),
+  sieve 835.7→802.7 (~4%), fib2 1230.8→1194.1 (~3% but fib2 has NO hot-path
+  memory access → within the ±2–4% run stddev). The bounds check was a
+  pinned-reg CMP + a well-predicted (never-taken) branch — cheap on an OoO
+  core, so eliding it saves few cycles. **The 1.75–3.9x gap vs wasmtime is
+  dominated by optimising-tier codegen quality (D-513), not bounds checks** —
+  exactly what the gap report's own ">4x outliers = tier quality" caveat
+  implied; this measurement extends it down to the sub-4x band too. The
+  elision still ships: it is correct, reduces code size, is the standard
+  production design, and its guard-fault machinery is the reusable foundation
+  D-509 requires — but it is NOT the perf lever the Context framed it as. Per
+  the perf-measure-first principle, the hypothesis is recorded as refuted.
 - **+** Base-stable memory is a prerequisite D-509 (shared memories) needs
   anyway; realloc-relocation dies here.
 - **−** 8 GiB VA reservation per qualifying memory (reserve-only; no commit

--- a/build.zig
+++ b/build.zig
@@ -1265,12 +1265,31 @@ pub fn build(b: *std.Build) void {
     const test_internal_fault_step = b.step("test-internal-fault", "Verify the internal-fault handler exits 70 (ADR-0166 / D-292 B-core)");
     test_internal_fault_step.dependOn(&run_internal_fault.step);
 
+    // ADR-0202 D4/D5 (D-507) — verify the guard-page bounds-elision path
+    // end-to-end on EACH host: `zwasm run --engine jit` on a boundary oob
+    // load (eff_addr 65533 + 4 > 65536) must, with the CMP elided, hardware-
+    // fault in the guard region, be redirected by the production handler to
+    // the oob stub, and surface as a wasm trap (exit 1). This is the only
+    // behavioural test of the FULL production elision path (installInternal-
+    // FaultHandler + guarded memory + elided codegen + Win64 VEH redirect);
+    // the spec corpus runs `.explicit` (non-guarded harness memory).
+    const run_oob_trap = b.addRunArtifact(exe);
+    run_oob_trap.addArgs(&.{
+        "run",      "--engine",
+        "jit",      "test/edge_cases/p7/memory_bounds/past_limit_load_i32.wasm",
+        "--invoke", "test",
+    });
+    run_oob_trap.expectExitCode(1); // a genuine trap → exit 1 (interp-parity)
+    const test_oob_trap_step = b.step("test-oob-elision", "Verify guard-page bounds elision traps oob (ADR-0202 D4/D5 / D-507)");
+    test_oob_trap_step.dependOn(&run_oob_trap.step);
+
     // `zig build test-all` — aggregate all enabled test layers.
     // Phase 0: only `test`. Phase 1+ adds spec / e2e / realworld /
     // c_api / fuzz steps as they land. Each layer registers itself
     // here so the user's invocation surface stays stable.
     const test_all_step = b.step("test-all", "Run all enabled test layers");
     test_all_step.dependOn(&run_internal_fault.step); // ADR-0166 B-core
+    test_all_step.dependOn(&run_oob_trap.step); // ADR-0202 D4/D5 (D-507) guard-page elision
     test_all_step.dependOn(&run_core_tests.step);
     test_all_step.dependOn(&run_cli_tests.step);
     test_all_step.dependOn(&run_spec_smoke.step);

--- a/src/cli/compile.zig
+++ b/src/cli/compile.zig
@@ -59,7 +59,11 @@ pub fn run(
     };
     defer gpa.free(wasm_bytes);
 
-    var compiled = try runner.compileWasm(gpa, wasm_bytes);
+    // ADR-0202 D5 — AOT MUST compile with explicit bounds checks (the
+    // `.cwasm` format + `aot/run.zig`'s plain-heap run-memory cannot yet
+    // uphold guard-page soundness; `produceFromCompiledWasm` hard-refuses an
+    // elided module). `compileWasmForAot` forces `.explicit` for this compile.
+    var compiled = try runner.compileWasmForAot(gpa, wasm_bytes);
     defer compiled.deinit(gpa);
 
     const cwasm_bytes = try aot_produce.produceFromCompiledWasm(gpa, &compiled, wasm_bytes);

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -1091,7 +1091,7 @@ test "runCwasm: compile → produce → load+run a .cwasm, i32 result surfaces a
         0x2a, 0x0b,
     };
 
-    var compiled = try runner.compileWasm(testing.allocator, &wasm);
+    var compiled = try runner.compileWasmForAot(testing.allocator, &wasm);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm);
     defer testing.allocator.free(cwasm);
@@ -1114,7 +1114,7 @@ test "runCwasmWasi: a WASI proc_exit(42) .cwasm surfaces exit code 42 end-to-end
     const runner = @import("../engine/runner.zig");
     const aot_produce = @import("../engine/codegen/aot/produce.zig");
 
-    var compiled = try runner.compileWasm(testing.allocator, &proc_exit_42_wasm);
+    var compiled = try runner.compileWasmForAot(testing.allocator, &proc_exit_42_wasm);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &proc_exit_42_wasm);
     defer testing.allocator.free(cwasm);
@@ -1149,7 +1149,7 @@ test "runCwasmWasi: a WASI fd_write .cwasm writes 'hi\\n' to the captured stdout
     const runner = @import("../engine/runner.zig");
     const aot_produce = @import("../engine/codegen/aot/produce.zig");
 
-    var compiled = try runner.compileWasm(testing.allocator, &fd_write_hi_wasm);
+    var compiled = try runner.compileWasmForAot(testing.allocator, &fd_write_hi_wasm);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &fd_write_hi_wasm);
     defer testing.allocator.free(cwasm);
@@ -1207,7 +1207,7 @@ test "runCwasmWasi: AOT clock_time_get reads a real (nonzero) host clock (D-251)
     const runner = @import("../engine/runner.zig");
     const aot_produce = @import("../engine/codegen/aot/produce.zig");
 
-    var compiled = try runner.compileWasm(testing.allocator, &clock_start_wasm);
+    var compiled = try runner.compileWasmForAot(testing.allocator, &clock_start_wasm);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &clock_start_wasm);
     defer testing.allocator.free(cwasm);
@@ -1278,7 +1278,7 @@ test "runCwasmWasi: threads argv → AOT guest args_sizes_get sees argc (D-251)"
     const runner = @import("../engine/runner.zig");
     const aot_produce = @import("../engine/codegen/aot/produce.zig");
 
-    var compiled = try runner.compileWasm(testing.allocator, &argc_exit_jit);
+    var compiled = try runner.compileWasmForAot(testing.allocator, &argc_exit_jit);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &argc_exit_jit);
     defer testing.allocator.free(cwasm);
@@ -1321,7 +1321,7 @@ test "runCwasmWasi: --dir preopen makes the AOT fd_prestat_get(3) succeed (D-251
     const runner = @import("../engine/runner.zig");
     const aot_produce = @import("../engine/codegen/aot/produce.zig");
 
-    var compiled = try runner.compileWasm(testing.allocator, &prestat_jit);
+    var compiled = try runner.compileWasmForAot(testing.allocator, &prestat_jit);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &prestat_jit);
     defer testing.allocator.free(cwasm);

--- a/src/engine/codegen/aot/produce.zig
+++ b/src/engine/codegen/aot/produce.zig
@@ -51,6 +51,13 @@ pub const Error = serialise.Error || error{
     /// A table/element segment is outside the cycle-2a subset (a
     /// non-const active-elem offset, or an offset past u32).
     UnsupportedTableState,
+    /// ADR-0202 D5 — the module was compiled with memory0 bounds-check
+    /// elision, which the `.cwasm` format cannot yet represent safely (no
+    /// elision bit / trap-registry table, and `aot/run.zig` binds plain
+    /// heap). Serializing it would produce a `.cwasm` whose oob accesses
+    /// read/write past the guest memory silently. Callers destined for AOT
+    /// MUST `runner.setBoundsChecks(.explicit)` before compiling.
+    ElidedBoundsNotAotSerializable,
 };
 
 /// Table-0 + element state collected for the producer (v0.3 cycle-2a).
@@ -85,6 +92,12 @@ pub fn produceFromCompiledWasm(
     compiled: *const runner.CompiledWasm,
     wasm_bytes: []const u8,
 ) Error![]u8 {
+    // ADR-0202 D5 — refuse to serialize elided codegen: the `.cwasm` format +
+    // `aot/run.zig`'s plain-heap run-memory cannot yet uphold the guard-page
+    // soundness invariant. This is the hard enforcement point that makes the
+    // "elided ⇒ guarded binding" invariant impossible to breach via AOT (a
+    // per-caller `.explicit` would be easy to forget). D-515 lifts it.
+    if (compiled.bounds_elided) return Error.ElidedBoundsNotAotSerializable;
     const arch = try hostArch();
 
     const n_funcs = compiled.func_results.len;
@@ -388,6 +401,31 @@ test "hostArch maps to a valid .cwasm arch tag on supported hosts" {
     }
 }
 
+test "produceFromCompiledWasm: REFUSES an elided module (ADR-0202 D5 soundness guard)" {
+    // A qualifying i32/64KiB memory + a load compiled with the DEFAULT .auto
+    // knob elides the bounds check. Serializing that to .cwasm would bind
+    // plain heap at run time with no guard region → silent OOB. The producer
+    // must hard-refuse. (guarded_mem.supported gate: on a non-qualifying host
+    // nothing elides, so the refusal can't fire — skip there.)
+    if (comptime !@import("../../../platform/guarded_mem.zig").supported) return;
+    const mem_load_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x03,
+        0x02, 0x01, 0x00,
+        0x05, 0x03, 0x01, 0x00, 0x01, // memory min 1 (i32, 64 KiB)
+        0x0a, 0x09, 0x01, 0x07, 0x00, 0x41, 0x00, 0x28, 0x02, 0x00, 0x0b, // i32.const 0; i32.load
+    };
+    runner.setBoundsChecks(.auto);
+    defer runner.setBoundsChecks(.auto); // leave the default as other tests expect
+    var compiled = try runner.compileWasm(testing.allocator, &mem_load_wasm);
+    defer compiled.deinit(testing.allocator);
+    try testing.expect(compiled.bounds_elided); // .auto + qualifying → elided
+    try testing.expectError(
+        Error.ElidedBoundsNotAotSerializable,
+        produceFromCompiledWasm(testing.allocator, &compiled, &mem_load_wasm),
+    );
+}
+
 test "produceFromCompiledWasm: tiny synthetic wasm round-trips through compileWasm + AOT producer" {
     // Synthetic wasm: () -> i32 returning 7.
     // Module sections: type, function, code.
@@ -406,7 +444,7 @@ test "produceFromCompiledWasm: tiny synthetic wasm round-trips through compileWa
         0x41, 0x07, 0x0b,
     };
 
-    var compiled = try runner.compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try runner.compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
 
     const out = try produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
@@ -457,7 +495,7 @@ test "produceFromCompiledWasm: a WASI import round-trips into the .cwasm v0.4 im
         0x01, 0x06, 0x00, 0x41, 0x2A, 0x10, 0x00, 0x0B,
     };
 
-    var compiled = try runner.compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try runner.compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
     const out = try produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
     defer testing.allocator.free(out);

--- a/src/engine/codegen/arm64/ctx.zig
+++ b/src/engine/codegen/arm64/ctx.zig
@@ -266,6 +266,14 @@ pub const EmitCtx = struct {
     /// Default `.i32` keeps the 36 existing compile() call sites
     /// behaviour-preserving when they pass struct-literal default.
     memory0_idx_type: sections.MemoryEntry.IdxType = .i32,
+    /// ADR-0202 D4 — when true, memory0 scalar/atomic/SIMD accesses
+    /// SKIP the inline `ADD/CMP/B.HI` bounds check (the guard-page
+    /// reservation + fault→trap redirect own oob detection) and the
+    /// kind=6 stub is force-emitted as the redirect target. Set only
+    /// when memory0 qualifies (i32 × 64 KiB pages × guarded host) AND
+    /// the engine knob is `.auto`. memory64 / bulk / GC-array checks
+    /// are NEVER elided. Default false = explicit checks (status quo).
+    bounds_elided: bool = false,
     /// Wasm 3.0 EH (ADR-0120) — per-tag
     /// param count threaded from `CompiledWasm.tag_param_counts`
     /// (compile.zig). Indexed by `tag_idx`. `throw.emit` /

--- a/src/engine/codegen/arm64/emit.zig
+++ b/src/engine/codegen/arm64/emit.zig
@@ -179,6 +179,11 @@ pub fn compile(
     /// Routes `call_indirect` through the subtype trampoline. `false` for
     /// non-subtyping modules + test helpers.
     uses_type_subtyping: bool,
+    /// ADR-0202 D4 — drop the inline bounds check for memory0
+    /// scalar/atomic/SIMD accesses (guard-page + fault→trap redirect
+    /// own oob detection) and force-emit the kind=6 stub. `false` for
+    /// non-qualifying modules, the `.explicit` knob, and test helpers.
+    bounds_elided: bool,
 ) Error!EmitOutput {
     if (alloc.slots.len != (func.liveness orelse return Error.AllocationMissing).ranges.len) {
         return Error.AllocationMissing;
@@ -848,6 +853,7 @@ pub fn compile(
         .globals_offsets = globals_offsets,
         .globals_valtypes = globals_valtypes,
         .memory0_idx_type = memory0_idx_type,
+        .bounds_elided = bounds_elided,
         .exception_table_builder = if (has_try_table) &eh_builder else null,
         .open_try_tables = if (has_try_table) &open_try_tables else null,
         .landing_pad_fixups = if (has_try_table) &landing_pad_fixups else null,
@@ -1934,7 +1940,21 @@ pub fn compile(
                         kind: u16,
                         fb: u32,
                     ) !void {
-                        if (fixups.len == 0) return;
+                        return emitForce(a, b, fixups, kind, fb, false);
+                    }
+
+                    /// `force` (ADR-0202 D4): emit the stub even with zero
+                    /// fixups — an elided-bounds function has no B.HI sites
+                    /// but the guard-fault PC-redirect needs the stub body.
+                    fn emitForce(
+                        a: std.mem.Allocator,
+                        b: *std.ArrayList(u8),
+                        fixups: []const u32,
+                        kind: u16,
+                        fb: u32,
+                        force: bool,
+                    ) !void {
+                        if (fixups.len == 0 and !force) return;
                         const stub_byte: u32 = @intCast(b.items.len);
                         try gpr.writeU32(a, b, inst.encMovzImm16(17, 1));
                         try gpr.writeU32(a, b, inst.encStrImmW(17, abi.runtime_ptr_save_gpr, jit_abi.trap_flag_off));
@@ -1989,11 +2009,14 @@ pub fn compile(
                 try EmitCindStub.emit(allocator, &buf, uncaught_exc_fixups.items, 12, frame_bytes);
                 // ADR-0202 D3 — capture the oob (kind=6) stub's byte offset for
                 // the trap registry's PC-redirect target. `EmitCindStub.emit`
-                // sets stub_byte = b.items.len on entry then early-returns when
-                // there are no fixups, so buf.items.len HERE is that same offset
-                // (or no_stub when the function has no bounds-checked access).
-                oob_stub_off = if (oob_fixups.items.len > 0) @intCast(buf.items.len) else oob_stub_off;
-                try EmitCindStub.emit(allocator, &buf, oob_fixups.items, 6, frame_bytes);
+                // sets stub_byte = b.items.len on entry then skips emission when
+                // there are no fixups AND no force, so buf.items.len HERE is that
+                // same offset (or no_stub when no stub is emitted). D4: elision
+                // FORCE-emits the stub — with the CMP gone there are no fixups,
+                // but the fault handler still needs the redirect target.
+                const force_oob_stub = bounds_elided;
+                if (oob_fixups.items.len > 0 or force_oob_stub) oob_stub_off = @intCast(buf.items.len);
+                try EmitCindStub.emitForce(allocator, &buf, oob_fixups.items, 6, frame_bytes, force_oob_stub);
                 // ADR-0179 #3a / D-314 — loop back-edge interrupt poll stub
                 // (code 16, POST-frame → fb=frame_bytes; distinct from the
                 // prologue interrupt stub which is fb=0).

--- a/src/engine/codegen/arm64/emit_test_alu_float.zig
+++ b/src/engine/codegen/arm64/emit_test_alu_float.zig
@@ -46,7 +46,7 @@ test "compile: f32 binary ALU each emits S-form" {
         } };
         const slots = [_]u16{ 0, 1, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         // Each f32.const emits MOVZ + MOVK + FMOV (3 u32s = 12 bytes).
@@ -79,7 +79,7 @@ test "compile: f32 cmps each emit FCMP-S + CSET-W with right Cond" {
         } };
         const slots = [_]u16{ 0, 1, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         // FCMP at body+24; CSET at body+28.
@@ -131,7 +131,7 @@ test "compile: f32 unary ops + min/max each emit correct encoding" {
             .{ .slots = &slots_binary, .n_slots = 2 }
         else
             .{ .slots = &slots_unary, .n_slots = 1 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         // For unary: 1 const = 3 u32s (MOVZ + MOVK + FMOV S) → body+12.
@@ -157,7 +157,7 @@ test "compile: f32.copysign emits 8-instr FMOV/BIC/AND/ORR sequence" {
     } };
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After 2 consts (each 3 u32s = 24 bytes), 8-instr copysign sequence at body+24.
@@ -187,7 +187,7 @@ test "compile: f64.copysign emits X-form 8-instr sequence with hw=3 mask" {
     } };
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // f64.const 1.5: bits=0x3FF8000000000000. Lanes: l0=0,l1=0,
     // l2=0,l3=0x3FF8. Only l3 nonzero → MOVZ + MOVK lane3 + FMOV D
@@ -228,7 +228,7 @@ test "compile: f64 binary ALU each emits D-form" {
         } };
         const slots = [_]u16{ 0, 1, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         // f64.const 1.0: bits=0x3FF0000000000000. Lanes: lo=0, l1=0,
         // l2=0, l3=0x3FF0. Only lane 3 nonzero (besides lane 0).
@@ -254,7 +254,7 @@ test "compile: i32.wrap_i64 emits MOV W,W (= ORR W, WZR, W)" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ X9, #0xCAFE: ORR W9, WZR, W9 (in-place wrap) at body+4.
@@ -274,7 +274,7 @@ test "compile: i64.extend_i32_s emits SXTW X, W" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ + MOVK loading 0xFFFFFFFF into W9 (8 bytes): SXTW X9,W9 at body+8.
@@ -294,7 +294,7 @@ test "compile: i64.extend_i32_u emits MOV W,W (zero-extends via W-write)" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ W9 #42: ORR W9, WZR, W9 at body+4.
@@ -314,7 +314,7 @@ test "compile: f32.convert_i32_s emits SCVTF S, W" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ W9 #7: SCVTF S16, W9 at body+4.
@@ -334,7 +334,7 @@ test "compile: f64.convert_i64_u emits UCVTF D, X" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ X9 #0xDEAD: UCVTF D16, X9 at body+4.
@@ -354,7 +354,7 @@ test "compile: f32.demote_f64 emits FCVT S, D" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Find FCVT S16, D16 in the byte stream.
     const expected = inst_fp.encFcvtSFromD(16, 16);
@@ -382,7 +382,7 @@ test "compile: f64.promote_f32 emits FCVT D, S" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected = inst_fp.encFcvtDFromS(16, 16);
     var found = false;
@@ -409,7 +409,7 @@ test "compile: i32.trunc_sat_f32_s emits FCVTZS W, S" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected = inst_fp.encFcvtzsWFromS(9, 16); // dest W9, src V16
     var found = false;
@@ -436,7 +436,7 @@ test "compile: i64.trunc_sat_f64_u emits FCVTZU X, D" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected = inst_fp.encFcvtzuXFromD(9, 16);
     var found = false;
@@ -463,7 +463,7 @@ test "compile: i32.reinterpret_f32 emits FMOV W, S" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected = inst_fp.encFmovWFromS(9, 16);
     var found = false;
@@ -490,7 +490,7 @@ test "compile: f64.reinterpret_i64 emits FMOV D, X" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected = inst_fp.encFmovDtoFromX(16, 9);
     var found = false;
@@ -517,7 +517,7 @@ test "compile: i32.trunc_f32_s emits NaN+lower+upper checks then FCVTZS W,S" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected core instructions to find in the byte stream:
@@ -563,7 +563,7 @@ test "compile: i32.trunc_f64_s emits NaN+f64-lower+f64-upper checks then FCVTZS 
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Walk the byte stream looking for the D-form NaN check + 2

--- a/src/engine/codegen/arm64/emit_test_alu_int.zig
+++ b/src/engine/codegen/arm64/emit_test_alu_int.zig
@@ -46,7 +46,7 @@ test "compile: (i32.const 7) (i32.const 5) i32.add end → returns 12 in X0" {
     // allocation matches what greedy produces.
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Stream: STP / MOV-FP / MOVZ X9 #7 / MOVZ X10 #5 / ADD X9 X9 X10 /
@@ -84,7 +84,7 @@ test "compile: i32.sub / i32.mul / i32.and / i32.or / i32.xor / i32.shl / i32.sh
         } };
         const slots = [_]u16{ 0, 1, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         // ALU op at body+8 (after MOVZ #7, MOVZ #5).
@@ -101,7 +101,7 @@ test "compile: stack underflow on ALU op with 1 pushed vreg surfaces AllocationM
     f.liveness = .{ .ranges = &[_]zir.LiveRange{.{ .def_pc = 0, .last_use_pc = 1 }} };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: i32.rotr emits single RORV W-variant" {
@@ -119,7 +119,7 @@ test "compile: i32.rotr emits single RORV W-variant" {
     } };
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // Stream: STP / MOV-FP / MOVZ #FF / MOVZ #4 / RORV / MOV X0 / LDP / RET.
@@ -142,7 +142,7 @@ test "compile: i32.rotl emits 3-instr NEG-via-MOVZ-SUB + RORV sequence" {
     } };
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After body+8 (2 const u32s): MOVZ W16, #32 / SUB W16, W16, W10 / RORV W9, W9, W16.
@@ -179,7 +179,7 @@ test "compile: i32 cmp ops each emit CMP + CSET with the right Cond mapping" {
         } };
         const slots = [_]u16{ 0, 1, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         // CMP at body+8, CSET at body+12.
@@ -201,7 +201,7 @@ test "compile: i32.clz emits direct CLZ" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ-W9-#FF: CLZ W9, W9 at body+4.
@@ -221,7 +221,7 @@ test "compile: i32.ctz emits RBIT + CLZ" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ-W9-#0x100: RBIT W9, W9 / CLZ W9, W9.
@@ -242,7 +242,7 @@ test "compile: i32.popcnt emits 4-instr V-register SIMD pattern" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ-W9 + MOVK-W9 (0xDEADBEEF needs both lanes):
@@ -277,7 +277,7 @@ test "compile: i64.add / sub / mul / and / or / xor each emit X-variant ALU op" 
         } };
         const slots = [_]u16{ 0, 1, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         try testing.expectEqual(c.want_word_at_offset, std.mem.readInt(u32, out.bytes[body0 + 8 ..][0..4], .little));
@@ -312,7 +312,7 @@ test "compile: i64 cmp ops each emit CMP-X + CSET-W with the right Cond mapping"
         } };
         const slots = [_]u16{ 0, 1, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         try testing.expectEqual(@as(u32, inst.encCmpRegX(9, 10)), std.mem.readInt(u32, out.bytes[body0 + 8 ..][0..4], .little));
@@ -342,7 +342,7 @@ test "compile: i64 shifts emit X-variant LSLV/LSRV/ASRV/RORV" {
         } };
         const slots = [_]u16{ 0, 1, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         try testing.expectEqual(c.want_word_at_offset, std.mem.readInt(u32, out.bytes[body0 + 8 ..][0..4], .little));
@@ -364,7 +364,7 @@ test "compile: i64.rotl emits 3-instr X-variant NEG-via-MOVZ-#64-SUB + RORV" {
     } };
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After 4 prologue+const u32s (16 bytes):
     // MOVZ X16, #64 / SUB X16, X16, X10 / RORV X9, X9, X16.
@@ -387,7 +387,7 @@ test "compile: i64.clz emits direct CLZ X" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     try testing.expectEqual(@as(u32, inst.encClzX(9, 9)), std.mem.readInt(u32, out.bytes[body0 + 4 ..][0..4], .little));
@@ -406,7 +406,7 @@ test "compile: i64.ctz emits RBIT-X + CLZ-X" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     try testing.expectEqual(@as(u32, inst.encRbitX(9, 9)), std.mem.readInt(u32, out.bytes[body0 + 4 ..][0..4], .little));
@@ -426,7 +426,7 @@ test "compile: i64.popcnt emits FMOV-D + CNT/ADDV/UMOV V-register pattern" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After STP/MOV-FP/MOVZ-X9 (12 bytes):
     // FMOV D31, X9 / CNT V31.8B / ADDV B31 / UMOV W9.
@@ -450,7 +450,7 @@ test "compile: i64.eqz emits CMP-X-imm-0 + CSET EQ" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     try testing.expectEqual(@as(u32, inst.encCmpImmX(9, 0)), std.mem.readInt(u32, out.bytes[body0 + 4 ..][0..4], .little));
@@ -470,7 +470,7 @@ test "compile: i32.eqz emits CMP-imm-0 + CSET EQ" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ W9 #0: CMP W9,#0 / CSET W9,EQ at body+4, +8.
@@ -507,7 +507,7 @@ test "compile: select_typed i64 (extra=0x7E) emits CSEL Xd, not Wd" {
     };
     const slots = [_]u16{ 0, 1, 2, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Walk emitted body looking for a CSEL — the i64 path emits
@@ -553,7 +553,7 @@ test "compile: select_typed f64 (extra=0x7C) emits FCSEL Dd via FP regalloc" {
     } };
     const slots = [_]u16{ 0, 1, 2, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     var saw_fcsel_d: bool = false;

--- a/src/engine/codegen/arm64/emit_test_call.zig
+++ b/src/engine/codegen/arm64/emit_test_call.zig
@@ -43,7 +43,7 @@ test "compile: call N (no-arg skeleton) emits BL placeholder + records fixup + r
     var sigs: [8]zir.FuncType = undefined;
     for (&sigs) |*s| s.* = .{ .params = &.{}, .results = &.{} };
     sigs[7] = .{ .params = &.{}, .results = &.{.i32} };
-    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     const body0 = prologue.body_start_offset(false);
@@ -72,7 +72,7 @@ test "compile: call N — i64 callee result captured via X-form ORR" {
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{.{ .params = &.{}, .results = &.{.i64} }};
-    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOV X0,X19 + BL: ORR X9,XZR,X0 (X-form for i64) at body+8.
@@ -91,7 +91,7 @@ test "compile: call N — f32 callee result captured via FMOV S, S0" {
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{.{ .params = &.{}, .results = &.{.f32} }};
-    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOV X0,X19 + BL: FMOV S16, S0 (f32 slot 0 → V16) at body+8.
@@ -119,7 +119,7 @@ test "compile: call N — i32 + i64 args marshalled into W1/X2 (X0=runtime ptr p
     const sigs = [_]zir.FuncType{
         .{ .params = &.{ .i32, .i64 }, .results = &.{.i32} },
     };
-    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Layout (bytes, post-ADR-0017 prologue = 32, sub-2d-ii):
@@ -159,7 +159,7 @@ test "compile: call N — f32 + f64 args marshalled into S0/D1" {
     const sigs = [_]zir.FuncType{
         .{ .params = &.{ .f32, .f64 }, .results = &.{.f32} },
     };
-    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // The two arg-marshal MOVs land just before the BL: search the
     // tail for FMOV S0, S16 + FMOV D1, D17 + BL 0.
@@ -193,7 +193,7 @@ test "compile: call N — void callee pushes no result vreg" {
     f.liveness = .{ .ranges = &.{} };
     const empty: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
     const sigs = [_]zir.FuncType{.{ .params = &.{}, .results = &.{} }};
-    const out = try compile(testing.allocator, &f, empty, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, empty, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // Body: MOV X0,X19 / BL / (epilogue follows).
@@ -236,7 +236,7 @@ test "compile: call N — 8 i32 args, 8th arg spills to caller stack [SP, #0] (S
     const sigs = [_]zir.FuncType{
         .{ .params = &.{ .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32 }, .results = &.{.i32} },
     };
-    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Caller-side marshal: args 0..6 go to W1..W7, arg 7 (overflow)
@@ -279,7 +279,7 @@ test "compile: call N — i32 result in spill slot lands STR W0 (spill-aware)" {
     const sigs = [_]zir.FuncType{
         .{ .params = &.{}, .results = &.{.i32} },
     };
-    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Expect STR W0, [SP, #0] after the BL — the call's i32 result
     // (W0 per AAPCS64) flushed to spill_base_off = 0 (no locals,
@@ -318,7 +318,7 @@ test "compile: table.grow i64-table — spilled result stores X-form STR X0 (D-4
     // Result vreg → slot 8 = first spill slot (max_reg_slots_gpr = 8).
     const slots = [_]u16{ 0, 1, 8 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 9 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected_x = inst.encStrImm(0, 31, 0); // STR X0, [SP, #0]
     const wrong_w = inst.encStrImmW(0, 31, 0); // the D-475 F1 bug shape
@@ -350,7 +350,7 @@ test "compile: table.grow i32-table — spilled result keeps W-form STR W0 (byte
     } };
     const slots = [_]u16{ 0, 1, 8 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 9 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected_w = inst.encStrImmW(0, 31, 0); // STR W0, [SP, #0]
     var found_w = false;
@@ -381,7 +381,7 @@ test "compile: call_indirect — bounds (CMP/B.HS) + sig (LDR/CMP/B.NE) + funcpt
     var types: [4]zir.FuncType = undefined;
     for (&types) |*t| t.* = .{ .params = &.{}, .results = &.{} };
     types[3] = .{ .params = &.{}, .results = &.{.i32} };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &types, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &types, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Layout (post-sub-2d-ii prologue=32; D-294 inserted CMN+B.EQ null-check
@@ -445,7 +445,7 @@ test "compile: bundled Class C MEMORY-class — caller LEA X8 + callee STR X8 + 
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
     const sigs = [_]zir.FuncType{.{ .params = &.{}, .results = &.{ .i32, .i32, .i32 } }};
-    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Frame layout:
@@ -541,7 +541,7 @@ test "compile: return_call_indirect — bounds + sig + funcptr-to-X16 + frame_te
     var types: [4]zir.FuncType = undefined;
     for (&types) |*t| t.* = .{ .params = &.{}, .results = &.{} };
     types[3] = .{ .params = &.{}, .results = &.{.i32} };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &types, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &types, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     const body0 = prologue.body_start_offset(false);
@@ -597,7 +597,7 @@ test "compile: return_call_indirect — multi-table (table_idx > 0) loads size+b
     var types: [4]zir.FuncType = undefined;
     for (&types) |*t| t.* = .{ .params = &.{}, .results = &.{} };
     types[3] = .{ .params = &.{}, .results = &.{.i32} };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &types, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &types, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     const body0 = prologue.body_start_offset(false);

--- a/src/engine/codegen/arm64/emit_test_control.zig
+++ b/src/engine/codegen/arm64/emit_test_control.zig
@@ -47,7 +47,7 @@ test "compile: block + br 0 + end — forward unconditional branch fixup" {
     };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Stream:
@@ -82,7 +82,7 @@ test "compile: loop + br 0 + end — backward unconditional branch" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Loop entry recorded at body0. D-314: the `br 0` emits the loop back-edge
@@ -127,7 +127,7 @@ test "compile: if (i32.const N) end — single-arm if; CBZ skips to end" {
     };
     const slots = [_]u16{ 0, 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Stream:
@@ -164,7 +164,7 @@ test "compile: if/else/end — CBZ skips to else; B-uncond skips to end" {
     };
     const slots = [_]u16{ 0, 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Stream:
@@ -219,7 +219,7 @@ test "compile: br_table — emits CMP+B.NE+B chain + default B" {
     };
     const slots = [_]u16{ 0, 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Stream:
@@ -259,7 +259,7 @@ test "compile: br_if 0 — forward CBNZ fixup" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Stream:
@@ -312,7 +312,7 @@ test "compile: try_table emit populates EmitOutput.exception_handlers" {
     });
 
     const alloc: regalloc.Allocation = .{ .slots = &[_]u16{}, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     try testing.expectEqual(@as(usize, 2), out.exception_handlers.len);
@@ -359,7 +359,7 @@ test "compile: throw emits B placeholder + appends bounds_fixup (trap-path)" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{} };
     const alloc: regalloc.Allocation = .{ .slots = &[_]u16{}, .n_slots = 0 };
 
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Prologue (STP + MOV FP, SP = 8 bytes) + B placeholder
@@ -391,6 +391,6 @@ test "compile: try_table reaches per-op emit with ExceptionTable.Builder wired" 
     const alloc: regalloc.Allocation = .{ .slots = &[_]u16{}, .n_slots = 0 };
     try testing.expectError(
         Error.UnsupportedOp,
-        compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false),
+        compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false),
     );
 }

--- a/src/engine/codegen/arm64/emit_test_local.zig
+++ b/src/engine/codegen/arm64/emit_test_local.zig
@@ -33,7 +33,7 @@ test "compile: empty body without liveness errors" {
     var f = ZirFunc.init(0, sig, &.{});
     defer f.deinit(testing.allocator);
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: empty function (no instrs, empty liveness) emits prologue+epilogue" {
@@ -46,7 +46,7 @@ test "compile: empty function (no instrs, empty liveness) emits prologue+epilogu
     // returns just the prologue (no epilogue). That's the expected
     // shape for a malformed body; the gate filters such
     // funcs at validate-time, so emit doesn't enforce well-formedness.
-    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // 2 prologue u32s = 8 bytes. (Empty body has no `end` op so the
     // stack-overflow trap stub is not emitted; only the prologue is
@@ -65,7 +65,7 @@ test "compile: (i32.const 42) end yields 5-instr body returning 42 in X0" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{.{ .def_pc = 0, .last_use_pc = 1 }} };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream: prologue (incl. ADR-0105 probe) + MOVZ X9,#42 +
@@ -99,7 +99,7 @@ test "compile: i32.const 0x12345678 emits MOVZ + MOVK (full 32-bit)" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{.{ .def_pc = 0, .last_use_pc = 1 }} };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // 7 u32s now: STP / MOV-FP-SP / MOVZ / MOVK / MOV-X0 / LDP / RET.
@@ -120,7 +120,7 @@ test "compile: unsupported op surfaces UnsupportedOp" {
     try f.instrs.append(testing.allocator, .{ .op = .@"memory.discard" });
     f.liveness = .{ .ranges = &.{} };
     const empty: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    try testing.expectError(Error.UnsupportedOp, compile(testing.allocator, &f, empty, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.UnsupportedOp, compile(testing.allocator, &f, empty, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: 1 local — prologue includes SUB SP,SP,#16; epilogue ADD SP,SP,#16" {
@@ -148,7 +148,7 @@ test "compile: 1 local — prologue includes SUB SP,SP,#16; epilogue ADD SP,SP,#
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     const body0 = prologue.body_start_offset(true);
@@ -184,7 +184,7 @@ test "compile: 3 locals — frame rounds up to 32 bytes (3*8=24 → align to 32)
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(true);
     // SUB SP, SP, #32 (3*8=24 → aligned 32) at body0 - 4 — frame unchanged.
@@ -222,7 +222,7 @@ test "compile: local.tee writes to local but keeps value pushed" {
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(true);
     // STR XZR (zero-init) at body+0 — unchanged.
@@ -249,7 +249,7 @@ test "compile: i64.const small value emits single MOVZ" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{.{ .def_pc = 0, .last_use_pc = 1 }} };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // Single MOVZ X9, #42 at body+0.
@@ -266,7 +266,7 @@ test "compile: i64.const 0xCAFEBABEDEADBEEF emits MOVZ + 3 MOVK lanes" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{.{ .def_pc = 0, .last_use_pc = 1 }} };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // MOVZ #BEEF / MOVK #DEAD lsl 16 / MOVK #BABE lsl 32 / MOVK #CAFE lsl 48 at body+0,4,8,12.
@@ -286,7 +286,7 @@ test "compile: f32.const emits emitConstU32 + FMOV S, W" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{.{ .def_pc = 0, .last_use_pc = 1 }} };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After STP/MOV-FP (8 bytes): MOVZ + MOVK (lo=0x0000, hi=0x3F80)
     // — but lo=0 so just MOVK fires? No wait: emitConstU32 always
@@ -324,7 +324,7 @@ test "compile: function with 8 i32 params lowers param[7] from caller stack" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Locate the LDR W16, [X29, #16] / STR W16, [SP, #56] pair
     // — the overflow load for param 7 (8th param, p_idx = 7,
@@ -359,7 +359,7 @@ test "compile: (param i64) — prologue stores X1 to [SP, #0] (STR X width)" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // STR X1, [SP, #0] for the i64 param at byte 36 (post-
     // prologue with frame). encStrImm width-X vs encStrImmW.
@@ -379,7 +379,7 @@ test "compile: (param f32) — prologue stores S0 to [SP, #0] (STR S width)" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected = inst.encStrSImm(0, 31, 0);
     try testing.expectEqual(expected, std.mem.readInt(u32, out.bytes[prologue.body_start_offset(true)..][0..4], .little));
@@ -397,7 +397,7 @@ test "compile: (param f64) — prologue stores D0 to [SP, #0] (STR D width)" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const expected = inst.encStrDImm(0, 31, 0);
     try testing.expectEqual(expected, std.mem.readInt(u32, out.bytes[prologue.body_start_offset(true)..][0..4], .little));
@@ -415,7 +415,7 @@ test "compile: mixed (param i32 f32 i64 f64) — independent X/V counters" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Param marshalling at byte 36 (post-prologue):
     //   STR W1, [SP, #0]   (i32 → X int_arg=1)
@@ -440,7 +440,7 @@ test "compile: (param i32) (result i32) local.get 0 — prologue stores W1 to [S
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Prologue (has_frame=true): bytes 0..36 standard. Then
     // multi-arg STR W1, [SP, #0] at byte 36 (4 bytes). Body
@@ -465,7 +465,7 @@ test "compile: (param i32 i32) — prologue stores W1, W2 to [SP, #0], [SP, #8]"
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // STR W1, [SP, #0] at byte 36; STR W2, [SP, #8] at byte 40.
     try testing.expectEqual(inst.encStrImmW(1, 31, 0), std.mem.readInt(u32, out.bytes[prologue.body_start_offset(true)..][0..4], .little));
@@ -494,7 +494,7 @@ test "compile: ADR-0018 sub-1c — i32.const into spilled vreg, full round-trip 
         .n_slots = 11,
         .max_reg_slots_gpr = 10,
     };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Bytes contain (in order): STP+MOVfp + SUB sp,#16 (frame

--- a/src/engine/codegen/arm64/emit_test_memory.zig
+++ b/src/engine/codegen/arm64/emit_test_memory.zig
@@ -40,7 +40,7 @@ test "compile: i32.load — emits zero-extend + bounds-check + LDR W reg-offset 
     };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // After MOVZ-W9 (body+0..4), spec-strict load sequence at body+4:
@@ -89,7 +89,7 @@ test "compile: memory64 i32.load — X-form addr load (encOrrReg, not encOrrRegW
     };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i64, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i64, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // body+4: ORR X16, XZR, X9 (X-form, encOrrReg) — i64 path
@@ -127,7 +127,7 @@ test "compile: memory64 i64.load offset=0x100000000 — 4-lane MOVZ+MOVK for u64
     };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i64, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i64, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // body+4: ORR X16, XZR, X<addr> (X-form)
@@ -155,7 +155,7 @@ test "compile: i32.load offset=0x10000000 — MOVZ/MOVK X17 + ADD reg" {
     };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // 0x10000000 split: low_16 = 0x0000, high_16 = 0x1000.
     // Sequence after ORR W16,WZR,W9: MOVZ X17,#0 / MOVK X17,#0x1000 lsl#16
@@ -203,7 +203,7 @@ test "compile: memory ops dispatch correctly per variant" {
         } };
         const slots = [_]u16{ 0, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         // After MOVZ W9 + ORR W16 + (no ADD: offset=0) + ADD X17,X16,#size
@@ -231,7 +231,7 @@ test "compile: f32.load + f64.load dispatch to S/D-form LDR" {
         } };
         const slots = [_]u16{ 0, 0 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         const body0 = prologue.body_start_offset(false);
         // Spec-strict bounds adds ADD X17,X16,#size before CMP/B.HI → +4 byte offset.
@@ -250,7 +250,7 @@ test "compile: memory.size emits LDR page_size_log2 + LSRV W_dest, W27 (custom-p
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // LDR W16, [X19, #page_size_log2_off] at body+0; LSRV W_dest, W27, W16 at body+4.
@@ -271,7 +271,7 @@ test "compile: memory.grow emits BLR-via-memory_grow_fn + X28/X27 reload (ADR-00
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const body0 = prologue.body_start_offset(false);
     // Stream from body+0:
@@ -306,7 +306,7 @@ test "compile: i32.store — emits bounds-check + STR W reg-offset" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Stream:
     //  [0]  STP / MOV-FP                      (8 bytes)
@@ -337,7 +337,7 @@ test "compile: global.get 0 (i32) — emits LDR W from [X23 + 0]" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     const body0 = prologue.body_start_offset(false);
@@ -359,7 +359,7 @@ test "compile: (i32.const 99) global.set 1 (i32) — emits STR W to [X23 + 16] (
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     const body0 = prologue.body_start_offset(false);

--- a/src/engine/codegen/arm64/op_memory.zig
+++ b/src/engine/codegen/arm64/op_memory.zig
@@ -248,14 +248,21 @@ pub fn emitMemOp(ctx: *EmitCtx, ins: *const ZirInstr) Error!void {
         try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.ne, 0)); // nonzero low bits = unaligned
         try ctx.unaligned_atomic_fixups.append(ctx.allocator, al_fixup);
     }
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddImm12(ip1, ip0, access_size));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(ip1, 27));
-    const fixup_at: u32 = @intCast(ctx.buf.items.len);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hi, 0)); // unsigned >
-    try ctx.oob_fixups.append(ctx.allocator, fixup_at);
-    // ADR-0028 M3-a-1: record bounds-check emit site (no-op when
-    // -Dtrace-ringbuffer=false; comptime-folded out of release).
-    trace.writeBounds(ctx.func.func_idx, fixup_at);
+    // ADR-0202 D4 — elided: the guard-page reservation covers every
+    // reachable ea (idx ≤ 2³²−1 + offset ≤ 2³²−1 + access ≤ 16 < the
+    // 8 GiB reservation), so an oob access hardware-faults and the
+    // fault→trap handler redirects to this function's force-emitted
+    // kind=6 stub. The atomic ALIGNMENT check above is NOT elided.
+    if (!ctx.bounds_elided) {
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddImm12(ip1, ip0, access_size));
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(ip1, 27));
+        const fixup_at: u32 = @intCast(ctx.buf.items.len);
+        try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBCond(.hi, 0)); // unsigned >
+        try ctx.oob_fixups.append(ctx.allocator, fixup_at);
+        // ADR-0028 M3-a-1: record bounds-check emit site (no-op when
+        // -Dtrace-ringbuffer=false; comptime-folded out of release).
+        trace.writeBounds(ctx.func.func_idx, fixup_at);
+    }
 
     // Final LDR/STR. Allocate result vreg first for loads.
     if (is_store) {

--- a/src/engine/codegen/arm64/op_simd.zig
+++ b/src/engine/codegen/arm64/op_simd.zig
@@ -89,6 +89,10 @@ fn v128MemPrologue(ctx: *EmitCtx, addr_vreg: u32, offset_imm: u64, access_size: 
             try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddReg(ip0, ip0, ip1));
         }
     }
+    // ADR-0202 D4 scope note: SIMD keeps the explicit check this phase
+    // (symmetric with x86_64, whose v128 handlers are param-threaded, not
+    // ctx-threaded). Scalar elision is the measured lever; SIMD elision is
+    // a same-machinery perf follow-up (debt D-514).
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encAddImm12(ip1, ip0, access_size));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpRegX(ip1, 27));
     const fixup_at: u32 = @intCast(ctx.buf.items.len);

--- a/src/engine/codegen/shared/compile.zig
+++ b/src/engine/codegen/shared/compile.zig
@@ -150,6 +150,11 @@ pub fn compileOne(
     /// the `jitCallIndirectSubtypeOk` trampoline (the inline D-111 structural
     /// compare is finality/subtype-blind). `false` for non-subtyping modules.
     uses_type_subtyping: bool,
+    /// ADR-0202 D4 — module-level guard-page bounds-elision flag. `true` only
+    /// when memory0 qualifies (i32 × 64 KiB pages × guarded host) AND the
+    /// engine knob is `.auto`. Threaded into the per-arch EmitCtx so memory0
+    /// scalar accesses drop the inline check + force-emit the redirect stub.
+    bounds_elided: bool,
     /// D-475 (table64) — per-table index types (imports-first wasm table
     /// index space). Attached to the produced `ZirFunc` so the table-op /
     /// call_indirect emitters pick 32- vs 64-bit index widths per table.
@@ -330,7 +335,7 @@ pub fn compileOne(
     // a local `var`; the mutation is scoped to this function.
     alloc.result_abi = result_abi;
     trace.passEnter(func_idx, .emit);
-    const out = try emit.compile(allocator, &func, alloc, func_sigs, module_types, num_imports, globals_offsets, globals_valtypes, memory0_idx_type, tag_param_counts, uses_type_subtyping);
+    const out = try emit.compile(allocator, &func, alloc, func_sigs, module_types, num_imports, globals_offsets, globals_valtypes, memory0_idx_type, tag_param_counts, uses_type_subtyping, bounds_elided);
     errdefer emit.deinit(allocator, out);
     {
         const applied: u32 = @intCast(func.instrs.items.len);
@@ -370,7 +375,7 @@ test "compileOne: pass_diagnostics records all 6 passes when trace enabled" {
     // Pure instruction bytes: `i32.const 7` (0x41 0x07) + `end` (0x0B).
     const body = [_]u8{ 0x41, 0x07, 0x0B };
     const sig: FuncType = .{ .params = &.{}, .results = &.{.i32} };
-    var r = try compileOne(testing.allocator, 42, sig, &body, &.{}, &.{}, &.{sig}, 0, &.{}, &.{}, &.{}, .register_write, .i32, &.{}, &.{}, &.{}, &.{}, false, &.{});
+    var r = try compileOne(testing.allocator, 42, sig, &body, &.{}, &.{}, &.{sig}, 0, &.{}, &.{}, &.{}, .register_write, .i32, &.{}, &.{}, &.{}, &.{}, false, false, &.{});
     defer deinitFuncResult(testing.allocator, &r);
 
     // Per-function slot populated with 6 records, in pipeline order.
@@ -408,7 +413,7 @@ test "compileOne: tiny straight-line module — (func (result i32) i32.const 7 e
     const body = [_]u8{ 0x41, 0x07, 0x0B };
     const sig: FuncType = .{ .params = &.{}, .results = &.{.i32} };
 
-    var r = try compileOne(testing.allocator, 0, sig, &body, &.{}, &.{}, &.{sig}, 0, &.{}, &.{}, &.{}, .register_write, .i32, &.{}, &.{}, &.{}, &.{}, false, &.{});
+    var r = try compileOne(testing.allocator, 0, sig, &body, &.{}, &.{}, &.{sig}, 0, &.{}, &.{}, &.{}, .register_write, .i32, &.{}, &.{}, &.{}, &.{}, false, false, &.{});
     defer deinitFuncResult(testing.allocator, &r);
 
     const bodies = [_]linker.FuncBody{

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -24,6 +24,7 @@ const build_options = @import("build_options");
 const linker = @import("linker.zig");
 const jit_abi = @import("jit_abi.zig");
 const stack_limit_mod = @import("../../../platform/stack_limit.zig");
+const signal = @import("../../../platform/signal.zig"); // ADR-0202 D4 fault-handler auto-install
 const entry_buffer_write = @import("entry_buffer_write.zig");
 
 /// Shared clobber set for the AAPCS64 inline-asm BLR thunks used by
@@ -221,6 +222,12 @@ inline fn invokeAndCheck(
     f: anytype,
     args: anytype,
 ) Error!R {
+    // ADR-0202 D4 — guard-page bounds elision converts an oob access into a
+    // hardware fault the production handler redirects to the oob stub. Any
+    // JIT execution must therefore have a fault handler armed; this is the
+    // single chokepoint (idempotent, skips when the CLI/embedding/spec-runner
+    // already installed one). Cheap atomic-bool fast path after the once.
+    signal.ensureInstalled();
     // ADR-0105 D1 — populate stack_limit per call for the prologue probe.
     rt.stack_limit = stack_limit_mod.computeStackLimit(stack_limit_mod.STACK_GUARD_HEADROOM);
     rt.trap_flag = 0;
@@ -244,6 +251,7 @@ inline fn invokeAndCheckVoid(
     f: anytype,
     args: anytype,
 ) Error!void {
+    signal.ensureInstalled(); // ADR-0202 D4 — see invokeAndCheck
     rt.stack_limit = stack_limit_mod.computeStackLimit(stack_limit_mod.STACK_GUARD_HEADROOM);
     rt.trap_flag = 0;
     stack_limit_mod.diagOnceWithRt(rt, jit_abi.stack_limit_off, rt.stack_limit);
@@ -2522,7 +2530,7 @@ test "entry: i32.load offset=0 reads memory[0..4] through X28 vm_base" {
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{sig};
 
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -2574,7 +2582,7 @@ test "entry: ADR-0018 sub-1c — spilled i32.const returns 42 via STR/LDR round-
         .max_reg_slots_gpr = 10,
     };
     const sigs = [_]zir.FuncType{sig};
-    const out = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out);
 
     const bodies = [_]linker.FuncBody{
@@ -2625,7 +2633,7 @@ test "entry: ADR-0027 — global.set 0 then global.get 0 (i32) round-trips throu
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{sig};
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
     const bodies = [_]linker.FuncBody{
         .{ .bytes = out0.bytes, .call_fixups = out0.call_fixups },
@@ -2677,7 +2685,7 @@ test "entry: pure constant function returns 42 (sanity — no memory access)" {
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{sig};
 
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -2726,7 +2734,7 @@ test "entry: callI32_i32i32 — 2 i32 params summed via i32.add" {
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
     const sigs = [_]zir.FuncType{sig};
 
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -2770,7 +2778,7 @@ test "entry: callI32_i32 — 1 i32 param echoed through W1 → SP slot 0 → res
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{sig};
 
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -2818,7 +2826,7 @@ test "entry: f32 local round-trip — local.get 0 of f32 param via V0" {
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{sig};
 
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -2868,7 +2876,7 @@ test "entry: callI64NoArgs — i64.const 0xDEADBEEFCAFE returns full 64-bit" {
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{sig};
 
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -2933,7 +2941,7 @@ test "entry: ref.as_non_null traps on null funcref source" {
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
     const sigs = [_]zir.FuncType{sig};
 
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -2999,7 +3007,7 @@ test "entry: br_on_null branches to block end on null funcref" {
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
     const sigs = [_]zir.FuncType{sig};
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -3065,7 +3073,7 @@ test "entry: br_on_non_null falls through on null funcref param" {
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
     const sigs = [_]zir.FuncType{sig};
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{
@@ -3135,7 +3143,7 @@ test "entry: br_on_cast matches i31 → branch carries the ref → i31.get_s = 7
     const slots = [_]u16{ 0, 10, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 11, .max_reg_slots_gpr = 10 };
     const sigs = [_]zir.FuncType{sig};
-    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
 
     const bodies = [_]linker.FuncBody{

--- a/src/engine/codegen/shared/entry_buffer_write.zig
+++ b/src/engine/codegen/shared/entry_buffer_write.zig
@@ -301,7 +301,7 @@ test "buffer-write entry: invokeMultiResultNoArgs unpacks 3-i32 result (ADR-0106
         .result_abi = .buffer_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer native_emit.deinit(testing.allocator, out);
     const bodies = [_]linker.FuncBody{
         .{ .bytes = out.bytes, .call_fixups = out.call_fixups },
@@ -350,7 +350,7 @@ test "buffer-write entry: native-emit () → (i32, i64) shape (SKIP arm callI32i
         .result_abi = .buffer_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer native_emit.deinit(testing.allocator, out);
     const bodies = [_]linker.FuncBody{
         .{ .bytes = out.bytes, .call_fixups = out.call_fixups },
@@ -398,7 +398,7 @@ test "buffer-write entry: native-emit () → (i64, i32) shape (SKIP arm callI64i
         .result_abi = .buffer_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer native_emit.deinit(testing.allocator, out);
     const bodies = [_]linker.FuncBody{
         .{ .bytes = out.bytes, .call_fixups = out.call_fixups },
@@ -474,7 +474,7 @@ test "buffer-write entry: native-emit () → (i32, i32, i32) multi-result via bu
         .result_abi = .buffer_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer native_emit.deinit(testing.allocator, out);
 
     const bodies = [_]linker.FuncBody{
@@ -522,7 +522,7 @@ test "buffer-write entry: native-emit (i32) → i32 identity via [args_ptr+0] (A
         .result_abi = .buffer_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer native_emit.deinit(testing.allocator, out);
 
     const bodies = [_]linker.FuncBody{
@@ -569,7 +569,7 @@ test "buffer-write entry: native-emit (i32.const 42) end → results[0] = 42 (AD
         .result_abi = .buffer_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer native_emit.deinit(testing.allocator, out);
 
     const bodies = [_]linker.FuncBody{

--- a/src/engine/codegen/shared/linker.zig
+++ b/src/engine/codegen/shared/linker.zig
@@ -655,9 +655,9 @@ test "link: 2-function module — fn0 calls fn1, returns 7" {
     const fn1_slots = [_]u16{0};
     const fn1_alloc: regalloc.Allocation = .{ .slots = &fn1_slots, .n_slots = 1 };
 
-    const out0 = try emit.compile(testing.allocator, &fn0, fn0_alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, fn0_alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
-    const out1 = try emit.compile(testing.allocator, &fn1, fn1_alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out1 = try emit.compile(testing.allocator, &fn1, fn1_alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out1);
 
     const bodies = [_]FuncBody{
@@ -855,9 +855,9 @@ test "link+execute: fn0 return_call fn1 returns 7 via B/JMP fixup (ADR-0112 D3/D
     const fn1_slots = [_]u16{0};
     const fn1_alloc: regalloc.Allocation = .{ .slots = &fn1_slots, .n_slots = 1 };
 
-    const out0 = try emit.compile(testing.allocator, &fn0, fn0_alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out0 = try emit.compile(testing.allocator, &fn0, fn0_alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out0);
-    const out1 = try emit.compile(testing.allocator, &fn1, fn1_alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out1 = try emit.compile(testing.allocator, &fn1, fn1_alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out1);
 
     const bodies = [_]FuncBody{
@@ -950,7 +950,7 @@ test "linkWithThunks: single multi-result function — wrapper invocation writes
         .result_abi = .register_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const out = try emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer emit.deinit(testing.allocator, out);
 
     const bodies = [_]FuncBody{.{ .bytes = out.bytes, .call_fixups = out.call_fixups }};

--- a/src/engine/codegen/shared/wrapper_thunk.zig
+++ b/src/engine/codegen/shared/wrapper_thunk.zig
@@ -1079,7 +1079,7 @@ test "wrapper_thunk: end-to-end execution — () → (i32, i32, i32) via wrapper
         .result_abi = .register_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const body_out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const body_out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer native_emit.deinit(testing.allocator, body_out);
 
     // Wrapper goes IMMEDIATELY AFTER the body in JIT memory.
@@ -1159,7 +1159,7 @@ test "wrapper_thunk: end-to-end execution — () → (i32, i64) via wrapper" {
         .result_abi = .register_write,
     };
     const sigs = [_]zir.FuncType{sig};
-    const body_out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const body_out = try native_emit.compile(testing.allocator, &f, alloc, &sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer native_emit.deinit(testing.allocator, body_out);
 
     const body_offset: u32 = 0;

--- a/src/engine/codegen/x86_64/ctx.zig
+++ b/src/engine/codegen/x86_64/ctx.zig
@@ -90,6 +90,8 @@ pub const InitArgs = struct {
     fuel_fixup: u32,
     /// ADR-0111 D4 — see EmitCtx field of the same name.
     memory0_idx_type: sections.MemoryEntry.IdxType = .i32,
+    /// ADR-0202 D4 — see EmitCtx field of the same name.
+    bounds_elided: bool = false,
     /// EH integration — see EmitCtx field of the same name.
     /// Defaults to `null`; populated by `compile()` only when the
     /// function contains a `try_table` op.
@@ -328,6 +330,11 @@ pub const EmitCtx = struct {
     /// branches on it at emitMemOp's entry. Default `.i32` keeps
     /// existing init args ergonomic.
     memory0_idx_type: sections.MemoryEntry.IdxType = .i32,
+    /// ADR-0202 D4 — drop the inline memory0 scalar bounds check
+    /// (guard-page + fault→trap redirect own oob detection); the
+    /// kind=6 stub is force-emitted as the redirect target. Set only
+    /// for qualifying modules under the `.auto` knob. Default false.
+    bounds_elided: bool = false,
     /// ADR-0120 — per-tag param
     /// count threaded from `CompiledWasm.tag_param_counts` for
     /// `throw.emit` / `try_table.emit` payload-marshalling.
@@ -384,6 +391,7 @@ pub const EmitCtx = struct {
             .cast_fail_fixups = args.cast_fail_fixups,
             .uncaught_exc_fixups = args.uncaught_exc_fixups,
             .oob_fixups = args.oob_fixups,
+            .bounds_elided = args.bounds_elided,
             .unaligned_atomic_fixups = args.unaligned_atomic_fixups,
             .back_edge_interrupt_fixups = args.back_edge_interrupt_fixups,
             .back_edge_fuel_fixups = args.back_edge_fuel_fixups,

--- a/src/engine/codegen/x86_64/emit.zig
+++ b/src/engine/codegen/x86_64/emit.zig
@@ -152,6 +152,9 @@ pub fn compile(
     /// Routes `call_indirect` through the subtype trampoline. `false` for
     /// non-subtyping modules + test helpers.
     uses_type_subtyping: bool,
+    /// ADR-0202 D4 — elide the memory0 scalar bounds check + force-emit
+    /// the kind=6 redirect stub. `false` for non-qualifying / `.explicit`.
+    bounds_elided: bool,
 ) Error!EmitOutput {
     if (alloc.slots.len != (func.liveness orelse return Error.AllocationMissing).ranges.len) {
         return Error.AllocationMissing;
@@ -888,6 +891,7 @@ pub fn compile(
         .interrupt_fixup = interrupt_fixup,
         .fuel_fixup = fuel_fixup,
         .memory0_idx_type = memory0_idx_type,
+        .bounds_elided = bounds_elided,
         .exception_table_builder = if (has_try_table) &eh_builder else null,
         .open_try_tables = if (has_try_table) &open_try_tables else null,
         .landing_pad_fixups = if (has_try_table) &landing_pad_fixups else null,

--- a/src/engine/codegen/x86_64/emit_test_float.zig
+++ b/src/engine/codegen/x86_64/emit_test_float.zig
@@ -37,7 +37,7 @@ test "compile: f32.const — MOV EAX,bits + MOVD XMM8,EAX" {
     } };
     const slots = [_]u16{0}; // FP slot 0 → XMM8
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Prologue (uses_runtime_ptr=false; no calls/memory) = 4 bytes.
     //   PUSH RBP        55              (1)
@@ -69,7 +69,7 @@ test "compile: f64.const — MOVABS RAX,bits + MOVQ XMM8,RAX" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Body layout (post-prologue at 4):
     //   MOVABS RAX,bits 48 b8 + 8 imm   (10) → body+10
@@ -97,7 +97,7 @@ test "compile: f32.add — MOVAPS XMM10,XMM8 + ADDSS XMM10,XMM9" {
     // FP slots 0,1,2 → XMM8, XMM9, XMM10.
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Body layout (4-byte prologue):
     //   [4..14]  f32.const 0x3F800000 (10 bytes: MOV EAX + MOVD XMM8)
@@ -128,7 +128,7 @@ test "compile: f64.mul — MOVAPS XMM10,XMM8 + MULSD XMM10,XMM9" {
     } };
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Body layout (4-byte prologue):
     //   [4..19]  f64.const 1.0 (15 bytes: MOVABS RAX + MOVQ XMM8,RAX)
@@ -155,7 +155,7 @@ test "compile: f64.promote_f32 — CVTSS2SD XMM9, XMM8" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f32.const at [body..body+10]: CVTSS2SD XMM9, XMM8 at [body+10..body+15].
     const body_start = prologue.body_start_offset(false, 0);
@@ -177,7 +177,7 @@ test "compile: i32.reinterpret_f32 — MOVD R10D, XMM8 (XMM→GPR bit-cast)" {
     // FP slot 0 → XMM8; result GPR slot 0 → RBX (after chunk 13b pool shrink).
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f32.const at [body..body+10]: MOVD EBX, XMM8 at [body+10..body+15].
     const body_start = prologue.body_start_offset(false, 0);
@@ -199,7 +199,7 @@ test "compile: f32.reinterpret_i32 — MOVD XMM8, R10D (GPR→XMM bit-cast)" {
     // GPR slot 0 → RBX (after chunk 13b pool shrink); FP slot 0 → XMM8.
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After i32.const at [body..body+5] (5 bytes for EBX): MOVD XMM8, EBX at [body+5..body+10].
     const body_start = prologue.body_start_offset(false, 0);
@@ -221,7 +221,7 @@ test "compile: f32.load — emit MOVSS xmm_dst, [rax + rdx] after eff-addr/bound
     // GPR slot 0 (idx) → R10; FP slot 0 (result) → XMM8.
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Verify the f32.load handler emits MOVSS XMM8, [RAX + RDX]
     // somewhere in the byte stream after the bounds prologue.
@@ -245,7 +245,7 @@ test "compile: f64.store — emit MOVSD [rax+rdx], xmm_src + bounds prologue wit
     // GPR slot 0 (idx) → R10; FP slot 1 (val) → XMM9.
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Verify the f64.store emits MOVSD [RAX+RDX], XMM9.
     const expected = inst.encMovssMovsdMemBaseIdx(.f64, true, .xmm9, .rax, .rdx);
@@ -272,7 +272,7 @@ test "compile: i32.trunc_f32_u — Wasm 1.0 trapping unsigned via .q-trick" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const neg_one = inst.encMovImm32W(.rax, 0xBF800000);
     const upper = inst.encMovImm32W(.rax, 0x4F800000);
@@ -296,7 +296,7 @@ test "compile: i64.trunc_f64_u — Wasm 1.0 trapping with 2^63 split path" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     const neg_one = inst.encMovImm64Q(.rax, 0xBFF0000000000000);
     const upper = inst.encMovImm64Q(.rax, 0x43F0000000000000);
@@ -323,7 +323,7 @@ test "compile: i32.trunc_f32_s — Wasm 1.0 trapping; NaN/upper/lower → bounds
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Verify presence of the 3 thresholds + CVTTSS2SI in the
     // emitted byte stream (full layout asserted via opcode+
@@ -350,7 +350,7 @@ test "compile: i64.trunc_sat_f32_u — 2^63 split path with SUBSS + sign-bit OR"
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Verify a few key encoder outputs are present (full byte
     // sequence is too long to assert exhaustively).
@@ -386,7 +386,7 @@ test "compile: i32.trunc_sat_f32_u — UCOMI/JP + clamp paths + CVTTSS2SI .q for
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f32.const at [body..body+10]:
     //   [body+10..+14] UCOMISS XMM8, XMM8     (4 bytes; REX.R+B)
@@ -431,7 +431,7 @@ test "compile: i32.trunc_sat_f32_s — CVTTSS2SI + CMP INT_MIN + branch saturati
     // FP slot 0 → XMM8; result GPR slot 0 → RBX (after chunk 13b pool shrink).
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f32.const at [body..body+10]:
     //   [body+10..+15] CVTTSS2SI EBX, XMM8      (5 bytes; F3 + REX + 0F + 2C + ModRM)
@@ -466,7 +466,7 @@ test "compile: i64.trunc_sat_f64_s — CVTTSD2SI .q + i64 sentinel via MOVABS+CM
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f64.const at [body..body+15]:
     //   [body+15..+20] CVTTSD2SI RBX, XMM8 (5 bytes; F2 + REX.W+R + 0F + 2C + ModRM 0xD8)
@@ -494,7 +494,7 @@ test "compile: f32.convert_i32_u — CVTSI2SS XMM8, R10 (REX.W on i32 src for ze
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // i32.const 0xFFFFFFFF at [body..body+5]; CVTSI2SS XMM8, RBX (i64 form) at [body+5..body+10].
     // (slot 0 = RBX after chunk 13b pool shrink — i32.const is 5 bytes.)
@@ -517,7 +517,7 @@ test "compile: f32.convert_i64_u — branch-based slow-path emit" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // i32.const at [body..body+5] (slot 0 = RBX after chunk 13b pool shrink). Then:
     //   [body+5..+8]   TEST RBX, RBX            (3 bytes; REX.W = 48 + 85 + DB)
@@ -565,7 +565,7 @@ test "compile: f32.convert_i32_s — CVTSI2SS XMM8, R10D" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After i32.const at [body..body+5] (slot 0 = RBX, 5 bytes after chunk 13b):
     // CVTSI2SS XMM8, EBX at [body+5..body+10].
@@ -589,7 +589,7 @@ test "compile: f32.min — branch-based emit (UCOMISS + JP/JE + 3 paths)" {
     } };
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Body offsets after 2× f32.const (10+10=20 bytes) at body..body+20:
     //   [body+20..+24] UCOMISS XMM8, XMM9     (4 bytes)
@@ -643,7 +643,7 @@ test "compile: f32.min — dst aliasing rhs slot is handled via commutative swap
     // Before D-092 this surfaced UnsupportedOp at op_alu_float.zig:105.
     const slots = [_]u16{ 0, 1, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After the swap, lhs↔rhs roles are exchanged, so the emit
     // produces: UCOMISS XMM9,XMM8 ; ... ; MOVAPS XMM9,XMM9 (no-op,
@@ -674,7 +674,7 @@ test "compile: f64.max — eq path uses ANDPD, common uses MAXSD" {
     } };
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After 2× f64.const (15+15=30 bytes) at body..body+30:
     //   [body+30..+35] UCOMISD XMM8, XMM9   (5 bytes: 66 prefix + REX)
@@ -709,7 +709,7 @@ test "compile: f32.copysign — bit-twiddle via RAX/RDX/RCX scratches" {
     } };
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After 2× f32.const (10+10=20 bytes) at body offset body..body+20:
     //   [body+20..+25] MOVD EAX, XMM8        (5 bytes)
@@ -746,7 +746,7 @@ test "compile: f64.copysign — same shape with .q widths and MOVABS masks" {
     } };
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After 2× f64.const (15+15=30 bytes) at body offset body..body+30:
     //   [body+30..+35] MOVQ RAX, XMM8        (5 bytes; 66 + REX.W + REX.R + ...)
@@ -781,7 +781,7 @@ test "compile: f32.sqrt — SQRTSS XMM9, XMM8" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f32.const at [body..body+10]: SQRTSS XMM9, XMM8 at [body+10..body+15].
     const body_start = prologue.body_start_offset(false, 0);
@@ -802,7 +802,7 @@ test "compile: f64.ceil — ROUNDSD XMM9, XMM8, mode=2" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f64.const at [body..body+15]: ROUNDSD XMM9, XMM8, 2 at [body+15..body+22].
     const body_start = prologue.body_start_offset(false, 0);
@@ -823,7 +823,7 @@ test "compile: f32.abs — mask materialisation + MOVAPS + ANDPS" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f32.const at [body..body+10]:
     //   [body+10..+15] MOV EAX, 0x7FFFFFFF (5 bytes)
@@ -850,7 +850,7 @@ test "compile: f64.neg — XORPD with sign-bit mask" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After f64.const at [body..body+15]:
     //   [body+15..+25] MOVABS RAX, 0x80...0 (10 bytes)
@@ -880,7 +880,7 @@ test "compile: f32.lt — UCOMISS swapped + SETA + MOVZX" {
     // Slots 0,1 → XMM8, XMM9; slot 2 (i32 result) → RBX (after chunk 13b).
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After 2× f32.const (10+10=20 bytes) at body offset 4..24. With slot 0
     // for the (FP-bank-only) f32.const operands the FP encoding is unchanged
@@ -912,7 +912,7 @@ test "compile: f32.eq — UCOMISS + SETNP/SETE + AND combine" {
     } };
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After 2× f32.const (20 bytes) at body offset body..body+20:
     //   [body+20..+24] UCOMISS XMM8, XMM9   (4 bytes; no swap for eq)
@@ -945,7 +945,7 @@ test "compile: f64.gt — UCOMISD + SETA + MOVZX" {
     } };
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // 2× f64.const = 30 bytes at [body..body+30]. Then at [body+30..]:
     //   UCOMISD XMM8, XMM9 (5 bytes; 66 prefix + REX)
@@ -967,7 +967,7 @@ test "compile: f32.add stack underflow → AllocationMissing" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: call_indirect — out-of-range type_idx → AllocationMissing" {
@@ -982,7 +982,7 @@ test "compile: call_indirect — out-of-range type_idx → AllocationMissing" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: call N — out-of-range callee_idx → AllocationMissing" {
@@ -995,7 +995,7 @@ test "compile: call N — out-of-range callee_idx → AllocationMissing" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{} };
     const slots = [_]u16{};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 0 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: i32.wrap_i64 with stack underflow → AllocationMissing" {
@@ -1009,7 +1009,7 @@ test "compile: i32.wrap_i64 with stack underflow → AllocationMissing" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: i32.add with stack underflow → AllocationMissing" {
@@ -1025,7 +1025,7 @@ test "compile: i32.add with stack underflow → AllocationMissing" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 // FP / i64 -aware function-level `end` return marshal (D-032).
@@ -1056,7 +1056,7 @@ test "compile: f32.const → end emits MOVAPS XMM0, XMM8 (FP-aware return marsha
     } };
     const slots = [_]u16{0}; // FP slot 0 → XMM8.
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout (uses_runtime_ptr = false, frame_bytes = 0):
     //   [0..body] prologue: PUSH RBP ; MOV RBP, RSP
@@ -1085,7 +1085,7 @@ test "compile: f64.const → end emits MOVAPS XMM0, XMM8 (same MOVAPS works for 
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout:
     //   [0..body] prologue
@@ -1112,7 +1112,7 @@ test "compile: i64-result end emits MOV RAX, src (.q full width avoids truncatio
     // GPR slot 0 → RBX (after chunk 13b pool shrink). Both vregs share slot id 0.
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout (slot 0 = RBX after chunk 13b — i32.const + self-MOV both shed REX):
     //   [0..body]   prologue
@@ -1136,7 +1136,7 @@ test "compile: nop emits no body bytes (between prologue and epilogue)" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{} };
     const slots = [_]u16{};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout (uses_runtime_ptr = false, frame_bytes = 0):
     //   [0..4] prologue: PUSH RBP ; MOV RBP, RSP
@@ -1157,7 +1157,7 @@ test "compile: drop pops vreg without machine bytes (i32.const, drop, end)" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout (slot 0 = RBX after chunk 13b pool shrink):
     //   [0..4]   prologue
@@ -1182,7 +1182,7 @@ test "compile: return mid-function (i32.const, return, end) emits MOV EAX + epil
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout (slot 0 = RBX after chunk 13b pool shrink):
     //   [0..body]    prologue: PUSH RBP ; MOV RBP, RSP (4 bytes)
@@ -1224,7 +1224,7 @@ test "compile: i64.add emits ADD .q (REX.W) — 64-bit width preserved" {
     // vreg 1 → R12 (slot 1), vreg 2 reuses slot 0 → RBX.
     const slots = [_]u16{ 0, 1, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // i64.add lowers to: MOV RBX, RBX (skip — same reg) + ADD RBX, R12 (.q).
     // After 4-byte prologue + 2× MOVABS (10 each) = byte 24 the
@@ -1253,7 +1253,7 @@ test "compile: i64.clz emits LZCNT .q (REX.W; F3 prefix) — 64-bit count" {
     // vreg 0 → RBX (slot 0); vreg 1 (result) → R12 (slot 1) after chunk 13b.
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // After prologue (4) + MOVABS RBX (10) = byte 14: LZCNT R12, RBX (.q form).
     const lzcnt_off = 14;
@@ -1280,7 +1280,7 @@ test "compile: i64.const emits MOVABS r64, imm64 (10 bytes)" {
     } };
     const slots = [_]u16{0}; // GPR slot 0 → RBX after chunk 13b pool shrink
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout (uses_runtime_ptr = false, frame_bytes = 0):
     //   [0..body]    prologue: PUSH RBP ; MOV RBP, RSP
@@ -1318,7 +1318,7 @@ test "compile: unreachable emits JMP rel32 + trap stub patches disp to trap_byte
     f.liveness = .{ .ranges = &[_]zir.LiveRange{} };
     const slots = [_]u16{};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Prologue post-`unreachable`-prescan addition:
     //   PUSH RBP (1) + PUSH R15 (2) + MOV RBP RSP (3)
@@ -1360,7 +1360,7 @@ test "compile: SysV callee with 6 i32 params — 6th param read from caller stac
 
     const slots = [_]u16{};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // 6 i32 args: slots 1..5 fill arg_gprs[1..5] (RSI..R9). The 6th
@@ -1405,7 +1405,7 @@ test "compile: i32.load with offset > i32 imm32 range lowers via MOVABS+ADD" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Look for the MOVABS RCX, 0x80000000 byte sequence anywhere
@@ -1445,7 +1445,7 @@ test "compile: br N — function-depth (depth == labels.len) emits inline epilog
 
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // The compiled body must contain exactly two RET (0xC3) bytes —
@@ -1478,7 +1478,7 @@ test "compile: total_locals=20 (>15 cap) — disp32 form lifts the i8 limit" {
 
     const slots = [_]u16{};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Deepest local 19 at [RBP - 8*(19+1)] = [RBP - 160]
@@ -1538,7 +1538,7 @@ test "compile: call N — 6 i32 args, SysV: 6th arg overflows to caller stack [R
     // via `gprLoadSpilled` then writes them to the outgoing region.
     const slots = [_]u16{ 0, 1, 2, 3, 4, 5 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 6, .max_reg_slots_gpr = 4 };
-    const out = try compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Locate the STR W to [RSP + 0] for the 6th arg (slot 5).
@@ -1573,7 +1573,7 @@ test "compile: v128-result end emits MOVAPS XMM0, src marshal (ADR-0046)" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer testing.allocator.free(out.bytes);
     // Sanity: emit succeeded with non-empty body.
     try testing.expect(out.bytes.len > 0);

--- a/src/engine/codegen/x86_64/emit_test_int.zig
+++ b/src/engine/codegen/x86_64/emit_test_int.zig
@@ -32,7 +32,7 @@ test "compile: empty body without liveness errors AllocationMissing" {
     var f = ZirFunc.init(0, sig, &.{});
     defer f.deinit(testing.allocator);
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: empty function (no instrs) emits prologue only" {
@@ -41,7 +41,7 @@ test "compile: empty function (no instrs) emits prologue only" {
     defer f.deinit(testing.allocator);
     f.liveness = .{ .ranges = &.{} };
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Prologue only: 55 48 89 E5 = 4 bytes (push rbp + mov rbp, rsp).
     try testing.expectEqualSlices(u8, &.{ 0x55, 0x48, 0x89, 0xE5 }, out.bytes);
@@ -56,7 +56,7 @@ test "compile: (i32.const 42) end → 13 bytes" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{.{ .def_pc = 0, .last_use_pc = 1 }} };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream (slot 0 = RBX after pool shrink — chunk 13b):
@@ -94,7 +94,7 @@ test "compile: (i32.const 0xDEADBEEF) end — little-endian imm32" {
     f.liveness = .{ .ranges = &[_]zir.LiveRange{.{ .def_pc = 0, .last_use_pc = 1 }} };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Differs from the 42 case only at the imm32 bytes. The imm32 follows the
     // 4-byte prologue + 1-byte MOV-EBX opcode (0xBB) → starts at offset 5.
@@ -111,7 +111,7 @@ test "compile: void function with `end` only emits prologue + epilogue" {
     try f.instrs.append(testing.allocator, .{ .op = .end });
     f.liveness = .{ .ranges = &.{} };
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // 55 48 89 E5 5D C3 = 6 bytes (prologue + pop + ret; no return marshalling).
     try testing.expectEqualSlices(u8, &.{ 0x55, 0x48, 0x89, 0xE5, 0x5D, 0xC3 }, out.bytes);
@@ -137,7 +137,7 @@ test "compile: function with 1 local + (i32.const 42) (local.set 0) (local.get 0
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Homed contract (slot 0 = RBX): the prologue still zero-inits the local
@@ -175,7 +175,7 @@ test "compile: local.tee preserves stack — uses top vreg without popping" {
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // The home reg (slot 0 = RBX) is seeded from the slot in the prologue
     // (MOV EBX, [RBP-8] = 8B 5D F8); the tee is a reg→reg MOV into RBX, leaving
@@ -198,7 +198,7 @@ test "compile: (block (br 0) end) end — forward br with end-patch" {
     try f.instrs.append(testing.allocator, .{ .op = .end }); // function-level
     f.liveness = .{ .ranges = &.{} };
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream:
@@ -235,7 +235,7 @@ test "compile: (loop (br 0) end) end — backward br with concrete disp" {
     try f.instrs.append(testing.allocator, .{ .op = .end });
     f.liveness = .{ .ranges = &.{} };
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // D-314: a `loop` forces uses_runtime_ptr (the back-edge poll reads
@@ -267,7 +267,7 @@ test "compile: (i32.const 1) (if) (i32.const 7) (end) end — single-arm if; JE 
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected layout (slot 0 = RBX, slot 1 = R12 after chunk 13b pool shrink):
@@ -324,7 +324,7 @@ test "compile: (block (i32.const 0) (br_if 0) end) end — Jcc forward fixup" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected (slot 0 = RBX after chunk 13b pool shrink):
@@ -371,7 +371,7 @@ test "compile: (loop (i32.const 0) (br_if 0) end) end — Jcc backward concrete 
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // D-314: loop forces uses_runtime_ptr → full R15 prologue, fb = 8 (no
@@ -406,7 +406,7 @@ test "compile: br_table — single case + default both → block end" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream (slot 0 = RBX after chunk 13b pool shrink):
@@ -471,7 +471,7 @@ test "compile: br_table count > 127 — wide case path (rel32 / imm32) compiles"
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer testing.allocator.free(out.bytes);
     try testing.expect(out.bytes.len > 0);
 }
@@ -491,7 +491,7 @@ test "compile: (i32.const 0) i32.load offset=0 end — ADR-0026 prologue + bound
     };
     const slots = [_]u16{ 0, 1 }; // R10D, R11D
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // ADR-0026 prologue (uses_runtime_ptr=true):
@@ -612,7 +612,7 @@ test "compile: i32.load with stack underflow → AllocationMissing" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: (i32.const 0)(i32.const 99) i32.store offset=0 — store path" {
@@ -631,7 +631,7 @@ test "compile: (i32.const 0)(i32.const 99) i32.store offset=0 — store path" {
     };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Prologue: 13 bytes (PUSH RBP / PUSH R15 / MOV RBP,RSP / MOV R15,RDI / SUB RSP,8)
@@ -670,7 +670,7 @@ test "compile: (i32.const 0) i32.load8_u → MOVZX r8" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Find MOVZX r32, byte ptr [RAX + RDX]: REX.R + 0F B6 24 10
@@ -702,7 +702,7 @@ test "compile: (i32.const 0) i32.load16_s → MOVSX r16" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // MOVSX r32, word ptr [RAX + RDX] for R12D (slot 1 after chunk 13b pool shrink):
@@ -733,7 +733,7 @@ test "compile: (i32.const 0)(i32.const 7) i32.store8 → MOV r8 store" {
     } };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // MOV [RAX + RDX], R12B (8-bit; slot 1 = R12 after chunk 13b pool shrink):
@@ -762,7 +762,7 @@ test "compile: i32.store with stack underflow → AllocationMissing" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: global.get 0 — emits ADR-0027 reload-from-runtime-ptr (i32)" {
@@ -776,7 +776,7 @@ test "compile: global.get 0 — emits ADR-0027 reload-from-runtime-ptr (i32)" {
     } };
     const slots = [_]u16{0}; // R10D
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Body should contain the 2-instruction global.get sequence:
@@ -810,7 +810,7 @@ test "compile: (i32.const 42) global.set 1 — emits ADR-0027 reload + store (i3
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Body should contain the global.set sequence:
@@ -841,7 +841,7 @@ test "compile: global.set with stack underflow → AllocationMissing" {
     try f.instrs.append(testing.allocator, .{ .op = .end });
     f.liveness = .{ .ranges = &.{} };
     const empty: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, empty, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, empty, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: br with depth strictly above labels.len → UnsupportedOp" {
@@ -855,7 +855,7 @@ test "compile: br with depth strictly above labels.len → UnsupportedOp" {
     try f.instrs.append(testing.allocator, .{ .op = .end });
     f.liveness = .{ .ranges = &.{} };
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    try testing.expectError(Error.UnsupportedOp, compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.UnsupportedOp, compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: function with 16 locals compiles (lifts the i8 cap)" {
@@ -868,7 +868,7 @@ test "compile: function with 16 locals compiles (lifts the i8 cap)" {
     try f.instrs.append(testing.allocator, .{ .op = .end });
     f.liveness = .{ .ranges = &.{} };
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 }
 
@@ -884,7 +884,7 @@ test "compile: function with v128 param → SysV compile-success" {
     defer f.deinit(testing.allocator);
     f.liveness = .{ .ranges = &.{} };
     const empty_alloc: regalloc.Allocation = .{ .slots = &.{}, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, empty_alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 }
 
@@ -901,7 +901,7 @@ test "compile: i32 param + local.get + end — params marshal MOV [rbp-8], esi" 
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // The marshalled MOV [rbp-8], <argreg> appears between the
     // SUB RSP and the body's local.get. SysV's user int arg 0 is
@@ -937,7 +937,7 @@ test "compile: (i32.const 7) (i32.const 5) i32.add end — verifies ADD is emitt
     } };
     const slots = [_]u16{ 0, 1, 2 }; // RBX, R12D, R13D after chunk 13b pool shrink
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream:
@@ -1007,7 +1007,7 @@ test "compile: i32.add when dst==rhs slot — commute path emits ADD dst, lhs (n
     // with commute, emit ADD dst, lhs (1 instr) directly.
     const slots = [_]u16{ 0, 1, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Look for ADD R12D, EBX (commuted: dst==R12, lhs==EBX). Encoding:
     //   41 01 DC                 ADD R12D, EBX
@@ -1038,7 +1038,7 @@ test "compile: (i32.const 8) (i32.const 3) i32.sub end — SUB opcode 29" {
     } };
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Spot-check (slot 2 = R13, slot 1 = R12 after chunk 13b pool shrink):
     // SUB R13D, R12D = 45 29 E5 lives at offset 18..21.
@@ -1062,7 +1062,7 @@ test "compile: (i32.const 6) (i32.const 7) i32.mul end — IMUL 0F AF" {
     } };
     const slots = [_]u16{ 0, 1, 2 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // IMUL r9, r/m9 has flipped REX semantics (slot 2 = R13, slot 1 = R12 after
     // chunk 13b pool shrink). dst=R13D (R=1), src=R12D (B=1) → REX = 0x45.
@@ -1088,7 +1088,7 @@ test "compile: (i32.const 7) (i32.const 5) i32.eq end — CMP+SETE+MOVZX" {
     } };
     const slots = [_]u16{ 0, 1, 2 }; // RBX, R12D, R13D after chunk 13b pool shrink
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream:
@@ -1152,7 +1152,7 @@ test "compile: i32.lt_s vs i32.lt_u — different cc codes" {
         } };
         const slots = [_]u16{ 0, 1, 2 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         // SETcc opcode byte (slot 0 = RBX, slot 1 = R12 after chunk 13b pool shrink).
         // Layout: [prologue 4][movimm-EBX 5][movimm-R12D 6][cmp 3] = 18,
@@ -1174,7 +1174,7 @@ test "compile: (i32.const 0) i32.eqz end — TEST+SETE+MOVZX" {
     } };
     const slots = [_]u16{ 0, 1 }; // RBX, R12D after chunk 13b pool shrink
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream:
@@ -1229,7 +1229,7 @@ test "compile: (i32.const 1) (i32.const 4) i32.shl end — MOV CL + MOV dst + SH
     } };
     const slots = [_]u16{ 0, 1, 2 }; // RBX, R12D, R13D after chunk 13b pool shrink
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream:
@@ -1294,7 +1294,7 @@ test "compile: i32.shr_s vs i32.shr_u — kind byte differs (sar 41 D3 fd vs shr
         } };
         const slots = [_]u16{ 0, 1, 2 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 3 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         // Layout (slot 0=RBX, slot 1=R12, slot 2=R13 after chunk 13b pool shrink):
         // 4 prologue + 5 mov-EBX + 6 mov-R12D + 3 mov-ECX + 3 mov-R13D = 21,
@@ -1317,7 +1317,7 @@ test "compile: (i32.const 8) i32.clz end — LZCNT" {
     } };
     const slots = [_]u16{ 0, 1 }; // RBX, R12D after chunk 13b pool shrink
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Expected stream:
@@ -1368,7 +1368,7 @@ test "compile: i32.clz vs i32.ctz vs i32.popcnt — opcode byte differs" {
         } };
         const slots = [_]u16{ 0, 1 };
         const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+        const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
         defer deinit(testing.allocator, out);
         // Layout (slot 0 = RBX after chunk 13b pool shrink):
         // 4 prologue + 5 mov-EBX-imm32 = 9. Then F3 at 9, REX at 10 (0x44),
@@ -1390,7 +1390,7 @@ test "compile: i32.eqz with stack underflow → AllocationMissing" {
     } };
     const slots = [_]u16{0};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false));
+    try testing.expectError(Error.AllocationMissing, compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false));
 }
 
 test "compile: i32.wrap_i64 emits MOV r32_dst, r32_src (self-MOV zero-extends)" {
@@ -1411,7 +1411,7 @@ test "compile: i32.wrap_i64 emits MOV r32_dst, r32_src (self-MOV zero-extends)" 
     // upper half).
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout: 4 prologue + 5 mov-EBX-imm32 = 9. Then MOV EBX, EBX = 2 bytes.
     // Prologue size sourced from body_start_offset().
@@ -1433,7 +1433,7 @@ test "compile: i64.extend_i32_u emits MOV r32_dst, r32_src" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout (slot 0 = RBX after chunk 13b pool shrink):
     // 4 prologue + 5 mov-EBX-imm32 = 9. Then MOV EBX, EBX = 2 bytes.
@@ -1457,7 +1457,7 @@ test "compile: i64.extend_i32_s emits MOVSXD r64_dst, r32_src" {
     } };
     const slots = [_]u16{ 0, 0 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
     // Layout (slot 0 = RBX after chunk 13b pool shrink):
     // 4 prologue + 5 mov-EBX-imm32 = 9. Then MOVSXD RBX, EBX = 3 bytes.
@@ -1480,7 +1480,7 @@ test "compile: call N — 0 args, void return — emits MOV RDI,R15 + CALL + fix
 
     const slots = [_]u16{};
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Prologue (uses_runtime_ptr=true since `call` triggers prescan):
@@ -1527,7 +1527,7 @@ test "compile: call N — 0 args, i32 return — captures EAX into result vreg" 
 
     const slots = [_]u16{0}; // result vreg → RBX (after chunk 13b pool shrink)
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Body layout (post-prologue at 13). Folded
@@ -1559,7 +1559,7 @@ test "compile: call N — 1 i32 arg — marshals top-of-stack into arg_gprs[1] (
 
     const slots = [_]u16{0}; // arg vreg → RBX (after chunk 13b pool shrink)
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &func_sigs, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Body layout (post-prologue at 13). Cc-pivot derives the
@@ -1590,7 +1590,7 @@ test "compile: call_indirect — bounds + sig (JAE+JNE → trap stub) + CALL RAX
 
     const slots = [_]u16{0}; // idx vreg → RBX (after chunk 13b pool shrink)
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 1 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &module_types, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &module_types, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Body starts at byte 13 (uses_runtime_ptr=true prologue).
@@ -1663,7 +1663,7 @@ test "compile: self-recursive (call 0) emits JBE with patched disp32 pointing at
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 0 };
     // compile(alloc, func, alloc, func_sigs, module_types, num_imports, globals_offsets, globals_valtypes).
     // func_sigs[0] = self's sig so `call 0` resolves to a valid sig.
-    const out = try compile(testing.allocator, &f, alloc, &.{sig}, &.{sig}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{sig}, &.{sig}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Locate JBE rel32 (0F 86) — emitted in the prologue right
@@ -1721,7 +1721,7 @@ test "compile: self-recursive (i64)->i64 — probe + i64-result marshal" {
     };
     const slots = [_]u16{ 0, 1 };
     const alloc: regalloc.Allocation = .{ .slots = &slots, .n_slots = 2 };
-    const out = try compile(testing.allocator, &f, alloc, &.{sig}, &.{sig}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{sig}, &.{sig}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // Assertion 1: JBE rel32 patched (probe wired). Sibling of the
@@ -1858,7 +1858,7 @@ test "compile: try_table emit populates EmitOutput.exception_handlers" {
     });
 
     const alloc: regalloc.Allocation = .{ .slots = &[_]u16{}, .n_slots = 0 };
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     try testing.expectEqual(@as(usize, 2), out.exception_handlers.len);
@@ -1888,7 +1888,7 @@ test "compile: throw emits JMP rel32 placeholder + appends unreach_fixup (trap-p
     f.liveness = .{ .ranges = &[_]zir.LiveRange{} };
     const alloc: regalloc.Allocation = .{ .slots = &[_]u16{}, .n_slots = 0 };
 
-    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false);
+    const out = try compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false);
     defer deinit(testing.allocator, out);
 
     // JMP rel32 is 5 bytes; prologue + trap stub adds more.
@@ -1912,6 +1912,6 @@ test "compile: try_table reaches per-op emit with ExceptionTable.Builder wired" 
     const alloc: regalloc.Allocation = .{ .slots = &[_]u16{}, .n_slots = 0 };
     try testing.expectError(
         Error.UnsupportedOp,
-        compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false),
+        compile(testing.allocator, &f, alloc, &.{}, &.{}, 0, &.{}, &.{}, .i32, &.{}, false, false),
     );
 }

--- a/src/engine/codegen/x86_64/op_control.zig
+++ b/src/engine/codegen/x86_64/op_control.zig
@@ -1609,7 +1609,10 @@ fn emitEndInter(ctx: *ctx_mod.EmitCtx) Error!void {
         }
     }
     // ADR-0164 A3 / D-292 — memory out-of-bounds (code 6) stub; `JA rel32` (6-byte).
-    if (ctx.oob_fixups.items.len > 0) {
+    // ADR-0202 D4 — force-emit even with zero fixups when bounds are elided:
+    // the elided memory0 accesses have no JA site, but the guard-fault
+    // PC-redirect (D2) needs the stub body as its target.
+    if (ctx.oob_fixups.items.len > 0 or ctx.bounds_elided) {
         const trap_byte = try emitTrapExitStub(ctx, 6);
         ctx.oob_stub_off = trap_byte; // ADR-0202 D3 — PC-redirect target for guard faults
         for (ctx.oob_fixups.items) |fx_byte| {

--- a/src/engine/codegen/x86_64/op_memory.zig
+++ b/src/engine/codegen/x86_64/op_memory.zig
@@ -79,6 +79,7 @@ pub fn emitMemOp(
     op: zir.ZirOp,
     offset: u32,
     func_idx: u32,
+    bounds_elided: bool,
 ) Error!void {
     const is_store = switch (op) {
         .@"i32.store",
@@ -208,14 +209,22 @@ pub fn emitMemOp(
         try buf.appendSlice(allocator, inst.encJccRel32(.ne, 0).slice()); // nonzero low bits = unaligned
         try unaligned_atomic_fixups.append(allocator, al_fixup);
     }
-    try buf.appendSlice(allocator, inst.encLeaR64BaseDisp8(.rcx, .rdx, access_size).slice());
-    try buf.appendSlice(allocator, inst.encCmpR64MemDisp32(.rcx, abi.runtime_ptr_save_gpr, jit_abi.mem_limit_off).slice());
-    const fixup_at: u32 = @intCast(buf.items.len);
-    try buf.appendSlice(allocator, inst.encJccRel32(.a, 0).slice()); // unsigned >
-    try oob_fixups.append(allocator, fixup_at);
-    // ADR-0028 M3-a-1: record bounds-check emit site (no-op when
-    // -Dtrace-ringbuffer=false; comptime-folded out of release).
-    trace.writeBounds(func_idx, fixup_at);
+    // ADR-0202 D4 — elided: the guard-page reservation covers every
+    // reachable ea; an oob access hardware-faults and the fault→trap
+    // handler redirects to the force-emitted kind=6 stub. The vm_base
+    // load + ea materialise stay (they feed the access); only the
+    // mem_limit reload + CMP + JA go. The atomic ALIGNMENT check above
+    // is NOT elided.
+    if (!bounds_elided) {
+        try buf.appendSlice(allocator, inst.encLeaR64BaseDisp8(.rcx, .rdx, access_size).slice());
+        try buf.appendSlice(allocator, inst.encCmpR64MemDisp32(.rcx, abi.runtime_ptr_save_gpr, jit_abi.mem_limit_off).slice());
+        const fixup_at: u32 = @intCast(buf.items.len);
+        try buf.appendSlice(allocator, inst.encJccRel32(.a, 0).slice()); // unsigned >
+        try oob_fixups.append(allocator, fixup_at);
+        // ADR-0028 M3-a-1: record bounds-check emit site (no-op when
+        // -Dtrace-ringbuffer=false; comptime-folded out of release).
+        trace.writeBounds(func_idx, fixup_at);
+    }
 
     // Per-op final encoding.
     if (is_store) {
@@ -312,6 +321,7 @@ pub fn emitI32Load(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Error!void {
         ins.op,
         @as(u32, @intCast(ins.payload)),
         ctx.func_idx,
+        ctx.bounds_elided,
     );
 }
 pub const emitI32Load8S = emitI32Load;

--- a/src/engine/compile.zig
+++ b/src/engine/compile.zig
@@ -28,6 +28,22 @@ const Error = runner_mod.Error;
 const CompiledWasm = runner_mod.CompiledWasm;
 const runtime_mod = @import("../runtime/runtime.zig");
 const needs_heap_detector = @import("../feature/gc/needs_heap_detector.zig");
+const memory_backing = @import("../runtime/instance/memory_backing.zig");
+
+/// ADR-0202 D5 — bounds-check mode knob. `.auto` (default) elides the
+/// memory0 scalar bounds check when memory0 qualifies for a guard-page
+/// reservation; `.explicit` forces the inline check everywhere (the
+/// D-510 differential-fuzz axis + a debugging escape hatch). Process-
+/// global so a fuzz harness can flip it between compiles without
+/// threading it through `compileWasm`'s 56 call sites.
+pub const BoundsChecks = enum { auto, explicit };
+var bounds_checks_mode: BoundsChecks = .auto;
+pub fn setBoundsChecks(m: BoundsChecks) void {
+    bounds_checks_mode = m;
+}
+pub fn boundsChecksMode() BoundsChecks {
+    return bounds_checks_mode;
+}
 
 pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledWasm {
     var module = try parser.parse(allocator, wasm_bytes);
@@ -882,6 +898,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
     // Imports take precedence (memidx 0 is the first imported
     // memory if any); otherwise the first defined memory.
     var memory0_idx_type: sections.MemoryEntry.IdxType = .i32;
+    var memory0_page_size_log2: u8 = 16; // ADR-0202 D4 — memory0 qualification
     var memory0_idx_type_known = false;
     // D-324 — collect the full per-memory idx_type slice (imports
     // first, then defined) so mixed i32/i64 multi-memory bodies
@@ -891,6 +908,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
         for (ib.items) |imp| if (imp.kind == .memory) {
             if (!memory0_idx_type_known) {
                 memory0_idx_type = imp.payload.memory.idx_type;
+                memory0_page_size_log2 = imp.payload.memory.page_size_log2;
                 memory0_idx_type_known = true;
             }
             try memory_idx_types.append(a, imp.payload.memory.idx_type);
@@ -902,6 +920,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
         defer ms_buf.deinit();
         if (!memory0_idx_type_known and ms_buf.items.len > 0) {
             memory0_idx_type = ms_buf.items[0].idx_type;
+            memory0_page_size_log2 = ms_buf.items[0].page_size_log2;
             memory0_idx_type_known = true;
         }
         for (ms_buf.items) |me| try memory_idx_types.append(a, me.idx_type);
@@ -1090,6 +1109,17 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
     // `store_raw_typeidx` (both derive from the same `usesTypeSubtyping`).
     const uses_type_subtyping = needs_heap_detector.usesTypeSubtyping(types);
 
+    // ADR-0202 D4 — elide memory0 scalar bounds checks when the knob is
+    // `.auto` AND memory0 qualifies for a guard-page reservation. The SAME
+    // `memory_backing.qualifies` predicate drives the runtime backing choice
+    // (setup.zig / instantiate.zig / wasm_memory_new), so elided code is only
+    // ever bound to a guarded memory0 — the binding-time soundness invariant
+    // holds by construction (no non-guarded path exists for a qualifying
+    // memory). `.explicit` forces checks (D-510 differential-fuzz axis).
+    const bounds_elided = boundsChecksMode() == .auto and
+        memory0_idx_type_known and // a module with no memory0 has nothing to elide
+        memory_backing.qualifies(memory0_idx_type, memory0_page_size_log2);
+
     const results = try allocator.alloc(compile_func.FuncResult, defined_func_typeidx.len);
     errdefer allocator.free(results);
     var compiled: usize = 0;
@@ -1169,6 +1199,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
             array_elem_valtypes,
             struct_field_valtypes,
             uses_type_subtyping,
+            bounds_elided,
             table_idx_types,
         ) catch |err| {
             std.debug.print("compileWasm: func[{d}] params={d} results={d} → {s}\n", .{

--- a/src/engine/compile.zig
+++ b/src/engine/compile.zig
@@ -45,6 +45,19 @@ pub fn boundsChecksMode() BoundsChecks {
     return bounds_checks_mode;
 }
 
+/// Compile for AOT serialization — always with EXPLICIT bounds checks
+/// (ADR-0202 D5). The `.cwasm` format + `aot/run.zig`'s plain-heap
+/// run-memory cannot yet uphold guard-page soundness, and
+/// `produceFromCompiledWasm` hard-refuses an elided module, so every
+/// AOT-destined compile MUST route here. Save/restore the global knob
+/// so a caller's ambient `.auto` (JIT) preference is untouched.
+pub fn compileWasmForAot(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledWasm {
+    const prev = bounds_checks_mode;
+    bounds_checks_mode = .explicit;
+    defer bounds_checks_mode = prev;
+    return compileWasm(allocator, wasm_bytes);
+}
+
 pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledWasm {
     var module = try parser.parse(allocator, wasm_bytes);
     defer module.deinit(allocator);
@@ -1320,6 +1333,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
         .tag_param_slot_counts = tag_param_slot_counts,
         .exception_table = .{ .entries = exception_entries },
         .exports = func_exports,
+        .bounds_elided = bounds_elided,
         .arena = arena,
     };
 }

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -61,6 +61,13 @@ pub const eh_registry = @import("codegen/shared/eh_registry.zig");
 // (`runner.compileWasm` etc still resolves).
 const compile_mod = @import("compile.zig");
 pub const compileWasm = compile_mod.compileWasm;
+// ADR-0202 D5 — bounds-check mode knob (re-export). `.auto` (default)
+// elides the memory0 scalar check for guard-page-qualifying memories;
+// `.explicit` forces the inline check (harnesses with non-guarded memory
+// + the D-510 differential axis).
+pub const BoundsChecks = compile_mod.BoundsChecks;
+pub const setBoundsChecks = compile_mod.setBoundsChecks;
+pub const boundsChecksMode = compile_mod.boundsChecksMode;
 pub const applyDefinedGlobalsInit = compile_mod.applyDefinedGlobalsInit;
 pub const resolveFuncrefGlobals = compile_mod.resolveFuncrefGlobals;
 pub const applyTableInit = compile_mod.applyTableInit;

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -68,6 +68,7 @@ pub const compileWasm = compile_mod.compileWasm;
 pub const BoundsChecks = compile_mod.BoundsChecks;
 pub const setBoundsChecks = compile_mod.setBoundsChecks;
 pub const boundsChecksMode = compile_mod.boundsChecksMode;
+pub const compileWasmForAot = compile_mod.compileWasmForAot;
 pub const applyDefinedGlobalsInit = compile_mod.applyDefinedGlobalsInit;
 pub const resolveFuncrefGlobals = compile_mod.resolveFuncrefGlobals;
 pub const applyTableInit = compile_mod.applyTableInit;
@@ -252,6 +253,13 @@ pub const CompiledWasm = struct {
     /// `arena.deinit()`), so `deinit` needs no extra free. Empty slice
     /// when the module exports no functions.
     exports: []const FuncExport,
+    /// ADR-0202 D4/D5 — true when memory0 scalar bounds checks were elided
+    /// (guard-page-dependent codegen). The AOT producer REFUSES to serialize
+    /// an elided module (the `.cwasm` format + `aot/run.zig` do not yet carry
+    /// the elision bit / trap-registry table / guarded run-memory — D5), so
+    /// this is the enforcement point that makes the "elided ⇒ guarded binding"
+    /// invariant impossible to violate via AOT.
+    bounds_elided: bool = false,
     arena: std.heap.ArenaAllocator,
 
     pub fn deinit(self: *CompiledWasm, allocator: Allocator) void {

--- a/src/engine/runner_test.zig
+++ b/src/engine/runner_test.zig
@@ -22,6 +22,7 @@ const skip = @import("../test_support/skip.zig");
 
 const runner = @import("runner.zig");
 const compileWasm = runner.compileWasm;
+const compileWasmForAot = runner.compileWasmForAot; // ADR-0202 D5 — AOT-destined compiles
 const CompiledWasm = runner.CompiledWasm;
 const findExportFunc = runner.findExportFunc;
 const runI32Export = runner.runI32Export;
@@ -1781,7 +1782,7 @@ test "AOT<->JIT differential: .cwasm produce->load->execute equals the JIT resul
     // the SAME machine code the JIT emitted; func[0]'s prologue expects
     // `*const JitRuntime` in X0/RDI, so we build a real runtime exactly
     // as `runI32Export` does and pass it in.
-    var compiled = try compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
 
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
@@ -1821,7 +1822,7 @@ test "AOT<->JIT differential: () -> i64 const round-trips through produce->load 
     const jit_result = try runI64Export(testing.allocator, &wasm_bytes, "f");
     try testing.expectEqual(@as(u64, 0x1_0000_0007), jit_result);
 
-    var compiled = try compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
     defer testing.allocator.free(cwasm);
@@ -1856,7 +1857,7 @@ test "AOT<->JIT differential: internal call's direct-call reloc executes through
     const jit_result = try runI32Export(testing.allocator, &wasm_bytes, "f");
     try testing.expectEqual(@as(u32, 7), jit_result);
 
-    var compiled = try compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
     defer testing.allocator.free(cwasm);
@@ -1884,7 +1885,7 @@ test "AOT producer serialises the func export table → loaded .cwasm resolves e
         0x07, 0x0b,
     };
 
-    var compiled = try compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
     defer testing.allocator.free(cwasm);
@@ -1919,7 +1920,7 @@ test "stateful .cwasm cycle-1: global.get returns the serialised init value via 
         0x00, 0x0b,
     };
 
-    var compiled = try compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
     defer testing.allocator.free(cwasm);
@@ -1951,7 +1952,7 @@ test "stateful .cwasm cycle-1b: linear memory store+load round-trips via reconst
         0x0b,
     };
 
-    var compiled = try compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
     defer testing.allocator.free(cwasm);
@@ -1980,7 +1981,7 @@ test "stateful .cwasm cycle-1b: active data segment initialises memory, load rea
         0x0b, 0x04, 0x07, 0x00, 0x00, 0x00,
     };
 
-    var compiled = try compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
     defer testing.allocator.free(cwasm);
@@ -2015,7 +2016,7 @@ test "stateful .cwasm cycle-2a: call_indirect through a reconstructed table retu
     // Validate the fixture via the JIT path (full setupRuntime).
     try testing.expectEqual(@as(u32, 7), try runI32Export(testing.allocator, &wasm_bytes, "g"));
 
-    var compiled = try compileWasm(testing.allocator, &wasm_bytes);
+    var compiled = try compileWasmForAot(testing.allocator, &wasm_bytes);
     defer compiled.deinit(testing.allocator);
     const cwasm = try aot_produce.produceFromCompiledWasm(testing.allocator, &compiled, &wasm_bytes);
     defer testing.allocator.free(cwasm);

--- a/src/platform/signal.zig
+++ b/src/platform/signal.zig
@@ -150,7 +150,32 @@ const win_impl = if (builtin.os.tag == .windows) struct {
 /// (production entry). No-op on wasi. NOT installed by the test harness — the spec
 /// runners own their own (recovery) handler; this is the production last-resort
 /// disposition.
+/// Set once SOME fault handler owns SIGSEGV/SIGBUS for this process —
+/// either this production handler OR the spec runner's recovery
+/// handler (which classifies guard faults first, then siglongjmp-
+/// recovers). `ensureInstalled` skips when set so the engine's
+/// auto-install (needed for elided JIT execution under plain
+/// `zig build test`) never clobbers a recovery handler.
+var handler_installed = std.atomic.Value(bool).init(false);
+
+/// Idempotent auto-install for the JIT invoke path (ADR-0202 D4):
+/// guard-page elision REQUIRES a fault handler, so any JIT execution
+/// must have one armed. No-op if a handler is already installed
+/// (production CLI init, embedding init, or the spec runner).
+pub fn ensureInstalled() void {
+    if (handler_installed.swap(true, .monotonic)) return;
+    installInternalFaultHandler();
+}
+
+/// Mark SIGSEGV/SIGBUS as owned by an externally-installed handler
+/// (the spec runner's recovery handler) so `ensureInstalled` stands
+/// down. Called from `spec_assert_runner_base.installSigsegvHandler`.
+pub fn markInstalled() void {
+    handler_installed.store(true, .monotonic);
+}
+
 pub fn installInternalFaultHandler() void {
+    handler_installed.store(true, .monotonic);
     if (comptime builtin.os.tag == .windows) {
         win_impl.install();
         return;

--- a/test/spec/simd_assert_runner.zig
+++ b/test/spec/simd_assert_runner.zig
@@ -48,6 +48,10 @@ const base = @import("spec_assert_runner_base.zig");
 
 pub fn main(init: std.process.Init) !void {
     base.initHostDispatchStubs();
+    // ADR-0202 D5 — JIT-executes against the bespoke non-guarded
+    // `base.growable_memory` array → explicit bounds checks mandatory
+    // (elision would read past it instead of faulting). D-515.
+    zwasm.engine.runner.setBoundsChecks(.explicit);
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/spec/spec_assert_runner.zig
+++ b/test/spec/spec_assert_runner.zig
@@ -26,6 +26,11 @@ const runner_mod = zwasm.engine.runner;
 const entry = zwasm.engine.codegen.shared.entry;
 
 pub fn main(init: std.process.Init) !void {
+    // ADR-0202 D5 — this runner JIT-executes against a bespoke non-guarded
+    // `scratch_memory` buffer, so it MUST compile with explicit bounds checks
+    // (guard-page elision would read past the buffer instead of faulting,
+    // violating the binding-time soundness invariant). D-515.
+    zwasm.engine.runner.setBoundsChecks(.explicit);
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/spec/spec_assert_runner_base.zig
+++ b/test/spec/spec_assert_runner_base.zig
@@ -2833,6 +2833,18 @@ const SIGNAL_STACK_SIZE: usize = 1 << 18;
 var signal_stack: [SIGNAL_STACK_SIZE]u8 align(std.heap.page_size_max) = undefined;
 
 pub fn installSigsegvHandler() void {
+    // ADR-0202 D5 — this harness backs JIT linear memory with its own
+    // bespoke buffers (`scratch_memory` heap allocs + the static
+    // `growable_memory` array), NOT guard-page reservations. Guard-page
+    // bounds elision would then read past a plain buffer instead of
+    // faulting (an oob assert would "not trap"), violating the D4/D5
+    // binding-time soundness invariant (elided code MUST bind guarded
+    // memory). Force `.explicit` so the corpus validates spec trap
+    // semantics against the checked codegen; the elision path is covered
+    // by the guarded runner_trap_test + the CLI oob test (debt D-515
+    // tracks running the full corpus under elision via guarded harness
+    // memory or the D-510 differential).
+    zwasm.engine.runner.setBoundsChecks(.explicit);
     // Windows: POSIX signals don't apply; `std.posix.Sigaction` is
     // `void` on Win64. Surfaced by windowsmini test-all
     // (`type 'void' does not support struct initialization syntax`
@@ -2895,6 +2907,11 @@ pub fn installSigsegvHandler() void {
     // arm64, mmap region truncation) so the runner survives the
     // same class of in-body fault on Mac.
     std.posix.sigaction(.BUS, &act, null);
+    // ADR-0202 D4 — this recovery handler (classify-first, then
+    // siglongjmp) now OWNS SIGSEGV/SIGBUS for the runner process;
+    // tell the engine's auto-install to stand down so it never
+    // clobbers this handler with the production exit-70 one.
+    zwasm.platform.signal.markInstalled();
 
     // Readback verification: confirm our handler is the active
     // SEGV disposition immediately post-install. Prints on stderr

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -350,6 +350,9 @@ fn recordJitRunErr(
 }
 
 pub fn main(init: std.process.Init) !void {
+    // ADR-0202 D5 — JIT-executes via base's bespoke non-guarded memory →
+    // explicit bounds checks mandatory (binding-time soundness). D-515.
+    zwasm.engine.runner.setBoundsChecks(.explicit);
     const io = init.io;
     const gpa = init.gpa;
 


### PR DESCRIPTION
## Summary

Final phase of **D-507** (ADR-0202 D4/D5), on top of phase 1 (#131) + phase 2
(#132). Flips on memory0 scalar bounds-check elision for guard-page-qualifying
memories, behind an `.auto`/`.explicit` knob, with a hard AOT soundness guard.
**Completes D-507.**

### Elision (D4)
- Both emit backends gain `bounds_elided`: when memory0 qualifies (i32 × 64 KiB
  × guarded host) AND the knob is `.auto`, memory0 scalar/atomic accesses drop
  the inline `ADD/CMP/B.HI` (x86_64: mem_limit reload + CMP + JA); the kind=6
  stub is force-emitted as the guard-fault redirect target. memory64 / bulk /
  GC-array / SIMD keep explicit checks (SIMD = follow-up D-514); atomic
  alignment checks are never elided.
- The elision decision uses the SAME `memory_backing.qualifies` predicate as
  the runtime backing choice → elided code only ever binds guarded memory
  (D5 binding-time soundness by construction).
- Any JIT execution auto-installs the fault handler (`entry.invokeAndCheck` →
  `signal.ensureInstalled`, idempotent).
- Knob `bounds_checks: .auto|.explicit` (`runner.setBoundsChecks`) — the D-510
  differential axis.

### AOT soundness guard (D5) — closes a confirmed memory-safety hole
An adversarial review found that the AOT `.cwasm` path compiled `.auto`
(elided) but `aot/run.zig` binds **plain heap** with no trap region → an oob
access would read/write past the guest memory **silently** (sandbox escape).
Fixed structurally: `CompiledWasm.bounds_elided` + `produceFromCompiledWasm`
**hard-refuses** an elided module (`ElidedBoundsNotAotSerializable`);
`compileWasmForAot` forces `.explicit` for every AOT compile. The three
bespoke-non-guarded-memory spec runners force `.explicit` too. Regression test
pins the refusal. Full D5 AOT-elision build-out tracked as D-515.

### Measured perf (retrospective — hypothesis refuted, recorded honestly)
The ADR framed elision as "the biggest tier-free lever (1.75–3.9x band)". The
arm64 shootout delta is **~noise**: matrix ~1%, base64 ~1.5%, sieve ~4%, fib2
within the ±2–4% run stddev. The check was a pinned-reg CMP + a well-predicted
never-taken branch — cheap on OoO. The real 1.75–3.9x gap vs wasmtime is
optimising-tier codegen quality (D-513), not bounds checks. The elision still
ships: correct, code-size win, standard production design, and its guard-fault
machinery is the reusable foundation D-509 (threads = base-stable memory)
needs.

## Verification
- Mac arm64: `zig build test` / `test-all` / `lint --max-warnings 0` green.
- ubuntu x86_64 + windowsmini native gates (test-all): both OK.
- `test-oob-elision` build step (all 3 OSes via test-all): `zwasm run --engine
  jit` on a boundary oob load → guard fault → redirect → trap → exit 1.
- Guarded elided OOB → oob_memory code 6 (`runner_trap_test`); AOT-refuses-
  elided regression test.
- Independent adversarial critique (Check #5): the confirmed AOT hole + the
  latent spec-runner breach both fixed in-branch; the JIT elision itself passed
  every soundness probe.

Refs: D-507 (completes) · ADR-0202 D4/D5 · D-514 (SIMD elision) · D-515 (AOT
elision build-out + corpus-under-elision) · D-513 (optimising-tier decision)