### PR TITLE
fix(api): 81 declared C-API symbols were missing from libzwasm.a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,25 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
 
 ## [Unreleased]
 
-_No changes yet._
+### Fixed
+
+- **81 declared C-API symbols were missing from `libzwasm.a`** (#161). Zig only
+  emits `export fn` symbols from files the analysis pass visits, and four
+  `src/api/` files (`ref_base.zig`, `config.zig`, `host_info.zig`,
+  `module_serialize.zig`) were absent from the `src/zwasm.zig` comptime
+  force-analyse block — their lazy `pub const` re-exports through `api/wasm.zig`
+  never trigger analysis. Every `wasm_X_copy` / `wasm_X_same` / `wasm_X_as_ref` /
+  `wasm_ref_as_X` / `wasm_X_{get,set}_host_info` / `wasm_config_*` /
+  `wasm_module_serialize`-family call declared in `include/wasm.h` failed at
+  link time. `ref_base.zig` additionally did not compile (`wasm_extern_copy`
+  nulled a field `Extern` does not have) — unnoticed precisely because the file
+  was never analysed; its 6 tests (plus 5 more from the other three files) now
+  run under `zig build test`. Three guards close the class: commit-time
+  `scripts/check_api_export_analysis.sh` (every `pub export fn` file listed in
+  the comptime block), plus two archive assertions in `scripts/test_extlink.sh`
+  (every `src/api/` `pub export fn`, and every installed-header declaration,
+  present in `libzwasm.a`). Verified end-to-end from C, Rust, and Go (cgo)
+  consumers over the system linker.
 
 ## [2.4.1] - 2026-08-04
 

--- a/scripts/check_api_export_analysis.sh
+++ b/scripts/check_api_export_analysis.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# scripts/check_api_export_analysis.sh — every src/api/*.zig that carries a
+# `pub export fn` MUST be force-analysed by the comptime block in src/zwasm.zig.
+#
+# Zig only emits `export` symbols from files the analysis pass visits; a lazy
+# `pub const` re-export through api/wasm.zig does NOT visit the file, so a file
+# missing from the comptime block silently drops ALL its exports from
+# libzwasm.a while include/*.h keeps declaring them — and its tests never run
+# (the comptime block is also what pulls in-file tests into the test build),
+# so it can even fail to compile unnoticed (issue #161: 81 symbols across
+# ref_base / config / host_info / module_serialize).
+#
+# Source-only (grep, no build), wired into gate_commit.sh so it runs at
+# commit time on any OS. The built-archive side of the same invariant
+# (declared header symbol present in libzwasm.a) lives in
+# scripts/test_extlink.sh (CI extended leg) — that is what gates the merge.
+#
+# Usage: bash scripts/check_api_export_analysis.sh [--gate]
+#   --gate: exit 1 on violation (default: same; flag kept for family symmetry)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Only the top-level `comptime { ... }` block counts: a `_ = @import` inside
+# the `test { ... }` loader is analysed in test builds only, not the lib build.
+comptime_block=$(sed -n '/^comptime {/,/^}/p' src/zwasm.zig)
+
+fail=0
+for f in src/api/*.zig; do
+    grep -q '^pub export fn' "$f" || continue
+    rel="${f#src/}"
+    if ! grep -qF "_ = @import(\"$rel\");" <<<"$comptime_block"; then
+        echo "[check_api_export_analysis] $f has pub export fn but no '_ = @import(\"$rel\");' in src/zwasm.zig's comptime block" >&2
+        fail=1
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo "[check_api_export_analysis] FAIL — add the file to the comptime force-analyse block in src/zwasm.zig" >&2
+    exit 1
+fi
+echo "[check_api_export_analysis] OK"

--- a/scripts/gate_commit.sh
+++ b/scripts/gate_commit.sh
@@ -174,6 +174,14 @@ else
     # existing `.dev/decisions/skip_<id>.md` ADR, and every skip-ADR
     # has ≥ 1 manifest consumer (no orphans). Plus the original
     # fixture-path existence checks for cited `.wasm` files.
+    # Issue #161: an src/api file with `pub export fn` absent from the
+    # zwasm.zig comptime force-analyse block ships a libzwasm.a missing
+    # every symbol the file exports (and never compiles or runs its tests).
+    # Pure grep — cross-platform, no build. The built-archive side of the
+    # invariant lives in test_extlink.sh (CI extended).
+    echo "[gate_commit] check_api_export_analysis --gate ..."
+    bash scripts/check_api_export_analysis.sh --gate > /dev/null
+
     echo "[gate_commit] check_skip_adrs --gate ..."
     bash scripts/check_skip_adrs.sh --gate > /dev/null
     # ADR-0122 (2026-05-27) — test-time SkipZigTest categorization:

--- a/scripts/test_extlink.sh
+++ b/scripts/test_extlink.sh
@@ -35,6 +35,43 @@ if ! ar t zig-out/lib/libzwasm.a | grep -q '^compiler_rt\.o$'; then
     exit 1
 fi
 
+# Every `pub export fn` in src/api/ must land in the archive. Zig only emits
+# export symbols from files the analysis pass visits, so a file missing from
+# src/zwasm.zig's comptime force-analyse block silently drops ALL its exports
+# while the header keeps declaring them (issue #161: 46 ref_base + 35
+# config/host_info/module_serialize symbols were unlinkable).
+nm -g zig-out/lib/libzwasm.a 2>/dev/null |
+    awk 'NF >= 3 && $2 != "U" { sub(/^_/, "", $3); print $3 }' | sort -u > "$out/archive_syms.txt"
+
+echo "[test_extlink] all src/api pub-export symbols present in the archive"
+missing=$(comm -23 \
+    <(grep -h '^pub export fn' src/api/*.zig | sed -E 's/^pub export fn ([A-Za-z0-9_]+).*/\1/' | sort -u) \
+    "$out/archive_syms.txt")
+if [ -n "$missing" ]; then
+    echo "[test_extlink] FAIL: exported fns missing from libzwasm.a (file absent from the src/zwasm.zig comptime block?):"
+    echo "$missing"
+    exit 1
+fi
+
+# Stronger, consumer-side statement of the same invariant: every function the
+# INSTALLED headers declare must be linkable. Preprocess each installed header
+# and require every declared wasm_*/wasi_*/zwasm_* function in the archive,
+# minus the `static inline` helpers the headers define themselves. Catches a
+# declared-but-never-implemented symbol, which the src-side check above cannot.
+echo "[test_extlink] all installed-header declarations present in the archive"
+for h in zig-out/include/*.h; do
+    "$CC" -E -P -Izig-out/include "$h" 2>/dev/null
+done > "$out/pp.h"
+fn_names() { grep -oE '\b(wasm|wasi|zwasm)_[a-z0-9_]+ *\(' | sed -E 's/ *\($//' | sort -u; }
+fn_names < "$out/pp.h" > "$out/hdr_all.txt"
+grep -A1 'static *inline' "$out/pp.h" | fn_names > "$out/hdr_inline.txt"
+hdr_missing=$(comm -23 <(comm -23 "$out/hdr_all.txt" "$out/hdr_inline.txt") "$out/archive_syms.txt")
+if [ -n "$hdr_missing" ]; then
+    echo "[test_extlink] FAIL: header-declared fns missing from libzwasm.a:"
+    echo "$hdr_missing"
+    exit 1
+fi
+
 LDFLAGS=(-lm)
 if [ "$(uname -s)" = "Linux" ]; then LDFLAGS+=(-Wl,-z,noexecstack); fi
 

--- a/src/api/ref_base.zig
+++ b/src/api/ref_base.zig
@@ -282,7 +282,6 @@ pub export fn wasm_extern_copy(e: ?*const handles.Extern) callconv(.c) ?*handles
     const c = alloc.create(handles.Extern) catch return null;
     c.* = src.*;
     c.borrowed = false;
-    c.extern_view = null;
     c.ref_view = null;
     c.host_info = null;
     c.host_info_finalizer = null;

--- a/src/zwasm.zig
+++ b/src/zwasm.zig
@@ -107,6 +107,10 @@ comptime {
     _ = @import("api/zwasm_ext.zig");
     _ = @import("api/module_introspect.zig");
     _ = @import("api/extern_new.zig");
+    _ = @import("api/ref_base.zig");
+    _ = @import("api/config.zig");
+    _ = @import("api/host_info.zig");
+    _ = @import("api/module_serialize.zig");
     _ = @import("api/cross_module.zig");
 }
 


### PR DESCRIPTION
Fixes #161.

## What was broken

Zig only emits `export fn` symbols from files the analysis pass visits, and four `src/api/` files were absent from the `src/zwasm.zig` comptime force-analyse block — their lazy `pub const` re-exports through `api/wasm.zig` never trigger analysis:

| file | missing symbols |
|---|---|
| `ref_base.zig` | 46 (`wasm_X_copy` / `wasm_X_same` / `wasm_X_as_ref` / `wasm_ref_as_X`) |
| `host_info.zig` | 27 (`wasm_X_{get,set}_host_info[_with_finalizer]`) |
| `module_serialize.zig` | 5 (`wasm_module_serialize` family) |
| `config.zig` | 3 (`wasm_config_*`, `wasm_engine_new_with_config`) |

The issue reported the 46; the other 35 were found by diffing every `src/api/` `pub export fn` against the archive — same root cause, fixed together.

`ref_base.zig` additionally did not compile (exactly as the issue diagnosed): `wasm_extern_copy` nulled an `extern_view` field that `handles.Extern` does not have — unnoticed precisely because the file was never analysed. The comptime block is also what pulls in-file tests into the test build, so its 6 tests (plus 5 across the other three files) had never run; they now do (`zig build test` 3026 → 3037 pass).

## Guards so the class cannot recur

- **`scripts/check_api_export_analysis.sh`** (new, wired into `gate_commit.sh`): every `src/api/*.zig` with a `pub export fn` must be listed in the comptime block. Source-only grep, commit-time, any OS.
- **`scripts/test_extlink.sh`** (CI extended leg): asserts every `src/api/` `pub export fn` is present in the archive (nm), and every installed-header declaration is present in the archive (`cc -E`, minus the headers' own `static inline` helpers). The header-side check also catches declared-but-never-implemented symbols — the exact shape the reporter framed (#153/#154 were the same class).

All three guards negative-tested (violation injected → FAIL with the offending file named).

## Verification

- `zig build test` 3037 pass / `test-all` green / lint clean / `gate_commit.sh` all gates passed.
- Cross-language, over the system linker (not zig's driver):
  - **C**: 22-check consumer covering every newly-exported family, incl. the reporter's exact flow — borrowed `wasm_extern_as_func` → `wasm_func_copy` → owned handle survives `wasm_extern_vec_delete` and calls through to 42.
  - **Rust**: `zig build run-rust-host` green (also runs on the CI Linux leg every PR).
  - **Go**: cgo consumer linking `libzwasm.a`, driving the same copy flow → 42.
- Independent adversarial review (20-criterion): 1 finding (guard diagnostics swallowed by `gate_commit.sh`'s `> /dev/null`) — fixed by routing violations to stderr, per the `check_*` family convention.