### PR TITLE
chore(release): v2.4.0

### DIFF
--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -5,10 +5,12 @@
 
 ## Current state — MAINTENANCE MODE (post-v2.0.0)
 
-**v2.3.0 is the release line** (tag cut 2026-07-17, USER-GRANTED in-session
-per ADR-0156 — WASI-0.3.0-official sweep + system-clock + Homebrew tap
-`brew install clojurewasm/tap/zwasm`; v2.2.1 = 2026-07-16 binary-size line,
-v2.2.0 = 2026-07-09 AOT line). v1 frozen at `v1.11.1`. Dev model: cut
+**v2.4.0 is the release line** (tag cut 2026-08-03, USER-GRANTED in-session
+per ADR-0156 — external-consumer release: `-Dcompiler-rt` for non-Zig static
+linking (#154) + sub-3.0 GC-cohort DCE fix (#150, v1_0 `.text` −11.6%);
+cljw re-pinned to it. v2.3.0 = 2026-07-17 WASI-0.3.0 sweep + Homebrew tap
+`brew install clojurewasm/tap/zwasm`; v2.2.1 = binary-size line, v2.2.0 =
+AOT line). v1 frozen at `v1.11.1`. Dev model: cut
 a `develop/<slug>` branch from `main` → PR → CI `ci-required` 3-OS gate must be
 green to merge. **Release stays user-only (ADR-0156)** — never autonomously tag /
 publish / cut over. No active campaign; no cron self-re-arm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
 
 ## [Unreleased]
 
+_No changes yet._
+
+## [2.4.0] - 2026-08-03
+
+External-consumer release: static-library linking from non-Zig
+toolchains now works without a workaround, and sub-3.0 builds shed the
+GC code that had been leaking into them.
+
 ### Added
 
 - **`-Dcompiler-rt=true` for `zig build static-lib`** — bundles Zig's
@@ -29,6 +37,15 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
   link line now builds with `-Dcompiler-rt=true`, and
   `scripts/test_extlink.sh` asserts `compiler_rt.o` is in the archive
   and runs on the CI extended leg so the claim can no longer rot.
+
+- **Sub-3.0 builds no longer carry the WasmGC code path.** The
+  GC/subtyping JIT helpers are held as `JitRuntime` function-pointer
+  fields whose default is the real helper (ADR-0203 D1), and a field
+  default takes the address unconditionally — so the whole GC cohort
+  stayed live even in a `-Dwasm=1.0` build. Each helper body is now
+  comptime-guarded, letting DCE reclaim it: `-Dwasm=1.0 -Dwasi=p1`
+  `.text` drops 2,957,749 → 2,614,800 bytes (−11.6%). Wasm 3.0 builds
+  are unaffected (#150).
 
 ## [2.3.0] - 2026-07-17
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zwasm,
-    .version = "2.3.0",
+    .version = "2.4.0",
     .fingerprint = 0xfdac0191bf453d15,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{


### PR DESCRIPTION
Cuts **v2.4.0**. Two changes since v2.3.0 are things a downstream can act on:

| # | Change | Why it needs a tag |
|---|---|---|
| #154 | `-Dcompiler-rt` bundles Zig's compiler-rt into `libzwasm.a` | @jtakakura's zwasm-rust-sdk could not link `libzwasm.a` from rustc **at all** (#153). Until this carries a tag they have to pin a git SHA. |
| #150 | Sub-3.0 builds stop carrying the WasmGC cohort | `-Dwasm=1.0 -Dwasi=p1` `.text` 2,957,749 → 2,614,800 B (−11.6%) for size-sensitive embedders. Landed 2026-07-18, unreleased. |

## MINOR, not PATCH

`-Dcompiler-rt` is a new build-surface option — a CHANGELOG "Added" entry — rather than a repair of documented behaviour, so 2.3.0 → **2.4.0**. (The docs *claimed* no such flag was needed, but that claim was false; the flag is new surface either way.)

## Also in this PR

**#150 was never written into CHANGELOG.md.** It shipped to `main` on 2026-07-18 and the Unreleased section stayed at "_No changes yet._". Backfilled here rather than released silently — a −343 KB `.text` reduction is exactly the kind of thing an embedder reads release notes for.

## Changes

- `build.zig.zon` `.version` 2.3.0 → 2.4.0. The CLI reads its version from there — verified `zwasm --version` now prints `zwasm v2.4.0 (wasm: v3_0, wasi: p2, engine: both)`.
- `CHANGELOG.md` — `[2.4.0] - 2026-08-03` section; `[Unreleased]` reset; #150 backfilled under Fixed.
- `.dev/handover.md` — release line updated.

No other file in the tree hardcodes the version (grepped).

## After merge

Push the `v2.4.0` tag → `release.yml` cross-builds every target from the Linux runner and publishes the GitHub Release. Then re-pin ClojureWasm's `build.zig.zon`.