### PR TITLE
docs: close D-507 (guard-page bounds elision complete)

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -3,42 +3,6 @@
 # Refresh on every /continue resume — .claude/skills/continue/RESUME.md Step 0.5.
 
 entries:
-  - id: "D-507"
-    layer: "code"
-    status: "now"
-    description: |-
-      QUEUE HEAD of front G-senior-gap (2026-07-06 senior-runtime gap analysis,
-      `.dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md`; queue order
-      G1=this, G2=D-508, G3=D-510, then note-class G4+). **Guard-page /
-      signal-based linear-memory bounds-check elision** — the single biggest
-      measured perf lever available WITHIN the single-pass JIT (no optimising
-      tier needed): zwasm emits an explicit CMP+branch per memory access;
-      wasmtime (`Config::memory_reservation`/`memory_guard_size`/
-      `signals_based_traps`, config.rs:1862/1945/3151) and WAMR (Segue) elide
-      it by reserving guard regions and converting the fault to an oob trap.
-      Measured evidence (report §0): shootout fib2 1.75x / matrix 3.9x /
-      heapsort 3.0x vs wasmtime — a substantial slice of the sub-4x band is
-      bounds-check overhead (the >4x outliers are optimising-tier codegen
-      quality, out of scope here → D-513). SHAPE (ADR REQUIRED first — codegen
-      strategy + signal-handler introduction are ADR-grade; also audit
-      `check_libc_boundary` for sigaction/mmap/VirtualAlloc additions):
-      (1) reserve base+4GiB+guard via mmap PROT_NONE (Win: VirtualAlloc
-      MEM_RESERVE + VEH) for i32 memories; commit-on-grow; (2) SIGSEGV/SIGBUS
-      (Win: vectored exception) handler classifies faults inside the guard →
-      route to the existing trap path (trap_kind oob) — must coexist with the
-      interrupt flag + EH unwinder; (3) emit flag drops the explicit CMP when
-      the memory qualifies (i32, guard-covered); memory64 KEEPS explicit
-      checks (wasmtime does the same); (4) interp unchanged (oracle). Fuzz
-      differential (D-510) SHOULD land first or together — it is the safety
-      net for exactly this class of change. 3-host verify mandatory
-      (JIT/ABI-class; Rosetta reproduces linux; windowsmini for VEH).
-    first_raised: "2026-07-06"
-    last_reviewed: "2026-07-06"
-    refs: |-
-      .dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md §0/§2.2
-      src/engine/codegen/{arm64,x86_64}/op_memory.zig (explicit bounds CMPs)
-      ~/Documents/OSS/wasmtime crates/wasmtime/src/config.rs:1862,1945,3151
-    front: G-senior-gap
   - id: "D-508"
     layer: "code"
     status: "note"

--- a/.dev/decisions/0202_guard_page_bounds_elision.md
+++ b/.dev/decisions/0202_guard_page_bounds_elision.md
@@ -1,12 +1,15 @@
 # ADR-0202 — Guard-page linear memory + signal-based OOB traps (bounds-check elision)
 
 > Doc-state: ACTIVE
-> Status: Accepted (2026-07-06) — D-507 (front G-senior-gap, G1). Implements
-> ROADMAP §4.9 as written; supersedes-in-part ADR-0166's premise ("v2 uses NO
-> signal-based wasm trap semantics") for the guard-fault class only.
-> Verification: existing oob corpus (test/edge_cases/p7/memory_bounds,
-> p9/memory_ops, p10/memory64, spec memory_trap) must stay green with
-> trap kind oob_memory (wire code 6); bench delta recorded at close.
+> Status: Implemented (2026-07-07, @5c5c45f6d) — D-507 CLOSED. Phase 1 #131
+> (reservation-backed memory), phase 2 #132 (fault→trap handler + registry),
+> phase 3 #133 (elision flip + AOT soundness guard). Implements ROADMAP §4.9 as
+> written; supersedes-in-part ADR-0166's premise ("v2 uses NO signal-based wasm
+> trap semantics") for the guard-fault class only. **Retrospective: the perf
+> hypothesis is REFUTED** (measured scalar-elision delta ~noise; the 1.75–3.9x
+> gap is optimising-tier quality = D-513). Elision shipped for correctness +
+> code-size + as the D-509 guard-fault foundation; AOT elision DISABLED (D5
+> clauses = D-515). Follow-ups: D-514 (SIMD elision), D-515 (AOT + corpus).
 
 ## Context
 

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -37,24 +37,21 @@ Post-v2.0.0 sweep (see `.dev/meta_audits/2026-07-03-maintenance-scaffolding-audi
 
 Senior-runtime gap analysis (measured; report =
 `.dev/meta_audits/2026-07-06-senior-runtime-gap-analysis.md`) opened front
-**G-senior-gap** (debt D-507..D-513, `front: G-senior-gap`). Queue order:
-- **G1 = D-507 (IN PROGRESS)** — guard-page/signal bounds-check elision.
-  **ADR-0202 filed** (adversarially critiqued + revised — read it first: D2
-  merges classification INTO the ADR-0166 handlers, SIGSEGV+SIGBUS, oob_stub_off
-  must be plumbed through EmitOutput→linker, binding-time soundness invariant).
-  **Phase 1 (D1) MERGED #131** (`main`): guarded_mem + memory_backing; all
-  creation/grow/free surfaces switched; std.c.mprotect = ADR-0070 B133.
-  **Phase 2 (D2+D3) DONE** on branch `develop/d507-fault-trap-handler`:
-  `platform/trap_registry.zig` (classify demands guarded-addr AND jit-pc),
-  auto-(un)register in guarded_mem.reserve/release, `platform/sigcontext.zig`
-  (per-OS mcontext PC read/write mirrors), fault→trap PC-redirect merged into
-  the ADR-0166 SIGSEGV/SIGBUS handler + Windows VEH, spec-runner handler
-  classifies FIRST; oob_stub_off plumbed emit→linker→registerCodeRegion at
-  publish / unregister in JitModule.deinit. Fork-proven redirect
-  (fault_redirect_test) + plumbing test; test-all + lint green on Mac.
-  **NEXT: phase 3** = D4 emit flip (drop CMP for qualifying memory0, force-emit
-  the oob stub) behind the D5 `bounds_checks: .auto|.explicit` knob + .cwasm
-  bit + per-OS CLI `trap kind=6` verification; 3-host + Rosetta. D-510 safety net.
+**G-senior-gap** (debt D-508..D-515, `front: G-senior-gap`). Queue order:
+- **G1 = D-507 COMPLETE + MERGED** (guard-page/signal bounds-check elision;
+  ADR-0202). Phase 1 #131 (reservation-backed memory), phase 2 #132 (fault→trap
+  handler + trap registry), phase 3 #133 (elision flip + AOT soundness guard).
+  On `main` (@5c5c45f6d). **KEY RETROSPECTIVE**: the measured scalar-elision
+  perf is ~NOISE (matrix ~1% / base64 ~1.5% / fib2 within stddev) — the ADR's
+  "biggest tier-free lever" hypothesis is REFUTED; the 1.75–3.9x gap vs wasmtime
+  is optimising-tier codegen quality (**D-513**), not bounds checks. Elision
+  still shipped: correct, code-size win, and its guard-fault infra is the base
+  D-509 (threads) needs. **AOT elision is DISABLED** — `compileWasmForAot`
+  forces `.explicit` + `produceFromCompiledWasm` hard-refuses elided (the
+  `.cwasm`/`aot/run.zig` plain-heap path can't uphold guard soundness yet).
+  Follow-ups: **D-514** (symmetric SIMD elision — x86_64 v128 handlers are
+  param-threaded), **D-515** (build the D5 AOT-elision clauses + run the spec
+  corpus under elision; the harnesses force `.explicit` today).
 - **G2 = D-508** — on-disk compilation cache (reuse .cwasm serialization).
 - **G3 = D-510** — committed differential-fuzz harness (interp oracle vs JIT);
   MAY be pulled ahead of D-507 as its safety net — either order is sanctioned.


### PR DESCRIPTION
Doc-only close of D-507 after all 3 implementation phases merged (#131/#132/#133, main @5c5c45f6d).

- Delete the D-507 debt row (git history retains it via this commit).
- Mark ADR-0202 `Status: Implemented` with the retrospective (perf hypothesis refuted — scalar elision ~noise; the 1.75–3.9x gap is optimising-tier quality = D-513).
- Retarget the handover G-senior-gap front at D-508; record that AOT elision is disabled pending D-515 and SIMD elision is D-514.

Doc-only → auto-skips the heavy CI legs (green via `ci-required`).