### PR TITLE
fix(wasi): cap a capture buffer — nothing else bounded guest output

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -3,6 +3,42 @@
 # Refresh on every /continue resume — .claude/skills/continue/RESUME.md Step 0.5.
 
 entries:
+  - id: "D-533"
+    layer: "code"
+    status: "resolved"
+    front: D-wasi
+    description: |-
+      **A capture buffer had no bound, and no other budget supplied one.** An
+      embedder that captures guest stdout/stderr (`runWasmCapturedFull`, the
+      WASI-P2/P3 test harnesses) handed zwasm an `ArrayList` that `fd_write`
+      appended to without limit. Fuel bounds INSTRUCTIONS, and bytes-per-
+      instruction is entirely the guest's choice, so fuel does not bound this.
+
+      MEASURED from the consumer side (ClojureWasm `wasm/run`, its D-349): a
+      25-line WASI guest looping on a 64-byte `fd_write` buffered exactly
+      64,000,000 bytes for 1,000,000 fuel — 64 bytes per unit of fuel. Under
+      zwasm's own default of 1e9 fuel that is ~64 GB of host memory before the
+      fuel trap fires. A 1e8-fuel run (~6.4 GB) had to be killed at 120 s.
+
+      FIX: `Host.max_capture_bytes` (`src/wasi/host.zig`) — null = unbounded,
+      which is what every existing caller had and still gets. Honoured at the
+      single append site in `writeSlice` (`src/wasi/fd.zig`): the prefix that
+      fits is KEPT and the errno is `.nospc`, the one a real fd gives when the
+      device is full, rather than a silent accept. `Host.capture_truncated`
+      lets the embedder report it; zwasm does not decide what truncation means
+      to the caller. Threaded through `cli.run.Limits.max_output_bytes` so a
+      captured run caps the same way it caps fuel and memory. The cap is PER
+      BUFFER, so capping both stdout and stderr bounds an embedder at 2x.
+      Regression: `fdWrite: max_capture_bytes bounds a capture buffer and
+      reports nospc` in `src/wasi/fd.zig` — covers the exact-fit, partial-fit,
+      no-room, and null-cap-is-unbounded cases.
+    refs: |-
+      src/wasi/host.zig (`max_capture_bytes` / `capture_truncated`);
+      src/wasi/fd.zig (`writeSlice` append site + the regression test);
+      src/cli/run.zig (`Limits.max_output_bytes`); ClojureWasm D-349 (the
+      consumer-side row this was measured from).
+    first_raised: "2026-08-04"
+    last_reviewed: "2026-08-04"
   - id: "D-527"
     layer: "code"
     status: "resolved"

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -38,6 +38,12 @@ pub const Limits = struct {
     /// (`--max-table-elements`); completes the JIT sandbox triad.
     max_table_elements: ?u64 = null,
     timeout_ms: ?u64 = null,
+    /// D-349 (found from cljw) — cap on each capture buffer. `null` = unbounded.
+    /// The other axes bound the guest's COMPUTE; this one bounds the host memory
+    /// the guest can make the runner hold, which nothing else does: fuel bounds
+    /// instructions and bytes-per-instruction is the guest's choice. Only
+    /// meaningful on a captured run; ignored when output goes to real stdio.
+    max_output_bytes: ?u64 = null,
     /// D-496 — engine for the C-API captured-run path. `.auto` (default) =
     /// JIT-preferring with interp fallback (the `.auto`→JIT flip); `.interp`
     /// forces interp (CLI `--engine interp`). `--engine jit` uses the dedicated
@@ -45,7 +51,7 @@ pub const Limits = struct {
     engine: @import("../api/instance.zig").EngineKind = .auto,
 
     pub fn any(self: Limits) bool {
-        return self.fuel != null or self.max_memory_bytes != null or self.max_table_elements != null or self.timeout_ms != null;
+        return self.fuel != null or self.max_memory_bytes != null or self.max_table_elements != null or self.timeout_ms != null or self.max_output_bytes != null;
     }
 };
 
@@ -131,6 +137,7 @@ pub fn runWasmJitCaptured(
     defer host.deinit();
     host.io = io;
     if (stdout_capture) |b| host.stdout_buffer = b;
+    host.max_capture_bytes = limits.max_output_bytes;
     // ADR-0179 #3a-4 — `--timeout` arms a timer on the io event loop that
     // raises the interrupt flag the JIT polls (prologue + back-edges).
     // ConcurrencyUnavailable surfaces loudly (a silent no-timeout run would

--- a/src/wasi/fd.zig
+++ b/src/wasi/fd.zig
@@ -163,7 +163,31 @@ pub fn writeSlice(host: *Host, fd: p1.Fd, bytes: []const u8) p1.Errno {
     else
         null;
 
-    if (buffer) |b| b.appendSlice(host.capture_alloc orelse host.alloc, bytes) catch return .nomem;
+    if (buffer) |b| {
+        // A capped capture reports `.nospc` rather than silently accepting the
+        // write: the guest asked to write N bytes and fewer were kept, and
+        // "no space left on device" is the errno a real fd would give. Report
+        // it AFTER keeping what fits, so the caller sees a prefix rather than
+        // losing the tail of the last useful line.
+        var to_write = bytes;
+        var capped = false;
+        if (host.max_capture_bytes) |cap| {
+            if (b.items.len >= cap) {
+                host.capture_truncated = true;
+                return .nospc;
+            }
+            const room = cap - b.items.len;
+            if (bytes.len > room) {
+                to_write = bytes[0..@intCast(room)];
+                capped = true;
+            }
+        }
+        b.appendSlice(host.capture_alloc orelse host.alloc, to_write) catch return .nomem;
+        if (capped) {
+            host.capture_truncated = true;
+            return .nospc;
+        }
+    }
     if (file_opt) |f| {
         // Positional write at the slot's logical cursor + advance (mirrors
         // fdReadFile; std.Io.File is positional-only).
@@ -1744,4 +1768,50 @@ test "pathUnlinkFile: non-preopen dirfd is notdir; bad fd is badf; .. escape is 
     // a `..` traversal is rejected before any fd work.
     @memcpy(mem[0..3], "../");
     try testing.expectEqual(p1.Errno.notcapable, pathUnlinkFile(&h, &mem, 1, 0, 3));
+}
+
+test "fdWrite: max_capture_bytes bounds a capture buffer and reports nospc" {
+    // D-349, found from cljw. Nothing else bounds a capture buffer: fuel bounds
+    // instructions, and bytes-per-instruction is the guest's choice. Measured
+    // from the consumer side, a 64-byte-per-iteration guest buffered 64 MB per
+    // 1e6 fuel — so ~64 GB under zwasm's own default fuel.
+    var h = try Host.init(testing.allocator);
+    defer h.deinit();
+    var capture: std.ArrayList(u8) = .empty;
+    defer capture.deinit(testing.allocator);
+    h.stdout_buffer = &capture;
+    h.max_capture_bytes = 5;
+
+    var mem: [32]u8 = @splat(0);
+    @memcpy(mem[8..12], "abcd");
+    std.mem.writeInt(u32, mem[0..4], 8, .little); // ciovec.buf
+    std.mem.writeInt(u32, mem[4..8], 4, .little); // ciovec.len = 4
+
+    // First write fits entirely.
+    try testing.expectEqual(p1.Errno.success, fdWrite(&h, &mem, 1, 0, 1, 16));
+    try testing.expectEqualStrings("abcd", capture.items);
+    try testing.expect(!h.capture_truncated);
+
+    // Second write has room for one byte: the prefix is KEPT (a caller is
+    // better served by a truncated tail than by losing the whole write) and the
+    // errno is nospc, the one a real fd gives when the device is full.
+    try testing.expectEqual(p1.Errno.nospc, fdWrite(&h, &mem, 1, 0, 1, 16));
+    try testing.expectEqualStrings("abcda", capture.items);
+    try testing.expect(h.capture_truncated);
+
+    // Third write has no room at all — still nospc, and nothing grows.
+    try testing.expectEqual(p1.Errno.nospc, fdWrite(&h, &mem, 1, 0, 1, 16));
+    try testing.expectEqual(@as(usize, 5), capture.items.len);
+
+    // A null cap is the default and is unbounded — the behaviour every existing
+    // caller had before this axis existed.
+    var h2 = try Host.init(testing.allocator);
+    defer h2.deinit();
+    var cap2: std.ArrayList(u8) = .empty;
+    defer cap2.deinit(testing.allocator);
+    h2.stdout_buffer = &cap2;
+    var i: usize = 0;
+    while (i < 10) : (i += 1) try testing.expectEqual(p1.Errno.success, fdWrite(&h2, &mem, 1, 0, 1, 16));
+    try testing.expectEqual(@as(usize, 40), cap2.items.len);
+    try testing.expect(!h2.capture_truncated);
 }

--- a/src/wasi/host.zig
+++ b/src/wasi/host.zig
@@ -131,6 +131,24 @@ pub const Host = struct {
     /// will free / `toOwnedSlice` them with, so the buffer's grow-allocator and
     /// the caller's free-allocator agree (no cross-allocator invalid-free).
     capture_alloc: ?Allocator = null,
+    /// Cap on how many bytes each capture buffer may accumulate. `null` =
+    /// unbounded, which is what every caller got before this existed and what
+    /// they still get by default.
+    ///
+    /// Capture buffers hold GUEST-CHOSEN volumes of data in HOST memory, and no
+    /// other budget bounds them: fuel bounds instructions, and bytes-per-
+    /// instruction is entirely the guest's choice. Measured from cljw
+    /// (`wasm/run`, its D-349): a guest looping on a 64-byte `fd_write` buffered
+    /// 64,000,000 bytes for 1,000,000 fuel — 64 bytes per unit — so under
+    /// zwasm's own 1e9 default fuel the host would buffer ~64 GB before the fuel
+    /// trap fired.
+    ///
+    /// The cap is PER BUFFER, so an embedder capping both stdout and stderr
+    /// bounds itself at 2x this number.
+    max_capture_bytes: ?u64 = null,
+    /// Set once a capture buffer hit `max_capture_bytes`. The embedder reports
+    /// it; zwasm does not decide what a truncated capture means to the caller.
+    capture_truncated: bool = false,
     /// Optional source of bytes for `fd_read` over fd 0 (stdin).
     /// Tests set both; `stdin_pos` is mutated as the guest reads.
     stdin_bytes: ?[]const u8 = null,


### PR DESCRIPTION
A capture buffer had no bound, and no other budget supplied one. Fuel bounds
INSTRUCTIONS; bytes-per-instruction is entirely the guest's choice.

**Measured** from the consumer side (ClojureWasm `wasm/run`, its D-349): a
25-line WASI guest looping on a 64-byte `fd_write` buffered exactly
**64,000,000 bytes for 1,000,000 fuel** — 64 bytes per unit. Under zwasm's own
1e9 default that is **~64 GB** of host memory before the fuel trap fires. A
1e8-fuel run (~6.4 GB) had to be killed at 120 s.

So an embedder capturing output from an untrusted guest had a straightforward
memory-exhaustion vector, and the two budgets that look like they cover it do
not.

## The fix

- `Host.max_capture_bytes` — `null` = unbounded, which is what every existing
  caller had and still gets.
- Honoured at the single append site in `writeSlice` (`src/wasi/fd.zig`): the
  prefix that fits is **kept** and the errno is `.nospc`, the one a real fd
  gives when the device is full. Keeping the prefix serves a caller better than
  losing the whole write; returning `.nospc` rather than success avoids telling
  the guest bytes were written when they were dropped.
- `Host.capture_truncated` lets the embedder report it. zwasm does not decide
  what truncation means to the caller.
- `cli.run.Limits.max_output_bytes` threads it through the captured-run path,
  so an embedder caps output the same way it caps fuel and memory. The cap is
  **per buffer**, so capping both stdout and stderr bounds an embedder at 2x.

## Verification

`fdWrite: max_capture_bytes bounds a capture buffer and reports nospc` covers
exact-fit, partial-fit (prefix kept, `.nospc` returned), no-room, and
null-cap-is-unbounded. `zig build test` green; `zig fmt` clean.

Tracked as D-533. Consumer side is ClojureWasm D-349, which stays open until
this lands and cljw passes a finite default.