### PR TITLE
fix(ci): the release workflow could not upload to a release that already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,14 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         shell: bash
         run: |
-          gh release create "$TAG_NAME" \
-            --title "$TAG_NAME" \
-            --generate-notes \
-            dist/*.tar.gz dist/*.zip dist/SHA256SUMS
+          # Idempotent: the release may already exist because a maintainer cut
+          # it by hand right after pushing the tag (ADR-0156 makes releasing a
+          # deliberate human act, so that ordering is normal, not a mistake).
+          # An unconditional `create` fails with "a release with the same tag
+          # name already exists" and takes the ARTIFACT UPLOAD down with it —
+          # the tag then has hand-written notes and no binaries, which is worse
+          # than either half alone. Happened on v2.4.1.
+          gh release view "$TAG_NAME" >/dev/null 2>&1 \
+            || gh release create "$TAG_NAME" --title "$TAG_NAME" --generate-notes
+          gh release upload "$TAG_NAME" \
+            dist/*.tar.gz dist/*.zip dist/SHA256SUMS --clobber


### PR DESCRIPTION
Releasing is a deliberate human act here (ADR-0156), so cutting the release by hand right after pushing the tag is a **normal** ordering. When that happens the workflow's `gh release create` fails with `a release with the same tag name already exists` — and takes the **artifact upload** down with it, because they were the same command. The tag ends up with hand-written notes and no binaries.

That happened on **v2.4.1**: the artifacts built and were then discarded.

cljw's release workflow has always been `view || create` then `upload --clobber`; this one was an unconditional `create`, and nothing compared the two. Same shape as the other findings this cycle — two paths to the same outcome, only one hardened.

Now: view-or-create, then `upload --clobber` as a separate step, so re-running on an existing release is a no-op that refreshes the assets.