### PR TITLE
build: -D option surface audit — retire -Dgc + run-repro, loud sanitize rejection, document the table (sweep S2)

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -258,8 +258,12 @@ entries:
       entries; D-335 REMAINING(2); D-523 (test-side)
   - id: "D-525"
     layer: "build"
-    status: "note"
+    status: "resolved"
     description: |-
+      RESOLVED 2026-08-12 (sweep S2): option (b) — the -Dgc flag, its
+      build_options.enable_gc threading, and the register.zig re-export are
+      retired; ADR-0115 carries the revision note. The strip lever is and
+      stays -Dwasm (wasm-level DCE). Original row:
       The `-Dgc` build option is INERT: `build.zig` threads it to
       `build_options.enable_gc`, whose only reader is the
       `src/feature/gc/register.zig` re-export that nothing consumes —

--- a/.dev/decisions/0015_canonical_debug_toolkit.md
+++ b/.dev/decisions/0015_canonical_debug_toolkit.md
@@ -1,6 +1,7 @@
 # 0015 — Adopt canonical debug toolkit for Phase 6+
 
 - **Status**: Closed (Phase 6 DONE)
+- **Revision note (2026-08-12, sweep S2)**: Part 4's `zig build run-repro -Dtask=<name>` step was retired — it presupposed the maintainer-local gitignored `private/` tree in the public build script (ADR-0206 contributor-generalization bar). Ad-hoc repros link a standalone `repro.zig` against the `zwasm` module directly; Part 2 (`-Dsanitize`) stays.
 - **Date**: 2026-05-04
 - **Author**: zwasm v2 / continue loop
 - **Tags**: phase-6, debug, tooling, observability, infrastructure

--- a/.dev/decisions/0115_gc_heap_collector_design.md
+++ b/.dev/decisions/0115_gc_heap_collector_design.md
@@ -1,6 +1,7 @@
 # 0115 — WasmGC heap + collector design: per-Store slab + pluggable vtable + needs_gc_heap zero-overhead gate
 
 - **Status**: Accepted (2026-05-25; Phase 10 / 10.D ADR round close)
+- **Revision note (2026-08-12, D-525)**: the §3 `-Dgc` compile-time gate was never adopted by the op handlers — GC ships with `-Dwasm=v3_0` and the wasm level is the strip lever (wasm-level DCE, `check_build_dce.sh`). The flag + its `enable_gc` re-export were retired (sweep S2); §3's heap/collector design itself is unchanged and landed.
 - **Date**: 2026-05-25
 - **Author**: claude (autonomous loop, /continue prep path)
 - **Tags**: wasmgc, wasm-3.0, gc-heap, collector-vtable, mark-sweep,

--- a/build.zig
+++ b/build.zig
@@ -47,6 +47,12 @@ pub fn build(b: *std.Build) void {
     // Adopted as a weekly Linux x86_64 lane, not per-commit (~2× slower).
     const sanitize = b.option(SanitizeMode, "sanitize", "Sanitizer (off / address / thread). Mac+Linux only.") orelse .off;
     const is_windows = target.result.os.tag == .windows;
+    if (is_windows and sanitize != .off) {
+        // A requested sanitizer must never silently vanish: Windows ucrt has
+        // no ASan/TSan runtime in this toolchain, so reject instead of
+        // building an unsanitized binary the caller believes is sanitized.
+        std.debug.panic("-Dsanitize={s} is not available on Windows targets (Mac+Linux only)", .{@tagName(sanitize)});
+    }
     const sanitize_c: ?std.zig.SanitizeC = if (is_windows) null else switch (sanitize) {
         .off => null,
         .address => .full,
@@ -61,11 +67,6 @@ pub fn build(b: *std.Build) void {
     // instead of `createModule + applySanitize` boilerplate (D-016
     // discharge).
     const sanitize_opts: SanitizeOpts = .{ .c = sanitize_c, .thread = sanitize_thread };
-    // Repro task name for `zig build run-repro -Dtask=<name>` per
-    // ADR-0015 §Decision Part 4. Discovers
-    // `private/dbg/<task>/repro.zig` and links it against the
-    // zwasm-lib module. Step is silent when -Dtask is unset.
-    const repro_task = b.option([]const u8, "task", "Repro task name (private/dbg/<task>/repro.zig)");
 
     // ADR-0028 / D-022: Diagnostic M3-a trace ringbuffer compile-time
     // gate. Default false so release builds emit zero trace code in
@@ -81,19 +82,6 @@ pub fn build(b: *std.Build) void {
     // `-Dtrace-stackprobe=true`.
     const trace_stackprobe = b.option(bool, "trace-stackprobe", "Compile in the [stack_probe]/[d-165] JIT diagnostic prints (default: false)") orelse false;
 
-    // ADR-0115 §3 — `-Dgc=true|false` zero-overhead compile-time
-    // gate. `false` (default for Phase 10 v0.1 since WasmGC ops
-    // aren't dispatched yet) means GC heap allocator + collector
-    // vtable + root walk all skip at runtime; future cycles add
-    // the dispatch-side comptime check that strips op_gc handlers
-    // via DCE when `enable_gc=false` (WAMR-equivalent nuclear
-    // strip per ADR-0115 §3). `true` opts the feature in once
-    // op_gc lands. Pairs with `Module.needs_gc_heap` parse-time
-    // predicate — the runtime gate at instantiate already
-    // skips heap materialisation when needs_gc_heap=false, so
-    // `enable_gc=false` is the additional source-level strip for
-    // module-construction code paths.
-    const enable_gc = b.option(bool, "gc", "Enable WasmGC heap+collector compile-in (default: false; per ADR-0115 §3)") orelse false;
     // Zig does NOT bundle compiler-rt into a static library by default (the
     // implicit default only covers exe + dynamic lib), so a NON-zig linker
     // consuming libzwasm.a is left with undefined `__zig_probe_stack`
@@ -123,7 +111,6 @@ pub fn build(b: *std.Build) void {
     options.addOption(EngineMode, "engine_mode", engine_mode);
     options.addOption(bool, "trace_ringbuffer", trace_ringbuffer);
     options.addOption(bool, "trace_stackprobe", trace_stackprobe);
-    options.addOption(bool, "enable_gc", enable_gc);
     options.addOption(bool, "enable_component", enable_component);
     options.addOption(bool, "enable_wasi_p3", enable_wasi_p3);
     options.addOption([]const u8, "version", zon.version);
@@ -452,7 +439,6 @@ pub fn build(b: *std.Build) void {
     comp_options.addOption(EngineMode, "engine_mode", engine_mode);
     comp_options.addOption(bool, "trace_ringbuffer", trace_ringbuffer);
     comp_options.addOption(bool, "trace_stackprobe", trace_stackprobe);
-    comp_options.addOption(bool, "enable_gc", enable_gc);
     comp_options.addOption(bool, "enable_component", true);
     comp_options.addOption(bool, "enable_wasi_p3", @intFromEnum(comp_wasi_level) >= @intFromEnum(WasiLevel.p3));
     comp_options.addOption([]const u8, "version", zon.version);
@@ -503,7 +489,6 @@ pub fn build(b: *std.Build) void {
     p3_options.addOption(EngineMode, "engine_mode", engine_mode);
     p3_options.addOption(bool, "trace_ringbuffer", trace_ringbuffer);
     p3_options.addOption(bool, "trace_stackprobe", trace_stackprobe);
-    p3_options.addOption(bool, "enable_gc", enable_gc);
     p3_options.addOption(bool, "enable_component", true);
     p3_options.addOption(bool, "enable_wasi_p3", true);
     p3_options.addOption([]const u8, "version", zon.version);
@@ -1441,36 +1426,6 @@ pub fn build(b: *std.Build) void {
     test_all_step.dependOn(&run_realworld_run_jit.step);
     test_all_step.dependOn(&run_wasmtime_misc_runtime.step);
     test_all_step.dependOn(&run_zig_facade.step);
-
-    // `zig build run-repro -Dtask=<name>` — discover
-    // `private/dbg/<task>/repro.zig`, link it against the zwasm
-    // library, and run it. Per ADR-0015 §Decision Part 4 / §9.6 /
-    // 6.K.7. Silent (non-failing) when -Dtask is unset, so
-    // `zig build` itself stays unaffected; running the step
-    // without -Dtask prints the usage hint.
-    const repro_step = b.step("run-repro", "Run private/dbg/<task>/repro.zig (-Dtask=<name>)");
-    if (repro_task) |task| {
-        const repro_path = b.fmt("private/dbg/{s}/repro.zig", .{task});
-        const repro_mod = createSanitizedModule(b, sanitize_opts, .{
-            .root_source_file = b.path(repro_path),
-            .target = target,
-            .optimize = optimize,
-            .link_libc = true,
-        });
-        repro_mod.addImport("zwasm", zwasm_lib_mod);
-        const repro_exe = b.addExecutable(.{
-            .name = b.fmt("zwasm-repro-{s}", .{task}),
-            .root_module = repro_mod,
-        });
-        const run_repro = b.addRunArtifact(repro_exe);
-        repro_step.dependOn(&run_repro.step);
-    } else {
-        const print_usage = b.addSystemCommand(&.{
-            "/bin/sh",                                                                                     "-c",
-            "echo 'usage: zig build run-repro -Dtask=<name>  (private/dbg/<name>/repro.zig)' >&2; exit 2",
-        });
-        repro_step.dependOn(&print_usage.step);
-    }
 
     // `zig build lint` — zlinter rule chain (ADR-0009 + Phase B
     // expansion). See `private/zlinter-builtins-survey-2026-05-03.md`

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,6 +26,25 @@ zig fmt src/             # format before committing
 [ziglang.org/download](https://ziglang.org/download/) or via the Nix shell
 below.
 
+## Build options
+
+The complete `-D` surface (`zig build --help` is always authoritative):
+
+| Option | Values (default first) | Effect |
+|---|---|---|
+| `-Dwasm` | `v3_0` / `v2_0` / `v1_0` | Wasm spec level; lower levels strip later proposals (incl. GC/EH at `v1_0`/`v2_0`) via compile-time DCE |
+| `-Dwasi` | `p2` / `p3` / `p1` / `none` | Ordered WASI tier. `p2` = Component Model + WASI-P2 host; `p3` adds Preview-3 native async; `p1` is the lean opt-out (strips the whole component subsystem) |
+| `-Dengine` | `both` / `jit` / `interp` | Engine selection compiled in |
+| `-Dstrip` | `false` / `true` | Strip debug info from the CLI binary |
+| `-Dsanitize` | `off` / `address` / `thread` | ASan+UBSan / TSan (Mac + Linux only — a Windows target rejects a non-`off` value at configure time rather than silently building unsanitized) |
+| `-Dcompiler-rt` | `false` / `true` | Bundle Zig compiler-rt into `libzwasm.a` for non-Zig linkers (`__zig_probe_stack` etc.) |
+| `-Dtrace-ringbuffer` | `false` / `true` | Compile in the diagnostic trace ringbuffer |
+| `-Dtrace-stackprobe` | `false` / `true` | Compile in the JIT stack-probe diagnostic prints |
+| `-Dtest-filter` | (string) | Run only matching tests in `zig build test-wasi-p3` |
+
+There is no separate GC flag: WasmGC ships with `-Dwasm=v3_0` (the default),
+and the wasm level is the strip lever.
+
 ## Tools: required vs optional
 
 | Tool | Status | Used for |

--- a/docs/migration_v1_to_v2.md
+++ b/docs/migration_v1_to_v2.md
@@ -308,7 +308,7 @@ Claims above are anchored to the v2 source tree (paths are repo-relative):
   `src/instruction/wasm_2_0/` are not interpreter-wired; real codegen lives in
   `src/engine/codegen/{arm64,x86_64}/op_simd_*.zig`; the spec SIMD runner
   (`test/spec/simd_assert_runner.zig`) JIT-executes.
-- **Build defaults:** `build.zig` (`-Dwasm` / `-Dwasi` / `-Dengine` / `-Dgc`;
+- **Build defaults:** `build.zig` (`-Dwasm` / `-Dwasi` / `-Dengine`;
   component + P3-async are derived from the `-Dwasi` tier).
 - **WASI confinement:** `src/wasi/path.zig` (`symlinkTargetEscapes`), `src/wasi/fd.zig`.
 

--- a/src/feature/gc/collector_iface.zig
+++ b/src/feature/gc/collector_iface.zig
@@ -12,9 +12,10 @@
 //!     sweep over the slab; barrier-zero (no write barriers).
 //!     Production-ship per ADR-0115 §10 (β must-ship).
 //!
-//! `-Dgc-collector={null,mark_sweep}` build-option selects;
-//! `-Dgc=false` strips the entire `feature/gc/` directory via
-//! compile-time DCE (WAMR-equivalent nuclear strip).
+//! Selection is programmatic (construct the impl directly) —
+//! the once-planned `-Dgc-collector` / `-Dgc` options were never
+//! introduced; the GC strip lever is the `-Dwasm` level
+//! (ADR-0115 revision note, D-525).
 //!
 //! ADR-0115 §3 specifies `allocObjectFn(ctx, *TypeInfo)`; cycle
 //! 4 (this commit) ships a placeholder size-based shape because

--- a/src/feature/gc/collector_null.zig
+++ b/src/feature/gc/collector_null.zig
@@ -9,9 +9,9 @@
 //! per ADR-0115 §10) reuses the same vtable shape in subsequent
 //! bundle cycles.
 //!
-//! Selection: `-Dgc-collector=null` build-option (cycle 5+
-//! adds the build-option dispatch). For cycle 4 the null
-//! collector is the only impl; tests construct it directly.
+//! Selection is programmatic (construct the impl directly);
+//! the once-planned `-Dgc-collector` build option was never
+//! introduced (cf. ADR-0115 revision note).
 //!
 //! Zone 1 (`src/feature/gc/`).
 

--- a/src/feature/gc/needs_heap_detector.zig
+++ b/src/feature/gc/needs_heap_detector.zig
@@ -360,9 +360,9 @@ test "mayUseTypeSubtyping: byte pre-filter true for a 0x50 sub-form module, fals
 }
 
 test {
-    // 10.G-foundation cycles 3+4+6: pull sibling heap.zig +
-    // collector_null.zig + register.zig (enable_gc build-option
-    // seam) tests into the test root walk. needs_heap_detector
+    // 10.G-foundation cycles 3+4: pull sibling heap.zig +
+    // collector_null.zig + register.zig tests into the test
+    // root walk. needs_heap_detector
     // is reached from src/parse/parser.zig directly (cycle 2
     // wiring), so this reference cascades sibling discovery
     // without depending on register.zig's re-export pattern.

--- a/src/feature/gc/register.zig
+++ b/src/feature/gc/register.zig
@@ -9,22 +9,14 @@
 //!
 //! The GC feature itself SHIPPED (Phase 10): its ops register via the
 //! per-op `src/instruction/wasm_3_0/` dispatch files, so `register()`
-//! stays a no-op, and the `enable_gc` re-export below is currently
-//! unwired — GC compiles in with `-Dwasm=v3_0`; see debt D-525.
+//! stays a no-op. GC compiles in with `-Dwasm=v3_0` — the wasm level IS
+//! the strip lever (wasm-level DCE, `check_build_dce.sh`); the separate
+//! `-Dgc` gate ADR-0115 §3 planned was never adopted by the op handlers
+//! and was retired 2026-08-12 (D-525).
 //!
 //! Zone 1 (`src/feature/gc/`).
 
 const dispatch_table = @import("../../ir/dispatch_table.zig");
-const build_options = @import("build_options");
-
-/// 10.G-foundation cycle 6 (ADR-0115 §3) — compile-time gate that
-/// future cycles' op_gc handlers will branch on. `false` (Phase
-/// 10 v0.1 default) lets DCE strip GC dispatch arms; `true`
-/// opts the feature in once op_gc lands. Pairs with the runtime
-/// `Module.needs_gc_heap` predicate — both must be true for GC
-/// heap allocation to fire. WAMR-equivalent nuclear strip per
-/// ADR-0115 §3.
-pub const enable_gc: bool = build_options.enable_gc;
 
 // 10.G-i31-helpers: i31 small-integer pack/unpack helpers per
 // ADR-0116 D4. Re-exported here so `zig build test` walks the
@@ -58,15 +50,4 @@ pub const collector_null = @import("collector_null.zig");
 
 pub fn register(_: *dispatch_table.DispatchTable) void {
     // Placeholder — feature implementation deferred per ADR-0023.
-}
-
-test "10.G-foundation cycle 6: enable_gc build-option compile-time gate" {
-    // Default (no -Dgc=true) → false. Pinning the default ensures
-    // accidentally-flipped invariants surface at test time. The
-    // value itself is build-option-controlled; this test runs in
-    // the default config and pins that contract.
-    try @import("std").testing.expect(enable_gc == false or enable_gc == true);
-    // The runtime gate `Module.needs_gc_heap` AND-combines with
-    // this flag at op_gc dispatch (future cycle); cycle 6 just
-    // establishes the seam.
 }

--- a/src/wasi/p2_sockets.zig
+++ b/src/wasi/p2_sockets.zig
@@ -1041,7 +1041,6 @@ fn winUdpBind(family: AddressFamily, addr: net.IpAddress) !net.Socket {
 // Tests
 // ============================================================
 const testing = std.testing;
-const skip = @import("../test_support/skip.zig");
 
 test "tcp client lifecycle: create → connect → echo against a loopback listener" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});


### PR DESCRIPTION
## What

The sweep's S2 axis: make the `-D` build-option surface honest and fully documented.

- **`-Dgc` retired** (D-525 resolved, option (b)): the flag threaded to `build_options.enable_gc`, whose only reader was a re-export nothing consumed — GC has always shipped with `-Dwasm=v3_0` (the default), and the wasm level is the real strip lever (wasm-level DCE, `check_build_dce.sh`). ADR-0115 carries the revision note; comment fossils referencing the never-introduced `-Dgc-collector` flag are cleaned alongside.
- **`run-repro` / `-Dtask` retired** (ADR-0015 revision note): the step hardcoded the maintainer-local gitignored `private/dbg/` tree inside the public build script — against the ADR-0206 "anyone can develop" bar. Ad-hoc repros link a standalone `repro.zig` against the `zwasm` module directly.
- **`-Dsanitize` on a Windows target now fails loudly at configure time** with a clear message, instead of silently building an unsanitized binary the caller believes is sanitized (verified both ways).
- **`docs/development.md` gains the complete build-option table** — the contributor SSOT previously had zero `-D` coverage; the migration guide's defaults list is updated to match.
- Drops `p2_sockets.zig`'s never-used test-section `skip` import (the identical one-line deletion rides on the S1 branch #169; git merges them cleanly).

## Verification

`zig build lint -- --max-warnings 0` → No issues · unit tests 3048 pass / 12 skip · Windows default configure unaffected; `-Dtarget=x86_64-windows-gnu -Dsanitize=address` rejects with the intended message.