### PR TITLE
chore(release): v2.5.0 — full WASI 0.3 coverage on all three OSes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,9 +30,10 @@ zwasm v2 is a ground-up redesign of zwasm (v1 git history at commit 517cc5a).
   under `docs/examples/`. Only README / LICENSE / CHANGELOG / build+flake files
   remain at root.
 - **Release stays user-only (ADR-0156)**: tag / publish / cutover are
-  manual. Current line = `v2.0.0-rc.1` (tag-only; Latest = v1.11.1).
-  `v2.0.0` final = bump `build.zig.zon` + push `v2.0.0` tag → `release.yml`
-  auto-builds + Release + Latest→v2. See `docs/migration_v1_to_v2.md`.
+  manual. The release line is the latest `v2.x` tag (see CHANGELOG /
+  GitHub Releases — do NOT hardcode it here, it rots). Cut = bump
+  `build.zig.zon` + CHANGELOG section + push the `vX.Y.Z` tag →
+  `release.yml` auto-builds + publishes. See `docs/migration_v1_to_v2.md`.
 - v1 ABI compatibility is out of scope; the C/Zig/CLI surfaces broke v1 on
   purpose (ADR-0156).
 

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -5,13 +5,15 @@
 
 ## Current state — MAINTENANCE MODE (post-v2.0.0)
 
-**v2.4.1 is the release line** (tag cut 2026-08-04, USER-GRANTED per ADR-0156;
-consumer-driven patch #157/#158/#159 from ClojureWasm). v2.4.0 = external-
-consumer release (`-Dcompiler-rt` #154 + GC-cohort DCE #150); v2.3.0 =
-WASI-0.3.0 sweep + Homebrew tap; v2.2.x = binary-size / AOT lines. v1 frozen
-at `v1.11.1`. Dev model: cut a `develop/<slug>` branch from `main` → PR → CI
-`ci-required` 3-OS gate green to merge. **Release stays user-only (ADR-0156)**
-— never autonomously tag / publish / cut over.
+**v2.5.0 release prep in flight (USER-GRANTED 2026-08-11 per ADR-0156)**:
+this branch bumps `build.zig.zon` → 2.5.0 + cuts the CHANGELOG section
+(headline: WASI 0.3 full coverage on all 3 OSes; also #162 C-API symbols,
+#164 doc sweep, #166 dev-env SSOT). After merge + CI green the USER pushes
+the `v2.5.0` tag → `release.yml` auto-builds + publishes. Prior line
+v2.4.1 (2026-08-04); v1 frozen at `v1.11.1`. Dev model: cut a
+`develop/<slug>` branch from `main` → PR → CI `ci-required` gate green to
+merge. **Release stays user-only (ADR-0156)** — never autonomously tag /
+publish / cut over.
 
 ## Closed campaigns (details in the cited ADR/CHANGELOG)
 
@@ -27,19 +29,14 @@ at `v1.11.1`. Dev model: cut a `develop/<slug>` branch from `main` → PR → CI
   CI **`doc-truth` job**). Binary-size CLOSED (ADR-0204). AOT full-fidelity
   CLOSED (ADR-0203; residual D-515(2)+D-514).
 
-## Active front — reproducible-dev-env (2026-08-11, user-directed)
+## Closed front — reproducible-dev-env (SHIPPED 2026-08-11, PR #166 → dc46526c5)
 
-Branch `develop/reproducible-dev-env` — **DONE, PR #166 open + CI all-green,
-awaiting user merge** (ADR-0206). Goal: anyone can develop this project.
-Delivered: `docs/development.md` SSOT (README/CONTRIBUTING link it; honest
-CI claim — windows leg is advisory); `scripts/dev_hosts.env.example`
-(per-machine host config for the OPTIONAL fan-out; absolute-dir sourcing
-pre-orphan-guard); yq guards (SKIP + pointer); 5 dead campaign scripts
-deleted (D5 list in the ADR); `.dev/README.md` split record-vs-host-setup.
-Verified: fresh-clone Zig-only `zig build test` 3153 pass; subdir-invocation
-config regression test; two clean-context agent audits (walkthrough "story
-holds, no blockers"; adversarial diff review 5 findings → all fixed).
-post-merge main CI for #165 (run 31487010199): **all-green** incl. extended.
+ADR-0206: anyone can develop this project. `docs/development.md` SSOT
+(README/CONTRIBUTING link it; honest CI claim — windows leg advisory);
+`scripts/dev_hosts.env.example` per-machine host config for the OPTIONAL
+fan-out; yq guards; 5 dead campaign scripts deleted. Verified by fresh-clone
+Zig-only build/test + two clean-context agent audits (5 findings all fixed).
+post-merge main CI green for both #165 (incl. extended) and #166.
 
 ## Operational invariants (keep using)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ zwasm v2 is a ground-up redesign of v1. **v1 ABI compatibility is out of
 scope** — see [`docs/migration_v1_to_v2.md`](docs/migration_v1_to_v2.md).
 SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
 
-## [Unreleased]
+## [2.5.0] - 2026-08-11
 
 ### Added
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zwasm,
-    .version = "2.4.1",
+    .version = "2.5.0",
     .fingerprint = 0xfdac0191bf453d15,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{


### PR DESCRIPTION
## Summary

Release prep for **v2.5.0** (minor bump — user-granted per ADR-0156; the tag
push itself stays manual).

Since v2.4.1 the line gained:

- **Full WASI 0.3.0 coverage on all three supported OSes** (ADR-0205, #165)
  — all six proposals over the Component-Model async substrate; official
  `wasm32-wasip3` corpus 45/45 green on macOS aarch64 / Linux x86_64 /
  Windows x86_64, zero skips. The headline feature.
- 81 missing C-API symbols restored to `libzwasm.a` (#162).
- Default-engine doc-truth sweep + always-on CI `doc-truth` job (#164).
- Reproducible contributor environment (ADR-0206, #166): `docs/development.md`
  SSOT, `scripts/dev_hosts.env` config for the optional local fan-out,
  dead-script sweep.

## Changes

- `build.zig.zon`: 2.4.1 → 2.5.0 (verified: `zwasm --version` reports
  `zwasm v2.5.0 (wasm: v3_0, wasi: p2, engine: both)`)
- `CHANGELOG.md`: `[Unreleased]` → `[2.5.0] - 2026-08-11`
- `.claude/CLAUDE.md`: de-fossilize the release-line paragraph (was stuck at
  v2.0.0-rc.1); now states the process without hardcoding a version
- `.dev/handover.md`: close the reproducible-dev-env front, record the
  release step

## After merge

1. Confirm this PR's post-merge CI on `main` is green.
2. Maintainer pushes the tag: `git tag v2.5.0 <merge-sha> && git push origin v2.5.0`
   → `release.yml` auto-builds + publishes the Release.

https://claude.ai/code/session_018FgZte4GUMFo8h28J5tekx