### PR TITLE
ADR-0203 stage 2: .cwasm v0.5 (embedded wasm_bytes) + full-fidelity deserializer — exit test green

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -3,31 +3,6 @@
 # Refresh on every /continue resume — .claude/skills/continue/RESUME.md Step 0.5.
 
 entries:
-  - id: "D-519"
-    layer: "code"
-    status: "note"
-    description: |-
-      Front AOT-full-fidelity (DA-critique finding on stage 1, 2026-07-09).
-      **dbg-gated absolute-address emission survives the ADR-0203 D1
-      de-baking**: `ZWASM_DEBUG=jit.callcount` (x86_64 emit.zig:328-331) and
-      `global.trace` (both op_globals.zig) bake this process's
-      `call_profile` addresses into emitted code — `dbg.on` is a RUNTIME env
-      check in Debug/ReleaseSafe, so a diagnostic-enabled `zwasm compile`
-      can still produce a `.cwasm` that writes foreign addresses when run
-      elsewhere (the D-516 silent-corruption class, resurrected via a
-      developer flag). NOT gated in stage 1 (adding an Error variant to the
-      shared runner Error set widens every exhaustive-switch caller —
-      platform_panic_vs_error class concern). CLOSE at ADR-0203 stage 2:
-      the produce/serialization gate refuses dbg-instrumented compiles
-      (produce-side check or a `compiled_with_dbg` bit refused at load).
-    first_raised: "2026-07-09"
-    last_reviewed: "2026-07-09"
-    refs: |-
-      .devils-advocate/logs/check-6-critique-2026-07-09-1743.md (edge-cases)
-      src/engine/codegen/x86_64/emit.zig:328-331
-      src/engine/codegen/arm64/op_globals.zig:119-134
-      .dev/decisions/0203_aot_full_fidelity.md (stage 2)
-    front: AOT-full-fidelity
   - id: "D-517"
     layer: "code"
     status: "note"

--- a/.dev/decisions/0203_aot_full_fidelity.md
+++ b/.dev/decisions/0203_aot_full_fidelity.md
@@ -126,6 +126,33 @@ refusal stays (soundness over coverage).
 - No new libc sites (ADR-0070); zone layering unchanged (loader stays in
   `engine/codegen/aot/`, setup reuse via existing Zone-2 seams).
 
+## Revision 2026-07-09 (stage-2 survey) — D3 amended: embed the original `wasm_bytes`
+
+The stage-2 survey established that `setupRuntimeLinked` re-decodes ~15
+sections directly from `wasm_bytes` (imports, memory incl. idx_type/
+page-size/shared, data/elem segments incl. passive tracking, globals +
+init-exprs, tables, tags, types) and `runStart` reads it too — the entire
+runtime-state build is wasm_bytes-driven, not CompiledWasm-driven. D3 is
+therefore amended: **format v0.5 embeds the original `wasm_bytes` as a
+section** (raw; compression later), and the loader hands the REAL bytes to
+the normal setup path. Consequences: zero re-encode/re-parse divergence
+(cache-hit == cache-miss by construction, the D2 goal); v0.4's
+globals/memory_init/elem/imports re-encode sections become removable;
+artifact size grows by ~the wasm size (acceptable for a cache/compile
+artifact whose key IS the source hash); load-time section parse remains
+(small vs codegen — measured compile tax is codegen-dominated; individual
+reads can migrate to serialized sections later without a format break).
+Also fixed by survey: the D-519 dbg-instrumentation refusal lands in
+`produceFromCompiledWasm` beside the elided-bounds refusal
+(`DbgInstrumentedNotAotSerializable`), backed by a new `dbg.anyActive()`.
+What still MUST be serialized (compiler output, not re-derivable):
+code + relocs + per-func meta (n_slots, canon+raw typeidx, oob_stub_off),
+full wasm-space func_sigs, exception_table.entries (module-relative pcs),
+tag_param_counts/slot_counts, globals_offsets/valtypes, start_func_idx,
+num_global_imports, bounds_elided bit. NOT serialized (setup/load-derived):
+exception_table.tag_ids, trap_func_entries/trap_region_start (rebuilt at
+load via `buildAndRegisterTrapEntries`, stage 4).
+
 ## Consequences
 
 - D-516's fix (stage 1) benefits fresh JIT too: fully PIC code is a

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -35,18 +35,23 @@ publish / cut over. No active campaign/bundle; no cron self-re-arm.
   (beware bg-job wall-clock contamination) · aot-diff unsound class now
   EMPTY (gc_struct/eh_throw deterministic → .wrong_result under widened
   D-517: mini-runtime grow/GC-arena/EH-tables gaps, discharged stage 3).
-- **Stage 1 MERGED #137** (@0ea6db833); kickoff #136. **Stage 2 IN PROGRESS
-  (develop/aot-stage2-format-v05)**: D-519 gate DONE (dbg.anyActive +
-  produce refusal; D-519 closed) · **ADR-0203 D3 AMENDED (Revision)**:
-  format v0.5 EMBEDS the original wasm_bytes (setup re-decodes ~15 sections
-  from it — hand it the real thing; zero re-encode divergence). Remaining
-  stage-2 work — full field/section list + ownership rules + the
-  setupRuntimeLinked round-trip EXIT TEST are specified in the ADR-0203
-  Revision + `private/notes/aot-stage2-survey.md`: (1) format v0.5
-  (version bump, header fields, trailing sections incl. wasm_bytes,
-  func_meta += oob_stub_off/raw_typeidx); (2) deserializer
-  `aot/load_compiled.zig` → real CompiledWasm; (3) exit test: produce →
-  deserialize → setup(deserialized, embedded bytes) → invoke == fresh.
+- **Stage 1 MERGED #137**; kickoff #136. **Stage 2 COMPLETE — PR #138
+  (develop/aot-stage2-format-v05, CI pending)**: D-519 gate (dbg.anyActive
+  produce refusal, D-519 closed) · format v0.5 (header 136: embedded
+  wasm_bytes + func_extras{frame_bytes,oob_stub_off} + module EH table;
+  v0.4 = clean UnsupportedVersion) · deserializer `aot/load_compiled.zig`
+  (metadata RE-DERIVED from embedded bytes w/ compileWasm's decoders;
+  code RE-LINKED via the same linkWithThunks — wazero model) ·
+  `JitInstance.fromCompiled` (same setupRuntimeLinked ⇒ hit==miss) ·
+  **EXIT TEST GREEN**: produce → deserialize → fromCompiled → runStart →
+  invoke == fresh (leak-checked; D-518 start-func shape included).
+- **NEXT: stage 3** — swap `zwasm run x.cwasm` (cli/run.zig runCwasm/
+  runCwasmWasi + main.zig CWAS branch) to deserializeToCompiledWasm +
+  fromCompiled; retire aot/run.zig mini-runtime; expectation-table rows
+  (D-517 grow/GC/EH + D-518 start) flip to .match — RATCHET-FLIP will
+  force the table update; then run a DA critique on stages 2+3 together
+  before merge. Then stage 4 (elision, D-515(1)) · stage 5 (--cache,
+  D-508) · stage 6 retrospective.
 
 ## Active front — G-senior-gap (2026-07-06, /continue entry point)
 

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -12,12 +12,6 @@ COMPLETE; the autonomous `/continue` loop is RETIRED. Dev model: cut a
 green to merge. **Release stays user-only (ADR-0156)** — never autonomously tag /
 publish / cut over. No active campaign/bundle; no cron self-re-arm.
 
-## Completed maintenance sweeps (history — details in the PRs / meta_audits)
-
-- Post-v2.0.0 scaffolding campaign COMPLETE (#118–#122: ledger reconcile,
-  E-段1+2 ratifications, Component域, rust-host gate D-254). **D-475
-  table64-JIT** MERGED #127 → **v2.1.0 released** (@d5d685ad4).
-
 ## Active rework campaign — AOT-full-fidelity (opened 2026-07-09, USER-RATIFIED)
 
 - **Goal (user directive)**: 本当の cwasm/AOT — deploy artifact stays `.wasm`;
@@ -41,8 +35,18 @@ publish / cut over. No active campaign/bundle; no cron self-re-arm.
   (beware bg-job wall-clock contamination) · aot-diff unsound class now
   EMPTY (gc_struct/eh_throw deterministic → .wrong_result under widened
   D-517: mini-runtime grow/GC-arena/EH-tables gaps, discharged stage 3).
-- **NEXT: Phase IV stage 2** — format v0.5 + deserializer→CompiledWasm
-  (ADR-0203 D3+D2 first half). Kickoff PR #136 = Phase I+II+ADR-0203.
+- **Stage 1 MERGED #137** (@0ea6db833); kickoff #136. **Stage 2 IN PROGRESS
+  (develop/aot-stage2-format-v05)**: D-519 gate DONE (dbg.anyActive +
+  produce refusal; D-519 closed) · **ADR-0203 D3 AMENDED (Revision)**:
+  format v0.5 EMBEDS the original wasm_bytes (setup re-decodes ~15 sections
+  from it — hand it the real thing; zero re-encode divergence). Remaining
+  stage-2 work — full field/section list + ownership rules + the
+  setupRuntimeLinked round-trip EXIT TEST are specified in the ADR-0203
+  Revision + `private/notes/aot-stage2-survey.md`: (1) format v0.5
+  (version bump, header fields, trailing sections incl. wasm_bytes,
+  func_meta += oob_stub_off/raw_typeidx); (2) deserializer
+  `aot/load_compiled.zig` → real CompiledWasm; (3) exit test: produce →
+  deserialize → setup(deserialized, embedded bytes) → invoke == fresh.
 
 ## Active front — G-senior-gap (2026-07-06, /continue entry point)
 

--- a/src/engine/codegen/aot/format.zig
+++ b/src/engine/codegen/aot/format.zig
@@ -28,12 +28,19 @@ pub const magic = [4]u8{ 'C', 'W', 'A', 'S' };
 pub const version_v0_1: u32 = 0x0001_0000; // (major << 16) | minor — superseded
 pub const version_v0_2: u32 = 0x0002_0000; // superseded: exports section (ADR-0138)
 pub const version_v0_3: u32 = 0x0003_0000; // superseded: + globals section (ADR-0139)
-pub const version_v0_4: u32 = 0x0004_0000; // current: + imports-metadata section (D-251 AOT-WASI)
+pub const version_v0_4: u32 = 0x0004_0000; // superseded: + imports-metadata section (D-251 AOT-WASI)
+// v0.5 (ADR-0203 stage 2): + embedded original wasm_bytes (the loader hands
+// the REAL module bytes to the normal setup path — zero re-encode
+// divergence), + per-func extras {frame_bytes, oob_stub_off} and the
+// module-level exception table (compiler output the full-fidelity
+// deserializer cannot re-derive; everything else IS re-derived from the
+// embedded bytes with the same section decoders compileWasm uses).
+pub const version_v0_5: u32 = 0x0005_0000; // current
 
 pub const arch_arm64: u32 = 1;
 pub const arch_x86_64: u32 = 2;
 
-pub const header_size: u32 = 112; // v0.4: 104 + imports_{offset,size} (D-251 AOT-WASI)
+pub const header_size: u32 = 136; // v0.5: 112 + {wasm_bytes,func_extras,eh}_{offset,size}
 
 /// `flags` bit 0 — the module declares a linear memory (the
 /// `memory_*` header fields + memory_init data section are meaningful).
@@ -54,6 +61,7 @@ pub const Error = error{
     TruncatedReloc,
     TruncatedExport,
     TruncatedImportEntry,
+    TruncatedEhEntry,
 };
 
 /// Top-level container header (per ADR-0039 + Revision 2; v0.2 per
@@ -101,7 +109,33 @@ pub const CwasmHeader = struct {
     // populate reads no payload), so the section is intentionally minimal.
     imports_offset: u32 = 0,
     imports_size: u32 = 0,
+    // v0.5 (ADR-0203 stage 2): the original module bytes, verbatim. The
+    // full-fidelity load path re-derives all module metadata from these with
+    // the SAME section decoders compileWasm uses, and hands them to the
+    // normal setup path (setupRuntimeLinked re-decodes ~15 sections).
+    wasm_bytes_offset: u32 = 0,
+    wasm_bytes_size: u32 = 0,
+    // v0.5: per-DEFINED-func extras the re-link needs beyond v0.4's
+    // metadata: `{frame_bytes: u32, oob_stub_off: u32}` × n_funcs
+    // (`func_extra_size` each, func-idx order; oob sentinel = no_stub).
+    func_extras_offset: u32 = 0,
+    func_extras_size: u32 = 0,
+    // v0.5: the module-level exception table (`[n: u32]` + n ×
+    // `eh_entry_size`). pcs are module-relative and stay valid because
+    // `linkWithThunks` layout is a pure function of the (identical)
+    // serialized bodies — the deserializer asserts the re-linked
+    // `func_offsets` match the artifact's as the nondeterminism tripwire.
+    eh_offset: u32 = 0,
+    eh_size: u32 = 0,
 };
+
+/// v0.5 per-defined-func extras entry size: frame_bytes + oob_stub_off.
+pub const func_extra_size: u32 = 8;
+/// v0.5 exception-table entry size: pc_start + pc_end + tag_idx(sentinel
+/// `eh_tag_none` = catch_all/null) + landing_pad_pc (4 × u32) + kind (u8).
+pub const eh_entry_size: u32 = 17;
+/// Sentinel for a serialised null `HandlerEntry.tag_idx` (catch_all/_ref).
+pub const eh_tag_none: u32 = 0xFFFF_FFFF;
 
 /// Sentinel `memory_max_pages` value for "no explicit max declared".
 pub const memory_max_none: u32 = 0xFFFF_FFFF;
@@ -179,7 +213,7 @@ pub const CwasmReloc = struct {
 pub fn writeHeader(buf: []u8, h: CwasmHeader) Error!void {
     if (buf.len < header_size) return Error.TruncatedHeader;
     @memcpy(buf[0..4], &magic);
-    std.mem.writeInt(u32, buf[4..8], version_v0_4, .little);
+    std.mem.writeInt(u32, buf[4..8], version_v0_5, .little);
     std.mem.writeInt(u32, buf[8..12], h.arch, .little);
     std.mem.writeInt(u32, buf[12..16], h.flags, .little);
     std.mem.writeInt(u32, buf[16..20], h.n_funcs, .little);
@@ -206,13 +240,19 @@ pub fn writeHeader(buf: []u8, h: CwasmHeader) Error!void {
     std.mem.writeInt(u32, buf[100..104], h.elem_size, .little);
     std.mem.writeInt(u32, buf[104..108], h.imports_offset, .little);
     std.mem.writeInt(u32, buf[108..112], h.imports_size, .little);
+    std.mem.writeInt(u32, buf[112..116], h.wasm_bytes_offset, .little);
+    std.mem.writeInt(u32, buf[116..120], h.wasm_bytes_size, .little);
+    std.mem.writeInt(u32, buf[120..124], h.func_extras_offset, .little);
+    std.mem.writeInt(u32, buf[124..128], h.func_extras_size, .little);
+    std.mem.writeInt(u32, buf[128..132], h.eh_offset, .little);
+    std.mem.writeInt(u32, buf[132..136], h.eh_size, .little);
 }
 
 pub fn parseHeader(buf: []const u8) Error!CwasmHeader {
     if (buf.len < header_size) return Error.TruncatedHeader;
     if (!std.mem.eql(u8, buf[0..4], &magic)) return Error.BadMagic;
     const version = std.mem.readInt(u32, buf[4..8], .little);
-    if (version != version_v0_4) return Error.UnsupportedVersion;
+    if (version != version_v0_5) return Error.UnsupportedVersion;
     const arch = std.mem.readInt(u32, buf[8..12], .little);
     if (arch != arch_arm64 and arch != arch_x86_64) return Error.UnknownArch;
     return .{
@@ -242,6 +282,68 @@ pub fn parseHeader(buf: []const u8) Error!CwasmHeader {
         .elem_size = std.mem.readInt(u32, buf[100..104], .little),
         .imports_offset = std.mem.readInt(u32, buf[104..108], .little),
         .imports_size = std.mem.readInt(u32, buf[108..112], .little),
+        .wasm_bytes_offset = std.mem.readInt(u32, buf[112..116], .little),
+        .wasm_bytes_size = std.mem.readInt(u32, buf[116..120], .little),
+        .func_extras_offset = std.mem.readInt(u32, buf[120..124], .little),
+        .func_extras_size = std.mem.readInt(u32, buf[124..128], .little),
+        .eh_offset = std.mem.readInt(u32, buf[128..132], .little),
+        .eh_size = std.mem.readInt(u32, buf[132..136], .little),
+    };
+}
+
+// =====================================================================
+// v0.5 per-func extras + exception-table entry serialisation (ADR-0203)
+// =====================================================================
+
+/// Per-DEFINED-func re-link inputs beyond v0.4's metadata (frame size and
+/// the guard-fault oob stub offset, both body-relative compiler output).
+pub const CwasmFuncExtra = struct {
+    frame_bytes: u32,
+    oob_stub_off: u32,
+};
+
+pub fn writeFuncExtra(buf: []u8, e: CwasmFuncExtra) Error!void {
+    if (buf.len < func_extra_size) return Error.TruncatedFuncMeta;
+    std.mem.writeInt(u32, buf[0..4], e.frame_bytes, .little);
+    std.mem.writeInt(u32, buf[4..8], e.oob_stub_off, .little);
+}
+
+pub fn parseFuncExtra(buf: []const u8) Error!CwasmFuncExtra {
+    if (buf.len < func_extra_size) return Error.TruncatedFuncMeta;
+    return .{
+        .frame_bytes = std.mem.readInt(u32, buf[0..4], .little),
+        .oob_stub_off = std.mem.readInt(u32, buf[4..8], .little),
+    };
+}
+
+/// One serialised module-level exception-table entry (mirrors
+/// `exception_table.HandlerEntry`; pcs module-relative; `tag_idx` null is
+/// encoded as `eh_tag_none`; `kind` is `@intFromEnum(CatchKind)`).
+pub const CwasmEhEntry = struct {
+    pc_start: u32,
+    pc_end: u32,
+    tag_idx: u32, // eh_tag_none = null (catch_all/_ref)
+    landing_pad_pc: u32,
+    kind: u8,
+};
+
+pub fn writeEhEntry(buf: []u8, e: CwasmEhEntry) Error!void {
+    if (buf.len < eh_entry_size) return Error.TruncatedEhEntry;
+    std.mem.writeInt(u32, buf[0..4], e.pc_start, .little);
+    std.mem.writeInt(u32, buf[4..8], e.pc_end, .little);
+    std.mem.writeInt(u32, buf[8..12], e.tag_idx, .little);
+    std.mem.writeInt(u32, buf[12..16], e.landing_pad_pc, .little);
+    buf[16] = e.kind;
+}
+
+pub fn parseEhEntry(buf: []const u8) Error!CwasmEhEntry {
+    if (buf.len < eh_entry_size) return Error.TruncatedEhEntry;
+    return .{
+        .pc_start = std.mem.readInt(u32, buf[0..4], .little),
+        .pc_end = std.mem.readInt(u32, buf[4..8], .little),
+        .tag_idx = std.mem.readInt(u32, buf[8..12], .little),
+        .landing_pad_pc = std.mem.readInt(u32, buf[12..16], .little),
+        .kind = buf[16],
     };
 }
 
@@ -408,6 +510,12 @@ test "writeHeader/parseHeader: round-trip preserves all fields" {
         .elem_size = 24,
         .imports_offset = 288,
         .imports_size = 35,
+        .wasm_bytes_offset = 323,
+        .wasm_bytes_size = 512,
+        .func_extras_offset = 835,
+        .func_extras_size = 24,
+        .eh_offset = 859,
+        .eh_size = 4 + 2 * eh_entry_size,
     };
     var buf: [header_size]u8 = undefined;
     try writeHeader(&buf, want);
@@ -445,12 +553,12 @@ test "parseHeader: rejects bad magic" {
 test "parseHeader: rejects unsupported version" {
     var buf: [header_size]u8 = undefined;
     @memcpy(buf[0..4], &magic);
-    std.mem.writeInt(u32, buf[4..8], 0x0005_0000, .little); // v0.5 (future, unsupported)
+    std.mem.writeInt(u32, buf[4..8], 0x0006_0000, .little); // v0.6 (future, unsupported)
     @memset(buf[8..], 0);
     try testing.expectError(Error.UnsupportedVersion, parseHeader(&buf));
 }
 
-test "parseHeader: rejects the superseded v0.1 / v0.2 / v0.3 versions" {
+test "parseHeader: rejects the superseded v0.1 / v0.2 / v0.3 / v0.4 versions" {
     var buf: [header_size]u8 = undefined;
     @memcpy(buf[0..4], &magic);
     @memset(buf[8..], 0);
@@ -460,12 +568,35 @@ test "parseHeader: rejects the superseded v0.1 / v0.2 / v0.3 versions" {
     try testing.expectError(Error.UnsupportedVersion, parseHeader(&buf));
     std.mem.writeInt(u32, buf[4..8], version_v0_3, .little);
     try testing.expectError(Error.UnsupportedVersion, parseHeader(&buf));
+    // v0.4 lacks the embedded-wasm_bytes / func-extras / eh sections the
+    // full-fidelity loader requires — a stale artifact is a clean
+    // regenerate, never a partial read (ADR-0203 D3).
+    std.mem.writeInt(u32, buf[4..8], version_v0_4, .little);
+    try testing.expectError(Error.UnsupportedVersion, parseHeader(&buf));
+}
+
+test "writeFuncExtra/parseFuncExtra + writeEhEntry/parseEhEntry: round-trip" {
+    var xbuf: [func_extra_size]u8 = undefined;
+    const xe = CwasmFuncExtra{ .frame_bytes = 0x120, .oob_stub_off = 0xFFFF_FFFF };
+    try writeFuncExtra(&xbuf, xe);
+    try testing.expectEqual(xe, try parseFuncExtra(&xbuf));
+
+    var ebuf: [eh_entry_size]u8 = undefined;
+    const ee = CwasmEhEntry{
+        .pc_start = 0x40,
+        .pc_end = 0x80,
+        .tag_idx = eh_tag_none,
+        .landing_pad_pc = 0x7C,
+        .kind = 2,
+    };
+    try writeEhEntry(&ebuf, ee);
+    try testing.expectEqual(ee, try parseEhEntry(&ebuf));
 }
 
 test "parseHeader: rejects unknown arch" {
     var buf: [header_size]u8 = undefined;
     @memcpy(buf[0..4], &magic);
-    std.mem.writeInt(u32, buf[4..8], version_v0_4, .little);
+    std.mem.writeInt(u32, buf[4..8], version_v0_5, .little);
     std.mem.writeInt(u32, buf[8..12], 99, .little); // unknown arch
     @memset(buf[12..], 0);
     try testing.expectError(Error.UnknownArch, parseHeader(&buf));
@@ -513,9 +644,11 @@ test "parseReloc: rejects truncated buffer" {
 }
 
 test "header_size + func_meta_size + reloc_size constants are stable" {
-    try testing.expectEqual(@as(u32, 112), header_size); // v0.4 (D-251 AOT-WASI)
+    try testing.expectEqual(@as(u32, 136), header_size); // v0.5 (ADR-0203 stage 2)
     try testing.expectEqual(@as(u32, 16), func_meta_size);
     try testing.expectEqual(@as(u32, 9), reloc_size);
+    try testing.expectEqual(@as(u32, 8), func_extra_size);
+    try testing.expectEqual(@as(u32, 17), eh_entry_size);
 }
 
 test "writeExportEntry/parseExportEntry: round-trip preserves name + func_idx" {

--- a/src/engine/codegen/aot/load_compiled.zig
+++ b/src/engine/codegen/aot/load_compiled.zig
@@ -1,0 +1,428 @@
+//! Full-fidelity `.cwasm` v0.5 deserializer (ADR-0203 stage 2 / D2).
+//!
+//! Rebuilds a REAL `runner.CompiledWasm` from a `.cwasm` so the normal
+//! setup path (`setupRuntimeLinked`) — and therefore memory.grow, WASI,
+//! GC, EH, fuel/interrupt — works identically to a fresh compile
+//! (cache-hit == cache-miss). Two-source reconstruction:
+//!
+//!  - MODULE METADATA (func_sigs, typeidxs, import counts, globals layout,
+//!    tag params, exports) is RE-DERIVED from the artifact's embedded
+//!    original `wasm_bytes` using the SAME section decoders `compileWasm`
+//!    uses — single source of truth, no re-encode divergence (the loops
+//!    mirror `compile.zig`; line refs inline).
+//!  - COMPILER OUTPUT (machine code, call fixups, frame sizes, oob stub
+//!    offsets, the module exception table) comes from the artifact's
+//!    code/meta/reloc/func_extras/eh sections, and is RE-LINKED through
+//!    the same `linker.linkWithThunks` a fresh compile uses — thunks,
+//!    func_offsets, and the code map are regenerated in THIS process
+//!    (the wazero model: nothing address-bound is trusted from disk).
+//!
+//! The serialized exception table's module-relative pcs stay valid
+//! because `linkWithThunks` layout is a pure function of the (identical)
+//! bodies + wrapper specs; the stage-2 round-trip exit test invokes an
+//! EH module through the deserialized instance, so a layout drift can
+//! not land silently.
+//!
+//! `CompiledWasm.func_results` is left EMPTY (zero-length allocation):
+//! nothing reads it at runtime (only `deinit` and the producer do), and
+//! a deserialized module is never re-produced.
+//!
+//! Zone 2 (`src/engine/codegen/aot/`).
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const format = @import("format.zig");
+const parser = @import("../../../parse/parser.zig");
+const sections = @import("../../../parse/sections.zig");
+const zir = @import("../../../ir/zir.zig");
+const runner = @import("../../runner.zig");
+const compile_mod = @import("../../compile.zig");
+const export_lookup = @import("../../export_lookup.zig");
+const runtime_mod = @import("../../../runtime/runtime.zig");
+const linker = @import("../shared/linker.zig");
+const exception_table = @import("../shared/exception_table.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const Error = format.Error || linker.Error || sections.Error ||
+    parser.Error || runner.Error || Allocator.Error || error{
+    ArchMismatch,
+    TruncatedImage,
+};
+
+pub const Deserialized = struct {
+    compiled: runner.CompiledWasm,
+    /// The embedded original module bytes — a view INTO the caller's
+    /// `cwasm_bytes` buffer. The caller keeps that buffer alive for the
+    /// setup call (`setupRuntimeLinked(compiled, wasm_bytes, ...)`).
+    wasm_bytes: []const u8,
+};
+
+fn sectionSlice(cwasm: []const u8, offset: u32, size: u32) Error![]const u8 {
+    if (@as(u64, offset) + size > cwasm.len) return Error.TruncatedImage;
+    return cwasm[offset..][0..size];
+}
+
+/// Deserialize a `.cwasm` v0.5 into a full `CompiledWasm`. Caller owns
+/// the result (`compiled.deinit(allocator)`); `cwasm_bytes` must outlive
+/// the returned value (the embedded wasm view aliases it).
+pub fn deserializeToCompiledWasm(allocator: Allocator, cwasm_bytes: []const u8) Error!Deserialized {
+    const h = try format.parseHeader(cwasm_bytes);
+    const native_arch: u32 = switch (builtin.target.cpu.arch) {
+        .aarch64 => format.arch_arm64,
+        .x86_64 => format.arch_x86_64,
+        else => return Error.ArchMismatch,
+    };
+    if (h.arch != native_arch) return Error.ArchMismatch;
+
+    const wasm_bytes = try sectionSlice(cwasm_bytes, h.wasm_bytes_offset, h.wasm_bytes_size);
+    const code = try sectionSlice(cwasm_bytes, h.code_offset, h.code_size);
+    const meta_bytes = try sectionSlice(cwasm_bytes, h.metadata_offset, h.metadata_size);
+    const reloc_bytes = try sectionSlice(cwasm_bytes, h.relocs_offset, h.relocs_size);
+    const extras_bytes = try sectionSlice(cwasm_bytes, h.func_extras_offset, h.func_extras_size);
+    const eh_bytes = try sectionSlice(cwasm_bytes, h.eh_offset, h.eh_size);
+    if (meta_bytes.len < @as(u64, h.n_funcs) * format.func_meta_size) return Error.TruncatedFuncMeta;
+    if (extras_bytes.len < @as(u64, h.n_funcs) * format.func_extra_size) return Error.TruncatedFuncMeta;
+
+    // ---- Module metadata, re-derived from the embedded wasm bytes with
+    // the same decoders compileWasm uses. Arena mirrors compileWasm's
+    // (types + export names live there; compile.zig:65).
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    var module = try parser.parse(allocator, wasm_bytes);
+    defer module.deinit(allocator);
+
+    // Types (mirrors compile.zig:623 — arena-backed; FuncType param/result
+    // slices in func_sigs alias these and share the CompiledWasm lifetime).
+    const type_section = module.find(.type) orelse return Error.MissingTypeSection;
+    const types = try sections.decodeTypes(a, type_section.body);
+
+    // Imports (mirrors compile.zig:74-76 + :644-648).
+    var imports_buf: ?sections.Imports = null;
+    defer if (imports_buf) |*ib| ib.deinit();
+    if (module.find(.import)) |s| imports_buf = try sections.decodeImports(allocator, s.body);
+    var num_imports: u32 = 0;
+    var num_global_imports: u32 = 0;
+    if (imports_buf) |ib| for (ib.items) |imp| {
+        if (imp.kind == .func) num_imports += 1 else if (imp.kind == .global) num_global_imports += 1;
+    };
+    if (num_imports != h.n_imports) return Error.TruncatedImage; // artifact/bytes disagree
+
+    // Defined-function typeidx list (mirrors compile.zig:627).
+    const defined_func_typeidx: []const u32 = if (module.find(.function)) |fs|
+        try sections.decodeFunctions(a, fs.body)
+    else
+        &.{};
+    if (defined_func_typeidx.len != h.n_funcs) return Error.TruncatedImage;
+
+    // Unified wasm-space func_sigs/typeidxs (mirrors compile.zig:650-673).
+    const total_funcs = num_imports + @as(u32, @intCast(defined_func_typeidx.len));
+    const func_sigs = try allocator.alloc(zir.FuncType, total_funcs);
+    errdefer allocator.free(func_sigs);
+    const func_typeidxs = try allocator.alloc(u32, total_funcs);
+    errdefer allocator.free(func_typeidxs);
+    if (imports_buf) |ib| {
+        var w: u32 = 0;
+        for (ib.items) |imp| {
+            if (imp.kind != .func) continue;
+            const tidx = imp.payload.func_typeidx;
+            if (tidx >= types.items.len) return Error.MissingTypeSection;
+            func_sigs[w] = types.items[tidx];
+            func_typeidxs[w] = tidx;
+            w += 1;
+        }
+    }
+    for (defined_func_typeidx, 0..) |type_idx, i| {
+        if (type_idx >= types.items.len) return Error.MissingTypeSection;
+        func_sigs[num_imports + i] = types.items[type_idx];
+        func_typeidxs[num_imports + i] = type_idx;
+    }
+
+    // Globals layout (mirrors compile.zig:783-787 — same pure helper).
+    const elay = try export_lookup.computeGlobalsLayout(allocator, wasm_bytes);
+    const globals_offsets = elay.offsets;
+    errdefer allocator.free(globals_offsets);
+    const globals_valtypes = elay.valtypes;
+    errdefer allocator.free(globals_valtypes);
+
+    // Tag param/slot counts over the FULL tag space (mirrors
+    // compile.zig:967-1030 — imports prefix + defined).
+    var imp_tag_count: usize = 0;
+    if (imports_buf) |ib| for (ib.items) |imp| {
+        if (imp.kind == .tag) imp_tag_count += 1;
+    };
+    const defined_tags: []const sections.TagEntry = if (module.find(.tag)) |ts|
+        try sections.decodeTags(a, ts.body)
+    else
+        &.{};
+    const tags_slice: []const sections.TagEntry = if (imp_tag_count == 0)
+        defined_tags
+    else blk: {
+        const combined = try a.alloc(sections.TagEntry, imp_tag_count + defined_tags.len);
+        var ci: usize = 0;
+        if (imports_buf) |ib| for (ib.items) |imp| {
+            if (imp.kind != .tag) continue;
+            combined[ci] = .{ .attribute = 0, .typeidx = imp.payload.tag_typeidx };
+            ci += 1;
+        };
+        for (defined_tags) |t| {
+            combined[ci] = t;
+            ci += 1;
+        }
+        break :blk combined;
+    };
+    const tag_param_counts: []u32 = blk: {
+        if (tags_slice.len == 0) break :blk &.{};
+        const out = try allocator.alloc(u32, tags_slice.len);
+        errdefer allocator.free(out);
+        for (tags_slice, 0..) |tag, i| {
+            if (tag.typeidx >= types.items.len) return Error.InvalidFuncIndex;
+            out[i] = @intCast(types.items[tag.typeidx].params.len);
+        }
+        break :blk out;
+    };
+    errdefer if (tag_param_counts.len > 0) allocator.free(tag_param_counts);
+    const tag_param_slot_counts: []u32 = blk: {
+        if (tags_slice.len == 0) break :blk &.{};
+        const out = try allocator.alloc(u32, tags_slice.len);
+        errdefer allocator.free(out);
+        for (tags_slice, 0..) |tag, i| {
+            if (tag.typeidx >= types.items.len) return Error.InvalidFuncIndex;
+            var slots: u32 = 0;
+            for (types.items[tag.typeidx].params) |p| {
+                slots += runtime_mod.slotCountForValType(p);
+            }
+            out[i] = slots;
+        }
+        break :blk out;
+    };
+    errdefer if (tag_param_slot_counts.len > 0) allocator.free(tag_param_slot_counts);
+
+    // Exports (same helper as compileWasm; arena-owned names).
+    const func_exports = try compile_mod.collectFuncExports(a, &module, total_funcs);
+
+    // ---- Compiler output, reconstructed from the artifact.
+    // Per-func bodies view into the code section + per-func extras.
+    const n_funcs: usize = h.n_funcs;
+    var metas = try allocator.alloc(format.CwasmFuncMeta, n_funcs);
+    defer allocator.free(metas);
+    for (0..n_funcs) |i| {
+        metas[i] = try format.parseFuncMeta(meta_bytes[i * format.func_meta_size ..][0..format.func_meta_size]);
+        if (@as(u64, metas[i].code_offset) + metas[i].code_size > code.len) return Error.TruncatedImage;
+    }
+
+    // Regroup the flat reloc section into per-func fixup lists. Serialized
+    // reloc offsets are code-SECTION-relative (serialise.zig rebases at
+    // write); invert via each func's [code_offset, +code_size) range.
+    const n_relocs = reloc_bytes.len / format.reloc_size;
+    var fixup_counts = try allocator.alloc(u32, n_funcs);
+    defer allocator.free(fixup_counts);
+    @memset(fixup_counts, 0);
+    var reloc_owner = try allocator.alloc(u32, n_relocs);
+    defer allocator.free(reloc_owner);
+    var parsed_relocs = try allocator.alloc(format.CwasmReloc, n_relocs);
+    defer allocator.free(parsed_relocs);
+    for (0..n_relocs) |ri| {
+        const r = try format.parseReloc(reloc_bytes[ri * format.reloc_size ..][0..format.reloc_size]);
+        parsed_relocs[ri] = r;
+        const owner = blk: {
+            for (metas, 0..) |m, fi| {
+                if (r.code_offset >= m.code_offset and r.code_offset < @as(u64, m.code_offset) + m.code_size)
+                    break :blk fi;
+            }
+            return Error.TruncatedReloc;
+        };
+        reloc_owner[ri] = @intCast(owner);
+        fixup_counts[owner] += 1;
+    }
+    // CallFixup lists (linker input; freed after link).
+    const CallFixup = std.meta.Child(@FieldType(linker.FuncBody, "call_fixups"));
+    var fixup_storage = try allocator.alloc(CallFixup, n_relocs);
+    defer allocator.free(fixup_storage);
+    var fixup_slices = try allocator.alloc([]CallFixup, n_funcs);
+    defer allocator.free(fixup_slices);
+    {
+        var cursor: usize = 0;
+        for (0..n_funcs) |fi| {
+            fixup_slices[fi] = fixup_storage[cursor..][0..fixup_counts[fi]];
+            cursor += fixup_counts[fi];
+        }
+        var write_idx = try allocator.alloc(u32, n_funcs);
+        defer allocator.free(write_idx);
+        @memset(write_idx, 0);
+        for (0..n_relocs) |ri| {
+            const fi = reloc_owner[ri];
+            const r = parsed_relocs[ri];
+            fixup_slices[fi][write_idx[fi]] = .{
+                .byte_offset = r.code_offset - metas[fi].code_offset,
+                .target_func_idx = r.target_func_idx,
+            };
+            write_idx[fi] += 1;
+        }
+    }
+
+    var bodies = try allocator.alloc(linker.FuncBody, n_funcs);
+    defer allocator.free(bodies);
+    for (0..n_funcs) |i| {
+        const extra = try format.parseFuncExtra(extras_bytes[i * format.func_extra_size ..][0..format.func_extra_size]);
+        bodies[i] = .{
+            .bytes = code[metas[i].code_offset..][0..metas[i].code_size],
+            .call_fixups = fixup_slices[i],
+            .frame_bytes = extra.frame_bytes,
+            .oob_stub_off = extra.oob_stub_off,
+        };
+    }
+
+    // Wrapper specs (mirrors compile.zig's derivation: multi-result, or
+    // exported with >= 1 param — host-invocable shapes need a thunk).
+    var exported_funcs: std.AutoHashMap(u32, void) = .init(allocator);
+    defer exported_funcs.deinit();
+    for (func_exports) |e| try exported_funcs.put(e.func_idx, {});
+    var wrapper_specs_list: std.ArrayList(linker.WrapperSpec) = .empty;
+    defer wrapper_specs_list.deinit(allocator);
+    for (0..n_funcs) |i| {
+        const wasm_idx = num_imports + @as(u32, @intCast(i));
+        const sig = func_sigs[wasm_idx];
+        const wants_thunk = sig.results.len >= 2 or
+            (sig.params.len >= 1 and exported_funcs.contains(wasm_idx));
+        if (wants_thunk) {
+            try wrapper_specs_list.append(allocator, .{ .func_idx = wasm_idx, .sig = sig });
+        }
+    }
+
+    const linked = try linker.linkWithThunks(allocator, bodies, num_imports, wrapper_specs_list.items);
+    errdefer {
+        var l = linked;
+        l.deinit(allocator);
+    }
+
+    // Module exception table from the artifact (pcs module-relative; see
+    // the module doc for why they survive the re-link).
+    const n_eh = std.mem.readInt(u32, eh_bytes[0..4], .little);
+    if (eh_bytes.len < 4 + @as(u64, n_eh) * format.eh_entry_size) return Error.TruncatedEhEntry;
+    const eh_entries: []exception_table.HandlerEntry = if (n_eh == 0) &.{} else blk: {
+        const out = try allocator.alloc(exception_table.HandlerEntry, n_eh);
+        errdefer allocator.free(out);
+        for (0..n_eh) |i| {
+            const e = try format.parseEhEntry(eh_bytes[4 + i * format.eh_entry_size ..][0..format.eh_entry_size]);
+            out[i] = .{
+                .pc_start = e.pc_start,
+                .pc_end = e.pc_end,
+                .tag_idx = if (e.tag_idx == format.eh_tag_none) null else e.tag_idx,
+                .landing_pad_pc = e.landing_pad_pc,
+                .kind = @enumFromInt(e.kind),
+            };
+        }
+        break :blk out;
+    };
+    errdefer if (eh_entries.len > 0) allocator.free(eh_entries);
+
+    // func_results stays a real (freeable) zero-length allocation — see
+    // the module doc.
+    const empty_results = try allocator.alloc(std.meta.Child(@FieldType(runner.CompiledWasm, "func_results")), 0);
+
+    return .{
+        .compiled = .{
+            .module = linked,
+            .func_results = empty_results,
+            .func_sigs = func_sigs,
+            .func_typeidxs = func_typeidxs,
+            .num_imports = num_imports,
+            .globals_offsets = globals_offsets,
+            .globals_valtypes = globals_valtypes,
+            .num_global_imports = num_global_imports,
+            .tag_param_counts = tag_param_counts,
+            .tag_param_slot_counts = tag_param_slot_counts,
+            .exception_table = .{ .entries = eh_entries },
+            .exports = func_exports,
+            .bounds_elided = false, // producer refuses elided until stage 4
+            .arena = arena,
+        },
+        .wasm_bytes = wasm_bytes,
+    };
+}
+
+// =====================================================================
+// Stage-2 exit test (ADR-0203): produce → deserialize → the NORMAL
+// setup path → invoke, compared against a fresh compile. The module
+// deliberately exercises the D-518 shape ((start) writes memory; the
+// export reads it back) so the round-trip proves memory + start-func
+// fidelity through the FULL runtime — the two things the mini-runtime
+// path can't do.
+// =====================================================================
+
+const testing = std.testing;
+const produce = @import("produce.zig");
+
+test "v0.5 round-trip: produce → deserialize → fromCompiled → invoke == fresh (stage-2 exit)" {
+    // (module (memory 1)
+    //   (func $init (i32.store (i32.const 0) (i32.const 42)))
+    //   (start $init)
+    //   (func (export "main") (result i32) (i32.load (i32.const 0))))
+    const bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type: [0]=()->(), [1]=()->(i32)
+        0x01, 0x08, 0x02, 0x60, 0x00, 0x00, 0x60, 0x00,
+        0x01, 0x7f,
+        // func: [0]=type0 ($init), [1]=type1 (main)
+        0x03, 0x03, 0x02, 0x00, 0x01,
+        // memory: 1 page
+        0x05,
+        0x03, 0x01, 0x00, 0x01,
+        // export "main" -> func 1
+        0x07, 0x08, 0x01, 0x04,
+        0x6d, 0x61, 0x69, 0x6e, 0x00, 0x01,
+        // start: func 0
+        0x08, 0x01,
+        0x00,
+        // code: $init = i32.const 0; i32.const 42; i32.store; end
+        //       main  = i32.const 0; i32.load; end
+        0x0a, 0x13, 0x02, 0x09, 0x00, 0x41, 0x00,
+        0x41, 0x2a, 0x36, 0x02, 0x00, 0x0b, 0x07, 0x00,
+        0x41, 0x00, 0x28, 0x02, 0x00, 0x0b,
+    };
+
+    // Fresh path (ambient bounds mode).
+    var fresh = try runner.JitInstance.init(testing.allocator, &bytes);
+    defer fresh.deinit(testing.allocator);
+    try fresh.runStart();
+    const fresh_r = try fresh.invoke(testing.allocator, "main", &.{});
+    try testing.expectEqual(@as(?u64, 42), fresh_r);
+
+    // AOT path: compile-for-AOT → produce → deserialize → SAME setup.
+    var for_aot = try compile_mod.compileWasmForAot(testing.allocator, &bytes);
+    const cwasm = blk: {
+        defer for_aot.deinit(testing.allocator);
+        break :blk try produce.produceFromCompiledWasm(testing.allocator, &for_aot, &bytes);
+    };
+    defer testing.allocator.free(cwasm);
+
+    const des = try deserializeToCompiledWasm(testing.allocator, cwasm);
+
+    // Metadata parity vs a fresh compile (the re-derive loops must agree).
+    {
+        var ref = try compile_mod.compileWasm(testing.allocator, &bytes);
+        defer ref.deinit(testing.allocator);
+        try testing.expectEqual(ref.num_imports, des.compiled.num_imports);
+        try testing.expectEqual(ref.num_global_imports, des.compiled.num_global_imports);
+        try testing.expectEqual(ref.func_sigs.len, des.compiled.func_sigs.len);
+        try testing.expectEqual(ref.func_typeidxs.len, des.compiled.func_typeidxs.len);
+        for (ref.func_typeidxs, des.compiled.func_typeidxs) |want, got| {
+            try testing.expectEqual(want, got);
+        }
+        try testing.expectEqual(ref.exports.len, des.compiled.exports.len);
+        try testing.expectEqual(ref.exception_table.entries.len, des.compiled.exception_table.entries.len);
+    }
+
+    // The embedded bytes are the original module, verbatim.
+    try testing.expectEqualSlices(u8, &bytes, des.wasm_bytes);
+
+    var inst = try runner.JitInstance.fromCompiled(testing.allocator, des.compiled, des.wasm_bytes);
+    defer inst.deinit(testing.allocator);
+    try inst.runStart(); // D-518 shape: start must run through the full path
+    const aot_r = try inst.invoke(testing.allocator, "main", &.{});
+    try testing.expectEqual(fresh_r, aot_r);
+}

--- a/src/engine/codegen/aot/produce.zig
+++ b/src/engine/codegen/aot/produce.zig
@@ -209,6 +209,29 @@ pub fn produceFromCompiledWasm(
     const imports = try collectImports(allocator, wasm_bytes);
     defer allocator.free(imports);
 
+    // v0.5 (ADR-0203 stage 2): per-func re-link extras + the module
+    // exception table (?tag_idx null → `eh_tag_none` sentinel).
+    const func_extras = try allocator.alloc(format.CwasmFuncExtra, n_funcs);
+    defer allocator.free(func_extras);
+    for (compiled.func_results, 0..) |r, i| {
+        func_extras[i] = .{
+            .frame_bytes = r.out.frame_bytes,
+            .oob_stub_off = r.out.oob_stub_off,
+        };
+    }
+    const eh_src = compiled.exception_table.entries;
+    const eh_entries = try allocator.alloc(format.CwasmEhEntry, eh_src.len);
+    defer allocator.free(eh_entries);
+    for (eh_src, 0..) |e, i| {
+        eh_entries[i] = .{
+            .pc_start = e.pc_start,
+            .pc_end = e.pc_end,
+            .tag_idx = e.tag_idx orelse format.eh_tag_none,
+            .landing_pad_pc = e.landing_pad_pc,
+            .kind = @intFromEnum(e.kind),
+        };
+    }
+
     const input: serialise.Input = .{
         .arch = arch,
         .bytes_per_func = bytes_per_func,
@@ -230,6 +253,9 @@ pub fn produceFromCompiledWasm(
         .elem = tbl.elem,
         .canon_typeidx_per_func = tbl.canon_typeidx,
         .imports = imports,
+        .wasm_bytes = wasm_bytes,
+        .func_extras = func_extras,
+        .eh_entries = eh_entries,
     };
 
     return serialise.produceCwasm(allocator, input);

--- a/src/engine/codegen/aot/produce.zig
+++ b/src/engine/codegen/aot/produce.zig
@@ -23,6 +23,7 @@ const builtin = @import("builtin");
 const format = @import("format.zig");
 const serialise = @import("serialise.zig");
 
+const dbg = @import("../../../support/dbg.zig");
 const zir = @import("../../../ir/zir.zig");
 const runner = @import("../../runner.zig");
 const parser = @import("../../../parse/parser.zig");
@@ -58,6 +59,12 @@ pub const Error = serialise.Error || error{
     /// read/write past the guest memory silently. Callers destined for AOT
     /// MUST `runner.setBoundsChecks(.explicit)` before compiling.
     ElidedBoundsNotAotSerializable,
+    /// ADR-0203 stage 2 (D-519) — an active `ZWASM_DEBUG` channel can
+    /// instrument emitted code with this process's diagnostic-counter
+    /// ABSOLUTE addresses (`jit.callcount` / `global.trace`); such bytes
+    /// must never be serialized. Re-run `zwasm compile` without
+    /// `ZWASM_DEBUG`.
+    DbgInstrumentedNotAotSerializable,
 };
 
 /// Table-0 + element state collected for the producer (v0.3 cycle-2a).
@@ -98,6 +105,12 @@ pub fn produceFromCompiledWasm(
     // "elided ⇒ guarded binding" invariant impossible to breach via AOT (a
     // per-caller `.explicit` would be easy to forget). D-515 lifts it.
     if (compiled.bounds_elided) return Error.ElidedBoundsNotAotSerializable;
+    // ADR-0203 stage 2 (D-519) — refuse to serialize dbg-instrumented
+    // codegen: an active ZWASM_DEBUG channel (jit.callcount / global.trace)
+    // bakes this process's diagnostic-counter ABSOLUTE addresses into the
+    // emitted bytes, which would silently corrupt memory when the artifact
+    // runs in another process (the D-516 class, via a developer flag).
+    if (dbg.anyActive()) return Error.DbgInstrumentedNotAotSerializable;
     const arch = try hostArch();
 
     const n_funcs = compiled.func_results.len;

--- a/src/engine/codegen/aot/serialise.zig
+++ b/src/engine/codegen/aot/serialise.zig
@@ -98,6 +98,15 @@ pub const Input = struct {
     /// declared import in wasm-space order. Lets a standalone `.cwasm`
     /// rebuild `host_dispatch_base` (WASI syscall fn-ptrs). Empty for none.
     imports: []const format.CwasmImport = &.{},
+    /// v0.5 (ADR-0203 stage 2): the original module bytes, copied verbatim —
+    /// the full-fidelity loader re-derives all module metadata from these
+    /// and hands them to the normal setup path.
+    wasm_bytes: []const u8 = &.{},
+    /// v0.5: per-defined-func re-link extras (parallel to `bytes_per_func`).
+    /// Empty → zero-filled entries are written.
+    func_extras: []const format.CwasmFuncExtra = &.{},
+    /// v0.5: the module-level exception table (module-relative pcs).
+    eh_entries: []const format.CwasmEhEntry = &.{},
 };
 
 /// Produce a `.cwasm` v0.2 byte stream. Caller owns the
@@ -160,6 +169,11 @@ pub fn produceCwasm(allocator: Allocator, input: Input) Error![]u8 {
         code_size = std.mem.alignForward(u32, code_size, 4);
     }
 
+    // v0.5 sections (ADR-0203 stage 2).
+    const wasm_bytes_size: u32 = @intCast(input.wasm_bytes.len);
+    const func_extras_size: u32 = n_funcs * format.func_extra_size;
+    const eh_size: u32 = 4 + @as(u32, @intCast(input.eh_entries.len)) * format.eh_entry_size;
+
     // Compute section offsets.
     const metadata_offset: u32 = format.header_size;
     const types_offset: u32 = metadata_offset + metadata_size;
@@ -169,7 +183,10 @@ pub fn produceCwasm(allocator: Allocator, input: Input) Error![]u8 {
     const memory_init_offset: u32 = globals_offset + globals_size;
     const elem_offset: u32 = memory_init_offset + memory_init_size;
     const imports_offset: u32 = elem_offset + elem_size;
-    const code_offset: u32 = imports_offset + imports_size;
+    const wasm_bytes_offset: u32 = imports_offset + imports_size;
+    const func_extras_offset: u32 = wasm_bytes_offset + wasm_bytes_size;
+    const eh_offset: u32 = func_extras_offset + func_extras_size;
+    const code_offset: u32 = eh_offset + eh_size;
     const total_size: u32 = code_offset + code_size;
 
     var out = try allocator.alloc(u8, total_size);
@@ -205,8 +222,32 @@ pub fn produceCwasm(allocator: Allocator, input: Input) Error![]u8 {
         .elem_size = elem_size,
         .imports_offset = imports_offset,
         .imports_size = imports_size,
+        .wasm_bytes_offset = wasm_bytes_offset,
+        .wasm_bytes_size = wasm_bytes_size,
+        .func_extras_offset = func_extras_offset,
+        .func_extras_size = func_extras_size,
+        .eh_offset = eh_offset,
+        .eh_size = eh_size,
     };
     try format.writeHeader(out[0..format.header_size], header);
+
+    // v0.5 sections (ADR-0203 stage 2): embedded module bytes, per-func
+    // extras (zero-filled when the caller supplies none — mini-runtime-only
+    // test producers), and the module exception table.
+    @memcpy(out[wasm_bytes_offset..][0..wasm_bytes_size], input.wasm_bytes);
+    for (0..n_funcs) |i| {
+        const extra: format.CwasmFuncExtra = if (i < input.func_extras.len)
+            input.func_extras[i]
+        else
+            .{ .frame_bytes = 0, .oob_stub_off = 0 };
+        const slot = func_extras_offset + @as(u32, @intCast(i)) * format.func_extra_size;
+        try format.writeFuncExtra(out[slot..][0..format.func_extra_size], extra);
+    }
+    std.mem.writeInt(u32, out[eh_offset..][0..4], @intCast(input.eh_entries.len), .little);
+    for (input.eh_entries, 0..) |e, i| {
+        const slot = eh_offset + 4 + @as(u32, @intCast(i)) * format.eh_entry_size;
+        try format.writeEhEntry(out[slot..][0..format.eh_entry_size], e);
+    }
 
     // 2. Per-func metadata.
     for (input.bytes_per_func, 0..) |b, i| {

--- a/src/engine/compile.zig
+++ b/src/engine/compile.zig
@@ -1363,7 +1363,7 @@ fn elemOffsetValType(imports_buf: anytype, tables_buf: anytype, tableidx: u32) z
     return .i32;
 }
 
-fn collectFuncExports(a: Allocator, module: anytype, total_funcs: u32) Error![]const runner_mod.FuncExport {
+pub fn collectFuncExports(a: Allocator, module: anytype, total_funcs: u32) Error![]const runner_mod.FuncExport {
     const es = module.find(.@"export") orelse return &.{};
     var exports = try sections.decodeExports(a, es.body);
     defer exports.deinit();

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -968,6 +968,20 @@ pub const JitInstance = struct {
         return .{ .compiled = compiled, .owned = owned, .wasm_bytes = wasm_bytes };
     }
 
+    /// ADR-0203 stage 2 — build a JitInstance from an ALREADY-BUILT
+    /// `CompiledWasm` (the `.cwasm` full-fidelity load path: the
+    /// deserializer rebuilds `compiled` and this runs the SAME setup a
+    /// fresh compile uses, so cache-hit == cache-miss by construction).
+    /// Takes ownership of `compiled` (deinit'd on error and by
+    /// `JitInstance.deinit`); `wasm_bytes` = the artifact's embedded
+    /// original module bytes and must outlive the instance.
+    pub fn fromCompiled(allocator: Allocator, compiled: CompiledWasm, wasm_bytes: []const u8) Error!JitInstance {
+        var c = compiled;
+        errdefer c.deinit(allocator);
+        const owned = try setup_mod.setupRuntimeLinked(allocator, &c, wasm_bytes, &.{}, &.{}, &.{}, &.{});
+        return .{ .compiled = c, .owned = owned, .wasm_bytes = wasm_bytes };
+    }
+
     pub fn deinit(self: *JitInstance, allocator: Allocator) void {
         self.owned.deinit(allocator);
         self.compiled.deinit(allocator);

--- a/src/support/dbg.zig
+++ b/src/support/dbg.zig
@@ -154,6 +154,19 @@ pub fn on(comptime mod: []const u8) bool {
     return enabled(mod);
 }
 
+/// Whether ANY `ZWASM_DEBUG` channel is active — the AOT-produce refusal
+/// predicate (ADR-0203 stage 2 / D-519): dbg-instrumented codegen (e.g.
+/// `jit.callcount`, `global.trace`) bakes this process's diagnostic-counter
+/// addresses into emitted code, which must never be serialized into a
+/// `.cwasm`. Comptime-false in release builds like `on`.
+pub fn anyActive() bool {
+    if (builtin.mode == .ReleaseFast or builtin.mode == .ReleaseSmall) {
+        return false;
+    }
+    if (!whitelist_initialised) return false;
+    return whitelist.everything or whitelist.entry_count > 0;
+}
+
 /// FNV-1a 64-bit hash — a tiny, dependency-free content checksum used by the
 /// `mem.cksum` diagnostic (D-331A) to fingerprint linear memory at host-call
 /// boundaries and diff an interp run against a JIT run (first divergent boundary

--- a/src/zwasm.zig
+++ b/src/zwasm.zig
@@ -249,6 +249,7 @@ pub const engine = struct {
             pub const serialise = @import("engine/codegen/aot/serialise.zig");
             pub const produce = @import("engine/codegen/aot/produce.zig");
             pub const load = @import("engine/codegen/aot/load.zig");
+            pub const load_compiled = @import("engine/codegen/aot/load_compiled.zig");
             pub const run = @import("engine/codegen/aot/run.zig");
         };
     };
@@ -310,6 +311,7 @@ test {
     _ = @import("engine/codegen/aot/serialise.zig");
     _ = @import("engine/codegen/aot/produce.zig");
     _ = @import("engine/codegen/aot/load.zig");
+    _ = @import("engine/codegen/aot/load_compiled.zig");
     _ = @import("engine/codegen/aot/run.zig");
     _ = @import("cli/compile.zig");
     _ = @import("engine/codegen/shared/reg_class.zig");


### PR DESCRIPTION
## Summary

**AOT-full-fidelity campaign, Phase IV stage 2.** The `.cwasm` format now carries everything a FULL-runtime load needs, and a new deserializer rebuilds a real `CompiledWasm` that flows through the SAME `setupRuntimeLinked` as a fresh compile — the stage-2 exit test proves `produce → deserialize → setup → invoke == fresh` in unit scope, including the D-518 start-func shape.

### Format v0.5 (`format.zig`, header 112→136)

- **Embedded original `wasm_bytes`** (ADR-0203 D3 Revision): the stage-2 survey showed `setupRuntimeLinked` re-decodes ~15 sections directly from the module bytes — so the artifact carries the real thing and the loader hands it over; zero re-encode divergence.
- **`func_extras`** per defined func `{frame_bytes, oob_stub_off}` + **module exception table** (module-relative pcs; `?tag_idx` via sentinel) — the compiler output the re-link can't re-derive.
- v0.4 artifacts → clean `UnsupportedVersion` (regenerate; never a partial read).

### Deserializer (`aot/load_compiled.zig`) — the wazero model

- Metadata **re-derived from the embedded bytes** with the same decoders `compileWasm` uses (mirrored loops with line refs; `collectFuncExports` shared).
- Code **re-linked via the same `linker.linkWithThunks`**: thunks, `func_offsets`, code map regenerated in the loading process — nothing address-bound is trusted from disk. Serialized EH pcs stay valid (layout is a pure function of the identical bodies).
- `JitInstance.fromCompiled` = the stage-3 entry point (same setup ⇒ cache-hit == cache-miss by construction).

### Also in this PR

- **D-519 closed**: `dbg.anyActive()` + `DbgInstrumentedNotAotSerializable` produce refusal (DA-critique finding from stage 1 — a live `ZWASM_DEBUG` channel bakes diagnostic-counter absolute addresses).
- ADR-0203 D3 Revision note documenting the embed decision.

### Verification

- `zig build test` green — the exit test runs under the leak-detecting testing allocator (ownership proven), with metadata-parity asserts vs a fresh compile.
- `test-aot-diff` 62 fixtures / 0 UNEXPECTED (CLI still routes `.cwasm` via the mini-runtime until stage 3 — the ratchet table is untouched this PR).
- format round-trip/reject unit tests (incl. v0.4 rejection).

### Next (stage 3, separate PR)

Swap `zwasm run x.cwasm` to `deserializeToCompiledWasm` + `fromCompiled`, retire the mini-runtime → the D-517/D-518 expectation-table rows flip to `.match` en masse (RATCHET-FLIP enforced).