### PR TITLE
ADR-0203 stage 1: de-bake all JIT helper absolute addresses into JitRuntime slots (closes D-516)

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -3,51 +3,49 @@
 # Refresh on every /continue resume — .claude/skills/continue/RESUME.md Step 0.5.
 
 entries:
-  - id: "D-516"
+  - id: "D-519"
     layer: "code"
-    status: "now"
+    status: "note"
     description: |-
-      Front AOT-full-fidelity (campaign stage-1 target; found 2026-07-09 by
-      direct experiment). **`zwasm compile` silently produces a `.cwasm` that
-      fatally crashes when run in a fresh process** for any module whose
-      codegen bakes a Zig-helper absolute address: 13 helpers
-      (`jitCallIndirectResolve`, `jitGcAlloc` + GC array family,
-      `jitGcRefCast`/`RefTest`, `rethrowFromExnref`) are emitted as
-      MOVZ/MOVK / movabs imm64 across ~32 op files; the only `.cwasm` reloc
-      kind is `direct_call`; zwasm is PIE so per-exec ASLR invalidates the
-      baked addresses. REPRO: struct.new module → `run` ok(42) / `compile`
-      exit 0 (NO refusal) / `run x.cwasm` = "internal error — caught a fatal
-      signal" exit 70. call_indirect happens to survive (elem-initialized
-      slots pre-resolved; helper only on the lazy path — still a landmine).
-      FIX (campaign): route all 13 helpers through JitRuntime struct fields
-      called via [rt+off] (the `memory_grow_fn` precedent; wazero's
-      context-register pattern) — makes code bytes fully PIC and fixes fresh
-      JIT + AOT alike. INTERIM correctness stopgap if the campaign pauses:
-      producer refuses modules whose FuncResults contain baked-helper sites.
+      Front AOT-full-fidelity (DA-critique finding on stage 1, 2026-07-09).
+      **dbg-gated absolute-address emission survives the ADR-0203 D1
+      de-baking**: `ZWASM_DEBUG=jit.callcount` (x86_64 emit.zig:328-331) and
+      `global.trace` (both op_globals.zig) bake this process's
+      `call_profile` addresses into emitted code — `dbg.on` is a RUNTIME env
+      check in Debug/ReleaseSafe, so a diagnostic-enabled `zwasm compile`
+      can still produce a `.cwasm` that writes foreign addresses when run
+      elsewhere (the D-516 silent-corruption class, resurrected via a
+      developer flag). NOT gated in stage 1 (adding an Error variant to the
+      shared runner Error set widens every exhaustive-switch caller —
+      platform_panic_vs_error class concern). CLOSE at ADR-0203 stage 2:
+      the produce/serialization gate refuses dbg-instrumented compiles
+      (produce-side check or a `compiled_with_dbg` bit refused at load).
     first_raised: "2026-07-09"
     last_reviewed: "2026-07-09"
     refs: |-
-      .dev/meta_audits/2026-07-09-aot-full-fidelity-investigation.md
-      src/engine/codegen/arm64/op_call.zig:314-319 (bake shape)
-      src/engine/codegen/x86_64/op_call.zig:500 (movabs mirror)
-      src/engine/codegen/aot/produce.zig (no GC/EH/call_indirect refusal)
+      .devils-advocate/logs/check-6-critique-2026-07-09-1743.md (edge-cases)
+      src/engine/codegen/x86_64/emit.zig:328-331
+      src/engine/codegen/arm64/op_globals.zig:119-134
+      .dev/decisions/0203_aot_full_fidelity.md (stage 2)
     front: AOT-full-fidelity
   - id: "D-517"
     layer: "code"
     status: "note"
     description: |-
-      Front AOT-full-fidelity (Phase II characterization, 2026-07-09).
-      **`memory.grow` is unsupported on the `.cwasm` run path** — the AOT
-      mini-runtime allocs min_pages plain-heap per call (aot/run.zig:154-163;
-      zero `grow` hits in aot/{run,load}.zig), so guest grow returns -1:
-      EVERY realworld Go fixture dies "runtime: out of memory" (7 fixtures,
-      exit 2) and rust_compression aborts ("memory allocation ... failed" →
-      unreachable trap), while the same `.wasm` runs fine. Pinned as
-      `.wrong_result` rows in test/aot/aot_process_diff.zig's expectation
-      table. Discharged BY ARCHITECTURE when the campaign's full-runtime
-      load path lands (deserialize-into-CompiledWasm → setupRuntimeLinked
-      binds the same growable reservation-backed memory as fresh JIT); the
-      harness's RATCHET-FLIP gate forces the table update in that PR.
+      Front AOT-full-fidelity (Phase II characterization, 2026-07-09;
+      WIDENED post-stage-1: covers ALL mini-runtime state gaps, not just
+      grow). **The `.cwasm` mini-runtime lacks runtime state the full JIT
+      has**: (a) `memory.grow` — plain-heap min_pages per call, grow returns
+      -1: every realworld Go fixture dies OOM (8 fixtures) + rust/cpp/c
+      alloc-aborts, while the same `.wasm` runs fine; (b) NO GC arena —
+      post-D-516-de-baking a GC .cwasm deterministically fatal-signals on
+      null `gc_heap`; (c) NO EH tables (not serialized) — a throw/catch
+      .cwasm traps `uncaught_exception` instead of catching. All pinned as
+      `.wrong_result` rows in test/aot/aot_process_diff.zig. Discharged BY
+      ARCHITECTURE at ADR-0203 stage 3 (deserialize-into-CompiledWasm →
+      setupRuntimeLinked binds growable guarded memory + GC arena + EH
+      registry exactly like fresh JIT); the RATCHET-FLIP gate forces the
+      table update in that PR.
     first_raised: "2026-07-09"
     last_reviewed: "2026-07-09"
     refs: |-

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -24,33 +24,25 @@ publish / cut over. No active campaign/bundle; no cron self-re-arm.
   `.cwasm` = explicit `zwasm compile` output AND the transparent-cache value.
   A `.cwasm` must load back into the **FULL runtime** (cache-hit == cache-miss)
   covering ALL module classes; then **D-508** transparent `run --cache` on top.
-- **Phase I Investigation DONE** (findings doc:
-  `.dev/meta_audits/2026-07-09-aot-full-fidelity-investigation.md`; details in
-  `private/notes/aot-campaign-*.md`): **D-516 now-class bug** (13 baked helper
-  absolute addresses — GC/EH/call_indirect-lazy — PIE ASLR → `.cwasm` fatal
-  signal in a fresh process; `compile` emits it silently) · **D-517**
-  (memory.grow unsupported on cwasm path: ALL 7 Go + rust_compression die) ·
-  **D-518** (start func not serialized → silently skipped, wrong results) ·
-  ROI ~110ms compile tax on 3MB Go · architecture = deserialize-into-
-  CompiledWasm + reuse setupRuntimeLinked (bakes no absolutes); helper
-  de-baking via JitRuntime-field indirection (wazero pattern); trap table as
-  offset-relative side section (wasmtime, = D-515); two-tier gate; versioned
-  cache dir.
-- **Phase II correctness net = test/aot/aot_process_diff.zig** (`zig build
-  test-aot-diff`, in test-all) — CROSS-PROCESS `.wasm`-vs-`.cwasm` subprocess
-  diff (in-process lanes can't see ASLR staleness) over realworld + crafted
-  corpus (test/aot/corpus: GC/EH/call_indirect/grow/start). Baseline 46/62
-  match; known gaps pinned in the expectation table (.wrong_result =
-  deterministic D-517/D-518, RATCHET-FLIP forces table update in the fixing
-  PR; .unsound = D-516 ASLR class, report-only).
-- **Phase III design ADR = ADR-0203** (D1 helper de-baking via JitRuntime
-  fields · D2 deserialize-into-CompiledWasm + normal setup, mini-runtime
-  retired · D3 format v0.5 completing the round-trip + two-tier gate ·
-  D4 elision serialization = D-515(1) · D5 `--cache` transparent cache ·
-  D6 six-stage migration with test-aot-diff ratchet table).
-- **NEXT: Phase IV stage 1** — helper de-baking, both arches (D-516 fix;
-  bench guard >2% blocks). Branch/PR per stage; `ci-required` gates each.
-  Kickoff PR #136 = Phase I docs + Phase II net + ADR-0203.
+- **Phases I–III DONE** (PR #136): findings doc =
+  `.dev/meta_audits/2026-07-09-aot-full-fidelity-investigation.md` (D-516
+  baked-address crash bug found by experiment · D-517 mini-runtime gaps ·
+  D-518 start-func skipped · ROI ~110ms/3MB); Phase II net =
+  `zig build test-aot-diff` (CROSS-PROCESS `.wasm`-vs-`.cwasm` subprocess
+  diff — in-process lanes can't see ASLR staleness; expectation table with
+  RATCHET-FLIP gate); design = **ADR-0203** (D1 de-baking · D2 deserialize-
+  into-CompiledWasm + normal setup · D3 format v0.5 + two-tier gate ·
+  D4 elision serialization · D5 `--cache` · D6 six-stage plan).
+- **Phase IV stage 1 DONE (develop/aot-stage1-debaking)** — all
+  36 baked helper sites → `[rt+off]` slot calls (14 JitRuntime tail fields,
+  defaults = real helpers, zero setup wiring). **D-516 CLOSED.** Verified:
+  pic_helper_test interposition red→green · test green · Rosetta
+  x86_64-macos green · fuzz-diff 0 mismatch · bench = user-CPU parity
+  (beware bg-job wall-clock contamination) · aot-diff unsound class now
+  EMPTY (gc_struct/eh_throw deterministic → .wrong_result under widened
+  D-517: mini-runtime grow/GC-arena/EH-tables gaps, discharged stage 3).
+- **NEXT: Phase IV stage 2** — format v0.5 + deserializer→CompiledWasm
+  (ADR-0203 D3+D2 first half). Kickoff PR #136 = Phase I+II+ADR-0203.
 
 ## Active front — G-senior-gap (2026-07-06, /continue entry point)
 

--- a/src/engine/codegen/arm64/op_call.zig
+++ b/src/engine/codegen/arm64/op_call.zig
@@ -311,11 +311,8 @@ fn emitCallIndirectSubtype(
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(table_idx)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(3, @intCast(expected_raw)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(0, 31, abi.runtime_ptr_save_gpr));
-    const addr: u64 = @intFromPtr(&jit_abi.jitCallIndirectResolve);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(16, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(16, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(16, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(16, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(16, abi.runtime_ptr_save_gpr, jit_abi.call_indirect_resolve_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(16));
 
     // X0 = funcptr | 0 (OOB / sig-subtype fail) | 1 (NULL_ELEM_SENTINEL).

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_copy.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_copy.zig
@@ -58,11 +58,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, _: *const zir.ZirInstr) ctx_mod.Error!void {
     // X0 = rt.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(0, 31, abi.runtime_ptr_save_gpr));
     // MOVZ/MOVK X16 = &jitGcArrayCopy; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayCopy);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_copy_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // W0: 1=ok, 0=OOB, 2=ARRAY_NULL_SENTINEL (D-293 array_oob). CMP #2 → null_reference (10);

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_fill.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_fill.zig
@@ -58,11 +58,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(typeidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(1, @intCast((typeidx >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcArrayFill; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayFill);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_fill_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // W0: 1=ok, 0=OOB, 2=ARRAY_NULL_SENTINEL (D-293 array_oob). CMP #2 → null_reference (10);

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_init_data.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_init_data.zig
@@ -64,11 +64,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(segidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(1, @intCast((segidx >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcArrayInitData; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayInitData);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_init_data_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // Trap on result == 0 (segment/array OOB; null caught inline above):

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_init_elem.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_init_elem.zig
@@ -60,11 +60,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(segidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(1, @intCast((segidx >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcArrayInitElem; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayInitElem);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_init_elem_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // Trap on result == 0 (segment/array OOB; null caught inline above):

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_new.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_new.zig
@@ -43,11 +43,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(typeidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(1, @intCast((typeidx >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcAllocArrayFill; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAllocArrayFill);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_array_fill_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // Capture W0 (GcRef) → result vreg.

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_new_data.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_new_data.zig
@@ -48,11 +48,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(2, @intCast(segidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(2, @intCast((segidx >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcArrayNewData; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayNewData);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_new_data_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // Trap on result == 0 (segment OOB): CMP W0,#0 ; B.EQ → oob_memory stub

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_new_default.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_new_default.zig
@@ -39,11 +39,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(typeidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(1, @intCast((typeidx >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcAllocArray; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAllocArray);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_array_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // Capture W0 (GcRef) → result vreg (mirror struct_new_default).

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_new_elem.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_new_elem.zig
@@ -50,11 +50,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(2, @intCast(segidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(2, @intCast((segidx >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcArrayNewElem; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayNewElem);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_new_elem_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // Trap on result == 0 (segment OOB): CMP W0,#0 ; B.EQ → oob_memory stub

--- a/src/engine/codegen/arm64/ops/wasm_3_0/array_new_fixed.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/array_new_fixed.zig
@@ -63,11 +63,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(0, 31, abi.runtime_ptr_save_gpr));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(typeidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(1, @intCast((typeidx >> 16) & 0xFFFF), 1));
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAllocArray);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(fn_scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(fn_scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(fn_scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(fn_scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(fn_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_array_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(fn_scratch));
 
     // W17 = zero-extended ref; element base X16 = slab + ref + 12 (slab

--- a/src/engine/codegen/arm64/ops/wasm_3_0/br_on_cast.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/br_on_cast.zig
@@ -55,11 +55,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(2, @intCast(arg2 & 0xFFFF)));
     if (arg2 >> 16 != 0) try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(2, @intCast((arg2 >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcRefTest; BLR X16 → W0 = 0/1.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcRefTest);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_ref_test_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // br_on_cast_fail: invert W0 = (W0 == 0) ? 1 : 0 so branchOnReg (which

--- a/src/engine/codegen/arm64/ops/wasm_3_0/ref_cast.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/ref_cast.zig
@@ -43,11 +43,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(2, @intCast(ht & 0xFFFF)));
     if (ht >> 16 != 0) try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(2, @intCast((ht >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcRefCast; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcRefCast);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_ref_cast_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // Trap on result == 0 (null / type mismatch): CMP X0,#0 ; B.EQ.

--- a/src/engine/codegen/arm64/ops/wasm_3_0/ref_cast_null.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/ref_cast_null.zig
@@ -53,11 +53,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     // W2 = ht (full 32-bit: MOVZ low half + MOVK high half).
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(2, @intCast(ht & 0xFFFF)));
     if (ht >> 16 != 0) try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(2, @intCast((ht >> 16) & 0xFFFF), 1));
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcRefCast);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_ref_cast_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encCmpImmX(0, 0));
     const fixup: u32 = @intCast(ctx.buf.items.len);

--- a/src/engine/codegen/arm64/ops/wasm_3_0/struct_new.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/struct_new.zig
@@ -55,11 +55,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(0, 31, abi.runtime_ptr_save_gpr));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(typeidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(1, @intCast((typeidx >> 16) & 0xFFFF), 1));
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAlloc);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(fn_scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(fn_scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(fn_scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(fn_scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(fn_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(fn_scratch));
 
     // W17 = zero-extended ref; object base X16 = slab + ref (slab base

--- a/src/engine/codegen/arm64/ops/wasm_3_0/struct_new_default.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/struct_new_default.zig
@@ -36,11 +36,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(1, @intCast(typeidx & 0xFFFF)));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(1, @intCast((typeidx >> 16) & 0xFFFF), 1));
     // MOVZ/MOVK X16 = &jitGcAlloc; BLR X16.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAlloc);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+    // ADR-0203 D1 — helper via the rt slot ([X19+off]), not a baked imm64 (D-516 PIC).
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_fn_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 
     // Capture W0 (GcRef) → result vreg (mirror op_table.emitTableGrow).

--- a/src/engine/codegen/arm64/ops/wasm_3_0/throw.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/throw.zig
@@ -44,7 +44,6 @@ const abi = @import("../../abi.zig");
 const gpr = @import("../../gpr.zig");
 const inst = @import("../../inst.zig");
 const jit_abi = @import("../../../shared/jit_abi.zig");
-const trampoline_mod = @import("../../../shared/throw_trampoline.zig");
 const zir = @import("../../../../../ir/zir.zig");
 
 pub const op_tag = meta.op_tag;
@@ -123,26 +122,17 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(0, tag_lo));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(0, tag_hi, 1));
 
-    const addr: u64 = @intFromPtr(&trampoline_mod.zwasmThrowTrampoline);
-    try emitTrampolineCallAndTrap(ctx, addr);
+    try emitTrampolineCallAndTrap(ctx, jit_abi.throw_trampoline_fn_off);
 }
 
 /// Shared emit for `throw` + `throw_ref` (`throw_ref` re-uses the
-/// same address-load + BLR + trap-stub-fallback shape this cycle;
-/// the two will diverge once exnref handling lands).
-pub fn emitTrampolineCallAndTrap(ctx: *ctx_mod.EmitCtx, trampoline_addr: u64) ctx_mod.Error!void {
-    // MOVZ X16, #(addr[0..16])
-    const w0: u16 = @intCast(trampoline_addr & 0xFFFF);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, w0));
-    // MOVK X16, #(addr[16..32]), LSL #16
-    const w1: u16 = @intCast((trampoline_addr >> 16) & 0xFFFF);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, w1, 1));
-    // MOVK X16, #(addr[32..48]), LSL #32
-    const w2: u16 = @intCast((trampoline_addr >> 32) & 0xFFFF);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, w2, 2));
-    // MOVK X16, #(addr[48..64]), LSL #48
-    const w3: u16 = @intCast((trampoline_addr >> 48) & 0xFFFF);
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, w3, 3));
+/// same slot-load + BLR + trap-stub-fallback shape this cycle; the
+/// two will diverge once exnref handling lands). The trampoline is
+/// reached through its `JitRuntime` slot (ADR-0203 D1 — never a
+/// baked imm64, the D-516 PIC invariant).
+pub fn emitTrampolineCallAndTrap(ctx: *ctx_mod.EmitCtx, trampoline_slot_off: u12) ctx_mod.Error!void {
+    // LDR X16, [X19, #slot]
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, trampoline_slot_off));
     // BLR X16 — call the trampoline. Returns here with trap_flag=1.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
     // B <trap_stub> — patched at function-end. D-292 C: route to the dedicated

--- a/src/engine/codegen/arm64/ops/wasm_3_0/throw_ref.zig
+++ b/src/engine/codegen/arm64/ops/wasm_3_0/throw_ref.zig
@@ -16,7 +16,6 @@ const abi = @import("../../abi.zig");
 const gpr = @import("../../gpr.zig");
 const inst = @import("../../inst.zig");
 const jit_abi = @import("../../../shared/jit_abi.zig");
-const trampoline_mod = @import("../../../shared/throw_trampoline.zig");
 const throw_op = @import("throw.zig");
 const zir = @import("../../../../../ir/zir.zig");
 
@@ -32,13 +31,11 @@ pub const is_safepoint: bool = false;
 /// X16 = IP0 (intra-procedure scratch, AAPCS64 §6.4 caller-saved).
 const scratch: inst.Xn = 16;
 
-/// MOVZ/MOVK X16 = abs addr; BLR X16 (a plain absolute call, no trap-stub
-/// fallback — `rethrowFromExnref` returns normally).
-fn emitAbsCall(ctx: *ctx_mod.EmitCtx, addr: u64) ctx_mod.Error!void {
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovzImm16(scratch, @intCast(addr & 0xFFFF)));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 16) & 0xFFFF), 1));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 32) & 0xFFFF), 2));
-    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encMovkImm16(scratch, @intCast((addr >> 48) & 0xFFFF), 3));
+/// LDR X16, [X19, #slot_off]; BLR X16 — call a helper through its
+/// `JitRuntime` slot (ADR-0203 D1: never a baked imm64, D-516 PIC). Plain
+/// call, no trap-stub fallback — `rethrowFromExnref` returns normally.
+fn emitSlotCall(ctx: *ctx_mod.EmitCtx, slot_off: u12) ctx_mod.Error!void {
+    try gpr.writeU32(ctx.allocator, ctx.buf, inst.encLdrImm(scratch, abi.runtime_ptr_save_gpr, slot_off));
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encBLR(scratch));
 }
 
@@ -54,6 +51,6 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     // (it only clobbers X16), so the dispatcher reads it as the throw-site
     // tag exactly like `throw`.
     try gpr.writeU32(ctx.allocator, ctx.buf, inst.encOrrReg(0, 31, abi.runtime_ptr_save_gpr));
-    try emitAbsCall(ctx, @intFromPtr(&jit_abi.rethrowFromExnref));
-    try throw_op.emitTrampolineCallAndTrap(ctx, @intFromPtr(&trampoline_mod.zwasmThrowTrampoline));
+    try emitSlotCall(ctx, jit_abi.rethrow_exnref_fn_off);
+    try throw_op.emitTrampolineCallAndTrap(ctx, jit_abi.throw_trampoline_fn_off);
 }

--- a/src/engine/codegen/shared/jit_abi.zig
+++ b/src/engine/codegen/shared/jit_abi.zig
@@ -577,6 +577,34 @@ pub const JitRuntime = extern struct {
     /// codegen `@offsetOf` unchanged. Null when the module has no host-func
     /// imports the bridge covers (WASI-only / no-import modules).
     host_payloads_base: ?[*]const usize = null,
+
+    // ADR-0203 D1 (D-516) — position-independence: Zig-helper entry points
+    // the JIT body calls, held as fn-pointer fields and reached via
+    // `[rt + offset]` (the `memory_grow_fn` pattern) instead of imm64
+    // addresses baked into emitted code. Baked addresses are the producing
+    // process's and die under per-exec ASLR when a `.cwasm` is reloaded —
+    // the field defaults below resolve in the RUNNING process (ordinary
+    // binary relocation), so every JitRuntime is correct without setup
+    // wiring and the emitted code bytes carry no absolute addresses.
+    // TRAILING — appended so existing codegen `@offsetOf` values are
+    // unchanged. All target functions take `rt` first and are
+    // self-contained, so the real helpers ARE the defaults.
+    call_indirect_resolve_fn: *const fn (rt: *JitRuntime, table_idx: u32, idx: u64, expected_typeidx: u32) callconv(.c) u64 = jitCallIndirectResolve,
+    gc_alloc_fn: *const fn (rt: *JitRuntime, typeidx: u32) callconv(.c) u32 = jitGcAlloc,
+    gc_alloc_array_fn: *const fn (rt: *JitRuntime, typeidx: u32, length: u32) callconv(.c) u32 = jitGcAllocArray,
+    gc_alloc_array_fill_fn: *const fn (rt: *JitRuntime, typeidx: u32, length: u32, init: u64) callconv(.c) u32 = jitGcAllocArrayFill,
+    gc_array_fill_fn: *const fn (rt: *JitRuntime, typeidx: u32, ref: u32, idx: u32, value: u64, count: u32) callconv(.c) u32 = jitGcArrayFill,
+    gc_array_copy_fn: *const fn (rt: *JitRuntime, dst_ref: u32, dst_off: u32, src_ref: u32, src_off: u32, len: u32) callconv(.c) u32 = jitGcArrayCopy,
+    gc_array_new_data_fn: *const fn (rt: *JitRuntime, typeidx: u32, segidx: u32, offset: u32, size: u32) callconv(.c) u32 = jitGcArrayNewData,
+    gc_array_new_elem_fn: *const fn (rt: *JitRuntime, typeidx: u32, segidx: u32, offset: u32, size: u32) callconv(.c) u32 = jitGcArrayNewElem,
+    gc_array_init_data_fn: *const fn (rt: *JitRuntime, segidx: u32, ref: u32, dst_off: u32, src_off: u32, len: u32) callconv(.c) u32 = jitGcArrayInitData,
+    gc_array_init_elem_fn: *const fn (rt: *JitRuntime, segidx: u32, ref: u32, dst_off: u32, src_off: u32, len: u32) callconv(.c) u32 = jitGcArrayInitElem,
+    gc_ref_test_fn: *const fn (rt: *JitRuntime, ref: u64, ht_nullbit: u32) callconv(.c) u32 = jitGcRefTest,
+    gc_ref_cast_fn: *const fn (rt: *JitRuntime, ref: u64, ht: u32) callconv(.c) u64 = jitGcRefCast,
+    rethrow_exnref_fn: *const fn (rt: *JitRuntime, exc_ptr: usize) callconv(.c) u32 = rethrowFromExnref,
+    /// The `throw`/`throw_ref` unwind entry (`callconv(.naked)`; reads its
+    /// arguments from the registers the op emit stages) — same D1 motive.
+    throw_trampoline_fn: *const fn () callconv(.naked) noreturn = @import("throw_trampoline.zig").zwasmThrowTrampoline,
 };
 
 /// Host-side context for `reifyExnref` (ADR-0120 D6 / D-327). Owns the
@@ -1437,6 +1465,22 @@ pub const trap_stub_entry_count_off: u12 = @offsetOf(JitRuntime, "trap_stub_entr
 /// reads ptr+count via `[X19/R15 + off]` to materialize
 /// `ExceptionTable` + `CodeMap` slices for `dispatchThrow`.
 pub const eh_table_entries_off: u12 = @offsetOf(JitRuntime, "eh_table_entries");
+// ADR-0203 D1 (D-516) — de-baked helper slots; X-form (8-byte fn pointers)
+// read via `LDR Xn, [X19, #off]` / `MOV rax, [R15 + off]` then BLR/CALL.
+pub const call_indirect_resolve_fn_off: u12 = @offsetOf(JitRuntime, "call_indirect_resolve_fn");
+pub const gc_alloc_fn_off: u12 = @offsetOf(JitRuntime, "gc_alloc_fn");
+pub const gc_alloc_array_fn_off: u12 = @offsetOf(JitRuntime, "gc_alloc_array_fn");
+pub const gc_alloc_array_fill_fn_off: u12 = @offsetOf(JitRuntime, "gc_alloc_array_fill_fn");
+pub const gc_array_fill_fn_off: u12 = @offsetOf(JitRuntime, "gc_array_fill_fn");
+pub const gc_array_copy_fn_off: u12 = @offsetOf(JitRuntime, "gc_array_copy_fn");
+pub const gc_array_new_data_fn_off: u12 = @offsetOf(JitRuntime, "gc_array_new_data_fn");
+pub const gc_array_new_elem_fn_off: u12 = @offsetOf(JitRuntime, "gc_array_new_elem_fn");
+pub const gc_array_init_data_fn_off: u12 = @offsetOf(JitRuntime, "gc_array_init_data_fn");
+pub const gc_array_init_elem_fn_off: u12 = @offsetOf(JitRuntime, "gc_array_init_elem_fn");
+pub const gc_ref_test_fn_off: u12 = @offsetOf(JitRuntime, "gc_ref_test_fn");
+pub const gc_ref_cast_fn_off: u12 = @offsetOf(JitRuntime, "gc_ref_cast_fn");
+pub const rethrow_exnref_fn_off: u12 = @offsetOf(JitRuntime, "rethrow_exnref_fn");
+pub const throw_trampoline_fn_off: u12 = @offsetOf(JitRuntime, "throw_trampoline_fn");
 pub const eh_table_count_off: u12 = @offsetOf(JitRuntime, "eh_table_count");
 pub const eh_code_map_entries_off: u12 = @offsetOf(JitRuntime, "eh_code_map_entries");
 pub const eh_code_map_count_off: u12 = @offsetOf(JitRuntime, "eh_code_map_count");
@@ -1613,6 +1657,17 @@ comptime {
     if ((gc_type_infos_ptr_off & 7) != 0) @compileError("gc_type_infos_ptr_off not 8-aligned");
     if (gc_heap_off > 32760) @compileError("gc_heap_off exceeds X-form imm12 budget");
     if (gc_type_infos_ptr_off > 32760) @compileError("gc_type_infos_ptr_off exceeds X-form imm12 budget");
+    // ADR-0203 D1 (D-516): de-baked helper slots — all X-form fn pointers.
+    for ([_]u12{
+        call_indirect_resolve_fn_off, gc_alloc_fn_off,          gc_alloc_array_fn_off,
+        gc_alloc_array_fill_fn_off,   gc_array_fill_fn_off,     gc_array_copy_fn_off,
+        gc_array_new_data_fn_off,     gc_array_new_elem_fn_off, gc_array_init_data_fn_off,
+        gc_array_init_elem_fn_off,    gc_ref_test_fn_off,       gc_ref_cast_fn_off,
+        rethrow_exnref_fn_off,        throw_trampoline_fn_off,
+    }) |off| {
+        if ((off & 7) != 0) @compileError("ADR-0203 helper fn slot not 8-aligned");
+        if (off > 32760) @compileError("ADR-0203 helper fn slot exceeds X-form imm12 budget");
+    }
 }
 
 // ============================================================
@@ -1633,7 +1688,7 @@ test "JitRuntime: layout offsets match documented prologue load sequence" {
     try testing.expectEqual(@as(u12, 80), jit_executed_flag_off);
 }
 
-test "JitRuntime: total size = 608 bytes" {
+test "JitRuntime: total size = 720 bytes" {
     // EH dispatcher fields appended
     // (+32 bytes = 2 ptrs × 8 B + 2 u32 × 4 B + 2 u32 pads × 4 B).
     // The handler-dispatch result fields
@@ -1656,7 +1711,8 @@ test "JitRuntime: total size = 608 bytes" {
     // `eh_thrown_tag_idx` (u32 +4) + `_pad_reify` (+4) → 568 + 24 = 592.
     // D-314(b) appends `store_table_elements_max` (u64 +8, trailing) → 592 + 8 = 600.
     // D-478 appends `host_payloads_base` (?[*]const usize +8 B, trailing) → 600 + 8 = 608.
-    try testing.expectEqual(@as(u32, 608), head_size);
+    // ADR-0203 D1 appends 14 de-baked helper fn slots (trailing) → 608 + 112 = 720.
+    try testing.expectEqual(@as(u32, 720), head_size);
 }
 
 test "jitGcAlloc: allocates struct{i32} via the *JitRuntime bridge" {

--- a/src/engine/codegen/x86_64/op_call.zig
+++ b/src/engine/codegen/x86_64/op_call.zig
@@ -497,8 +497,8 @@ pub fn emitCallIndirect(
         try buf.appendSlice(allocator, inst.encMovRR(.q, ag[0], abi.runtime_ptr_save_gpr).slice());
         try buf.appendSlice(allocator, inst.encMovImm32W(ag[1], table_idx).slice());
         try buf.appendSlice(allocator, inst.encMovImm32W(ag[3], expected_raw).slice());
-        const addr: u64 = @intFromPtr(&jit_abi.jitCallIndirectResolve);
-        try buf.appendSlice(allocator, inst.encMovImm64Q(.rax, addr).slice());
+        // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+        try buf.appendSlice(allocator, inst.encMovR64FromMemDisp32(.rax, abi.runtime_ptr_save_gpr, jit_abi.call_indirect_resolve_fn_off).slice());
         try buf.appendSlice(allocator, inst.encCallReg(.rax).slice());
         // RAX = funcptr | 0 (OOB/sig) | 1 (NULL_ELEM_SENTINEL). D-294 residual:
         // CMP RAX,1 ; JE → uninitialized_elem (code 13) FIRST, so a null elem under

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_copy.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_copy.zig
@@ -56,8 +56,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, _: *const zir.ZirInstr) ctx_mod.Error!void {
     // arg 0 = rt (R15) → arg_gprs[0] (RDI on SysV, RCX on Win64).
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     // MOVABS R10 = &jitGcArrayCopy; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayCopy);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_copy_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // EAX: 1=ok, 0=OOB, 2=ARRAY_NULL_SENTINEL (D-293 array_oob). CMP EAX,2 ; JE →

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_fill.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_fill.zig
@@ -59,8 +59,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], typeidx).slice());
     // MOVABS R10 = &jitGcArrayFill; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayFill);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_fill_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // EAX: 1=ok, 0=OOB, 2=ARRAY_NULL_SENTINEL (D-293 array_oob). CMP EAX,2 ; JE →

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_init_data.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_init_data.zig
@@ -66,8 +66,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], segidx).slice());
     // MOVABS R10 = &jitGcArrayInitData; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayInitData);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_init_data_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Trap on result == 0 (segment/array OOB; null already caught inline above):

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_init_elem.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_init_elem.zig
@@ -62,8 +62,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], segidx).slice());
     // MOVABS R10 = &jitGcArrayInitElem; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayInitElem);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_init_elem_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Trap on result == 0 (segment/array OOB; null caught inline above):

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_new.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_new.zig
@@ -35,8 +35,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], typeidx).slice());
     // MOVABS R10 = &jitGcAllocArrayFill; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAllocArrayFill);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_array_fill_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Capture EAX (GcRef) → result vreg.

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_new_data.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_new_data.zig
@@ -46,8 +46,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], typeidx).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[2], segidx).slice());
     // MOVABS R10 = &jitGcArrayNewData; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayNewData);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_new_data_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Trap on result == 0 (segment OOB): TEST EAX, EAX ; JE → oob_memory stub

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_new_default.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_new_default.zig
@@ -35,8 +35,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], typeidx).slice());
     // MOVABS R10 = &jitGcAllocArray; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAllocArray);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_array_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Capture EAX (GcRef) → result vreg (mirror struct_new_default).

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_new_elem.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_new_elem.zig
@@ -48,8 +48,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], typeidx).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[2], segidx).slice());
     // MOVABS R10 = &jitGcArrayNewElem; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcArrayNewElem);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_array_new_elem_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Trap on result == 0 (segment OOB): TEST EAX, EAX ; JE → oob_memory stub

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/array_new_fixed.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/array_new_fixed.zig
@@ -60,8 +60,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[2], n).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], typeidx).slice());
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAllocArray);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_array_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Object base R11 = slab + ref (slab base re-loaded post-call). MOV

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/br_on_cast.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/br_on_cast.zig
@@ -49,8 +49,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[2], arg2).slice());
     // MOVABS R10 = &jitGcRefTest; CALL R10 → EAX = 0/1.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcRefTest);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_ref_test_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // br_on_cast_fail: invert EAX = (EAX == 0) ? 1 : 0 so branchOnReg (branch

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/ref_cast.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/ref_cast.zig
@@ -42,8 +42,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[2], ht).slice());
     // MOVABS R10 = &jitGcRefCast; CALL R10.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcRefCast);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_ref_cast_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Trap on result == 0 (null / type mismatch): TEST RAX,RAX ; JE → trap.

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/ref_cast_null.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/ref_cast_null.zig
@@ -48,8 +48,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     if (xsrc != abi.current.arg_gprs[1]) try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[1], xsrc).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[2], ht).slice());
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcRefCast);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_ref_cast_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encTestRR(.q, .rax, .rax).slice());
     const fixup: u32 = @intCast(ctx.buf.items.len);

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/struct_new.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/struct_new.zig
@@ -52,8 +52,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     // Alloc: RDI = rt (R15), ESI = typeidx, CALL &jitGcAlloc → EAX = ref.
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], typeidx).slice());
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAlloc);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Object base R11 = slab + ref (slab base re-loaded post-call). MOV

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/struct_new_default.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/struct_new_default.zig
@@ -38,8 +38,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, abi.current.arg_gprs[0], abi.runtime_ptr_save_gpr).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(abi.current.arg_gprs[1], typeidx).slice());
     // Materialise &jitGcAlloc into R10 (emit scratch) and CALL it.
-    const addr: u64 = @intFromPtr(&jit_abi.jitGcAlloc);
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(call_scratch, addr).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(call_scratch, abi.runtime_ptr_save_gpr, jit_abi.gc_alloc_fn_off).slice());
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(call_scratch).slice());
 
     // Capture EAX (GcRef, i32) → fresh result vreg's home (mirror

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/throw.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/throw.zig
@@ -38,7 +38,6 @@ const abi = @import("../../abi.zig");
 const gpr = @import("../../gpr.zig");
 const inst = @import("../../inst.zig");
 const jit_abi = @import("../../../shared/jit_abi.zig");
-const trampoline_mod = @import("../../../shared/throw_trampoline.zig");
 const zir = @import("../../../../../ir/zir.zig");
 
 pub const op_tag = meta.op_tag;
@@ -92,16 +91,17 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
         inst.Gpr.rdi;
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm32W(first_arg_reg, tag_idx).slice());
 
-    const addr: u64 = @intFromPtr(&trampoline_mod.zwasmThrowTrampoline);
-    try emitTrampolineCallAndTrap(ctx, addr);
+    try emitTrampolineCallAndTrap(ctx, jit_abi.throw_trampoline_fn_off);
     ctx.dead_code.* = true;
 }
 
-/// Shared emit for `throw` + `throw_ref` (same shape for now;
-/// will diverge once exnref handling lands).
-pub fn emitTrampolineCallAndTrap(ctx: *ctx_mod.EmitCtx, trampoline_addr: u64) ctx_mod.Error!void {
-    // MOVABS R10, <trampoline_addr> — 10 bytes.
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(.r10, trampoline_addr).slice());
+/// Shared emit for `throw` + `throw_ref` (same shape for now; will
+/// diverge once exnref handling lands). The trampoline is reached
+/// through its `JitRuntime` slot (ADR-0203 D1 — never a baked
+/// imm64, the D-516 PIC invariant).
+pub fn emitTrampolineCallAndTrap(ctx: *ctx_mod.EmitCtx, trampoline_slot_off: u12) ctx_mod.Error!void {
+    // MOV R10, [R15 + slot] — 7-8 bytes.
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(.r10, abi.runtime_ptr_save_gpr, trampoline_slot_off).slice());
     // CALL R10 — 3 bytes (REX.B + FF /2).
     try ctx.buf.appendSlice(ctx.allocator, inst.encCallReg(.r10).slice());
     // JMP rel32 placeholder — 5 bytes; patched at function-end. D-292 C: route to

--- a/src/engine/codegen/x86_64/ops/wasm_3_0/throw_ref.zig
+++ b/src/engine/codegen/x86_64/ops/wasm_3_0/throw_ref.zig
@@ -18,7 +18,6 @@ const gpr = @import("../../gpr.zig");
 const inst = @import("../../inst.zig");
 const jit_abi = @import("../../../shared/jit_abi.zig");
 const op_call = @import("../../op_call.zig");
-const trampoline_mod = @import("../../../shared/throw_trampoline.zig");
 const throw_op = @import("throw.zig");
 const zir = @import("../../../../../ir/zir.zig");
 
@@ -42,7 +41,8 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     if (exn_reg != arg1) try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, arg1, exn_reg).slice());
     // arg0 = rt; CALL rethrowFromExnref → RAX = tag_idx, payload restored.
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.q, arg0, abi.runtime_ptr_save_gpr).slice());
-    try ctx.buf.appendSlice(ctx.allocator, inst.encMovImm64Q(.r10, @intFromPtr(&jit_abi.rethrowFromExnref)).slice());
+    // ADR-0203 D1 — helper via the rt slot ([R15+off]), not a baked imm64 (D-516 PIC).
+    try ctx.buf.appendSlice(ctx.allocator, inst.encMovR64FromMemDisp32(.r10, abi.runtime_ptr_save_gpr, jit_abi.rethrow_exnref_fn_off).slice());
     // Win64: rethrowFromExnref is a regular C-ABI fn that homes its reg args
     // to the 32-byte shadow space; reserve it (no-op on SysV / when the frame
     // already reserves outgoing space). D-327 Win64 fix.
@@ -53,6 +53,6 @@ pub fn emit(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) ctx_mod.Error!void 
     // first-arg reg as the throw-site tag indicator (mirror of throw.emit's
     // marshal). The trampoline call below only clobbers R10, so arg0 survives.
     try ctx.buf.appendSlice(ctx.allocator, inst.encMovRR(.d, arg0, abi.return_gpr).slice());
-    try throw_op.emitTrampolineCallAndTrap(ctx, @intFromPtr(&trampoline_mod.zwasmThrowTrampoline));
+    try throw_op.emitTrampolineCallAndTrap(ctx, jit_abi.throw_trampoline_fn_off);
     ctx.dead_code.* = true;
 }

--- a/src/engine/pic_helper_test.zig
+++ b/src/engine/pic_helper_test.zig
@@ -1,0 +1,117 @@
+//! ADR-0203 D1 (D-516) — position-independence of emitted code: the JIT
+//! body must reach Zig helpers through `JitRuntime` fn-pointer fields
+//! (`[rt + off]` loads, the `memory_grow_fn` pattern), never via imm64
+//! addresses baked at compile time. Interposition proof: swapping the
+//! field on a live instance must reroute the very next executed op — a
+//! baked address ignores the swap (and dies under per-exec ASLR when a
+//! `.cwasm` compiled by another process is loaded: the D-516 crash class,
+//! pinned cross-process by `test/aot/aot_process_diff.zig`).
+//! Discovered by the unit-test loader via `src/zwasm.zig`'s `test {}`.
+
+const std = @import("std");
+const testing = std.testing;
+
+const runner = @import("runner.zig");
+const JitInstance = runner.JitInstance;
+const jit_abi = @import("codegen/shared/jit_abi.zig");
+
+var interposed_gc_alloc_calls: u32 = 0;
+
+fn countingGcAlloc(rt: *jit_abi.JitRuntime, typeidx: u32) callconv(.c) u32 {
+    interposed_gc_alloc_calls += 1;
+    return jit_abi.jitGcAlloc(rt, typeidx);
+}
+
+test "JIT struct.new_default reaches jitGcAlloc via the rt field, not a baked address (ADR-0203 D1)" {
+    // (module (type (struct (field (mut i32))))
+    //   (func (export "f") (result i32) struct.new_default 0  ref.is_null))
+    // — the runner_gc_test A-2b-1 module (hand-encoded; wat2wasm predates GC).
+    const bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x09, 0x02, 0x5f, 0x01, 0x7f, 0x01, 0x60,
+        0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x01, 0x07,
+        0x05, 0x01, 0x01, 0x66, 0x00, 0x00, 0x0a, 0x08,
+        0x01, 0x06, 0x00, 0xfb, 0x01, 0x00, 0xd1, 0x0b,
+    };
+    var jit = try JitInstance.init(testing.allocator, &bytes);
+    defer jit.deinit(testing.allocator);
+
+    interposed_gc_alloc_calls = 0;
+    jit.owned.rt.gc_alloc_fn = countingGcAlloc;
+
+    const r = try jit.invoke(testing.allocator, "f", &.{});
+    try testing.expectEqual(@as(?u64, 0), r); // fresh struct is non-null → 0
+    // The emitted struct.new_default must have gone through the swapped
+    // field — 0 here means the code called a compile-time-baked address.
+    try testing.expect(interposed_gc_alloc_calls > 0);
+}
+
+fn helperSlotDefault(comptime field_name: []const u8) @FieldType(jit_abi.JitRuntime, field_name) {
+    inline for (std.meta.fields(jit_abi.JitRuntime)) |f| {
+        if (comptime std.mem.eql(u8, f.name, field_name)) {
+            const dv: *const @FieldType(jit_abi.JitRuntime, field_name) =
+                @ptrCast(@alignCast(f.default_value_ptr.?));
+            return dv.*;
+        }
+    }
+    unreachable;
+}
+
+test "JitRuntime helper-slot defaults point at the real helpers, all 14 (ADR-0203 D1)" {
+    // The defaults resolve in THIS process (ordinary binary relocation), so
+    // any JitRuntime — including one rebuilt by a future `.cwasm` loader —
+    // is correct without setup wiring. Exhaustive over every de-baked slot
+    // so a future field whose default drifts off its helper is caught.
+    try testing.expectEqual(&jit_abi.jitCallIndirectResolve, helperSlotDefault("call_indirect_resolve_fn"));
+    try testing.expectEqual(&jit_abi.jitGcAlloc, helperSlotDefault("gc_alloc_fn"));
+    try testing.expectEqual(&jit_abi.jitGcAllocArray, helperSlotDefault("gc_alloc_array_fn"));
+    try testing.expectEqual(&jit_abi.jitGcAllocArrayFill, helperSlotDefault("gc_alloc_array_fill_fn"));
+    try testing.expectEqual(&jit_abi.jitGcArrayFill, helperSlotDefault("gc_array_fill_fn"));
+    try testing.expectEqual(&jit_abi.jitGcArrayCopy, helperSlotDefault("gc_array_copy_fn"));
+    try testing.expectEqual(&jit_abi.jitGcArrayNewData, helperSlotDefault("gc_array_new_data_fn"));
+    try testing.expectEqual(&jit_abi.jitGcArrayNewElem, helperSlotDefault("gc_array_new_elem_fn"));
+    try testing.expectEqual(&jit_abi.jitGcArrayInitData, helperSlotDefault("gc_array_init_data_fn"));
+    try testing.expectEqual(&jit_abi.jitGcArrayInitElem, helperSlotDefault("gc_array_init_elem_fn"));
+    try testing.expectEqual(&jit_abi.jitGcRefTest, helperSlotDefault("gc_ref_test_fn"));
+    try testing.expectEqual(&jit_abi.jitGcRefCast, helperSlotDefault("gc_ref_cast_fn"));
+    try testing.expectEqual(&jit_abi.rethrowFromExnref, helperSlotDefault("rethrow_exnref_fn"));
+    try testing.expectEqual(&@import("codegen/shared/throw_trampoline.zig").zwasmThrowTrampoline, helperSlotDefault("throw_trampoline_fn"));
+}
+
+var interposed_gc_alloc_array_calls: u32 = 0;
+
+fn countingGcAllocArray(rt: *jit_abi.JitRuntime, typeidx: u32, length: u32) callconv(.c) u32 {
+    interposed_gc_alloc_array_calls += 1;
+    return jit_abi.jitGcAllocArray(rt, typeidx, length);
+}
+
+test "JIT array.new_default reaches jitGcAllocArray via the rt field (ADR-0203 D1)" {
+    // (module (type (array (mut i32)))
+    //   (func (export "f") (result i32)
+    //     i32.const 3  array.new_default 0  array.len))
+    // Second interposition family (alloc-array) — with the slot-defaults
+    // test above, a re-bake regression on any GC-alloc-family slot is
+    // caught by one of the two nets. array.new_default = fb 07; array.len
+    // = fb 0f. Hand-encoded (wat2wasm predates GC).
+    const bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type: [0]=array{i32 mut} (5e 7f 01), [1]=func ()->(i32)
+        0x01, 0x08, 0x02, 0x5e, 0x7f, 0x01, 0x60, 0x00,
+        0x01, 0x7f, 0x03, 0x02, 0x01, 0x01, 0x07, 0x05,
+        0x01, 0x01, 0x66, 0x00, 0x00,
+        // body: i32.const 3 [41 03], array.new_default 0 [fb 07 00],
+        // array.len [fb 0f], end — 8 bytes + locals byte.
+        0x0a, 0x0b, 0x01,
+        0x09, 0x00, 0x41, 0x03, 0xfb, 0x07, 0x00, 0xfb,
+        0x0f, 0x0b,
+    };
+    var jit = try JitInstance.init(testing.allocator, &bytes);
+    defer jit.deinit(testing.allocator);
+
+    interposed_gc_alloc_array_calls = 0;
+    jit.owned.rt.gc_alloc_array_fn = countingGcAllocArray;
+
+    const r = try jit.invoke(testing.allocator, "f", &.{});
+    try testing.expectEqual(@as(?u64, 3), r); // array.len of the 3-elem array
+    try testing.expect(interposed_gc_alloc_array_calls > 0);
+}

--- a/src/zwasm.zig
+++ b/src/zwasm.zig
@@ -369,6 +369,7 @@ test {
     _ = @import("engine/runner.zig");
     _ = @import("engine/runner_test.zig");
     _ = @import("engine/runner_gc_test.zig");
+    _ = @import("engine/pic_helper_test.zig");
     _ = @import("engine/runner_v128_jit_test.zig");
     _ = @import("engine/runner_multiarg_invoke_test.zig");
     _ = @import("engine/runner_trap_test.zig");

--- a/test/aot/aot_process_diff.zig
+++ b/test/aot/aot_process_diff.zig
@@ -52,8 +52,11 @@ const KnownEntry = struct { name: []const u8, exp: Expectation };
 // Keys are fixture basenames (unique across all driven corpora).
 const known_table = [_]KnownEntry{
     // Crafted corpus (test/aot/corpus/) — pinned by Phase I experiments.
-    .{ .name = "gc_struct.wasm", .exp = .{ .unsound = "D-516 baked jitGcAlloc address" } },
-    .{ .name = "eh_throw.wasm", .exp = .{ .unsound = "D-516 baked EH helper + unserialized EH tables" } },
+    // Post-ADR-0203-D1 de-baking these are DETERMINISTIC (the helper is
+    // reached via the rt slot; what remains is the mini-runtime's missing
+    // state, discharged by the stage-3 full-runtime load path):
+    .{ .name = "gc_struct.wasm", .exp = .{ .wrong_result = "D-517 mini-runtime has no GC arena (null gc_heap -> fatal signal)" } },
+    .{ .name = "eh_throw.wasm", .exp = .{ .wrong_result = "D-517 EH tables not serialized -> uncaught_exception instead of catch" } },
     .{ .name = "mem_grow.wasm", .exp = .{ .wrong_result = "D-517 memory.grow unsupported on the cwasm run path" } },
     .{ .name = "start_func.wasm", .exp = .{ .wrong_result = "D-518 start function not serialized (silently skipped)" } },
     // Realworld corpus — every Go runtime heap-grows at startup and every


### PR DESCRIPTION
## Summary

**AOT-full-fidelity campaign, Phase IV stage 1** (ADR-0203 D1). Every Zig-helper call the JIT body emits now goes through a `JitRuntime` fn-pointer field via `[rt + offset]` (the in-tree `memory_grow_fn` pattern; wazero's context-register model) instead of a `MOVZ/MOVK` / `movabs` imm64 baked at compile time. Baked addresses were the producing process's own and died under per-exec ASLR when a `.cwasm` was loaded in another process — the **D-516** class (GC/EH `.cwasm` = fatal signal), found and pinned cross-process by the Phase II differential (#136).

### Changes

- `jit_abi.zig`: 14 trailing `JitRuntime` fields (call_indirect resolve, the 11-helper GC alloc/array/cast family, rethrow_exnref, throw_trampoline). **Defaults = the real helpers**, so every construction site — including the AOT mini-runtime's `.{}`-based `minimalRuntime` — resolves them in its OWN address space with zero setup wiring. Offset consts + comptime 8-alignment/imm12-budget asserts; head-size test 608 → 720.
- 30 op sites (15/arch) mechanically converted: 5-instr imm64 materialize → 1 `LDR [X19+off]` (arm64) / `movabs` → `MOV r,[R15+off]` (x86_64). Code-size win at every site.
- throw/throw_ref (4 files): `emitTrampolineCallAndTrap`/`emitSlotCall` now take the slot offset; orphaned `trampoline_mod` imports removed.
- NEW `src/engine/pic_helper_test.zig`: interposition proofs (swap `rt.gc_alloc_fn` / `rt.gc_alloc_array_fn` on a live instance → the next struct.new_default / array.new_default routes through it; red before the conversion, green after) + an exhaustive all-14 slot-defaults check.
- `test/aot` expectation table TIGHTENED: the `.unsound` (ASLR-dependent) class is now **empty** — gc_struct (fatal on null `gc_heap`) and eh_throw (`uncaught_exception` instead of catch) are deterministic post-de-baking, reclassified `.wrong_result` under the widened D-517 (mini-runtime state gaps; discharged at stage 3).
- Debt: **D-516 closed**; D-517 widened (grow + GC-arena + EH-tables); **D-519 filed** (DA-critique finding: dbg-gated `jit.callcount`/`global.trace` bakes survive — closed by the stage-2 serialization gate).

### Verification

- `zig build test` green (interposition tests red→green across the conversion).
- Rosetta `-Dtarget=x86_64-macos` suite green (both-arch JIT-codegen rule).
- `fuzz-diff` 14 funcs / 0 mismatch; `test-aot-diff` 62 fixtures / 0 UNEXPECTED / 0 ratchet-flips.
- Bench A/B vs main: user-CPU parity on cpp_json/sha256/tinygo (ADR-0203 <2% hot-path guard met; wall-clock deltas were background-job contamination, re-measured quiet).
- Independent Devil's-Advocate critique (check #6): 16/20 → findings fixed in-commit (orphaned imports, stale test title, dangling SHA, test coverage) or filed (D-519); all focused hazards (scratch-register deltas, imm12 scaling, prologue order, extern-ABI, regex blast radius, throw hand-edits) verified CLEAR.

### Follow-ups (next stages per ADR-0203 D6)

Stage 2 = format v0.5 + deserialize-into-CompiledWasm (+ D-519 dbg-refusal gate) → stage 3 = full-runtime load path swap (mass ratchet flip) → stage 4 elision serialization → stage 5 `--cache`.