### PR TITLE
feat(build): add -Dcompiler-rt option to bundle Zig compiler-rt into static library

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -94,6 +94,7 @@ pub fn build(b: *std.Build) void {
     // `enable_gc=false` is the additional source-level strip for
     // module-construction code paths.
     const enable_gc = b.option(bool, "gc", "Enable WasmGC heap+collector compile-in (default: false; per ADR-0115 §3)") orelse false;
+    const bundle_compiler_rt = b.option(bool, "compiler-rt", "Bundle Zig compiler-rt into the static library (default: false)") orelse false;
 
     // ADR-0193 — the Component Model + WASI-P2 host is gated by the WASI
     // tier, NOT a separate `-Dcomponent` flag (removed — it duplicated the
@@ -1110,6 +1111,7 @@ pub fn build(b: *std.Build) void {
         .linkage = .static,
         .root_module = core,
     });
+    c_api_lib.bundle_compiler_rt = bundle_compiler_rt;
 
     const c_host_mod = createSanitizedModule(b, sanitize_opts, .{
         .target = target,


### PR DESCRIPTION
## Summary

Add `-Dcompiler-rt` build option to control whether Zig's compiler-rt is bundled into the static library (`libzwasm.a`). When external linkers (rustc, gcc) link against `libzwasm.a`, they encounter undefined symbol errors (`___zig_probe_stack`, etc.) because Zig's compiler-rt is not included by default. Passing `-Dcompiler-rt=true` resolves this.

Usage: `zig build static-lib -Dcompiler-rt=true`

## Related

Closes #153

## Checklist

- [x] `zig build test-all` passes locally
- [x] `zig fmt src/` is clean
- [ ] Tests / fixtures added or updated for the change (if applicable)
- [ ] Docs updated (if user-facing behavior changed)
