### PR TITLE
cli: option-surface audit — spellable --engine auto, uniform usage exit codes (sweep S3)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,7 +29,7 @@ parse/compile).
 | Flag                       | Effect                                                                                                                                                                                                                                       |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--invoke <name>[=a,b,…]` | run the named export instead of `_start`/`main`. Zero-arg form → result surfaces as the exit code. `=args` (comma-separated, parsed by param type i32/i64/f32/f64) → typed results print bare, one per line, on stdout. Works on both the interpreter and the JIT (D-477) |
-| `--engine <interp\|jit>`   | **default (omitted) = `auto`** — prefers the JIT, falls back to the interpreter. `--engine interp` / `jit` force one. BOTH do full WASI; `jit` additionally executes SIMD-128                                                              |
+| `--engine <auto\|interp\|jit>` | default `auto` — prefers the JIT, falls back to the interpreter (`--engine auto` is the explicit spelling of the same). `--engine interp` / `jit` force one. BOTH do full WASI; `jit` additionally executes SIMD-128                    |
 | `--dir <host>[:<guest>]`   | preopen a host directory for WASI (colon separator; guest path mirrors host when omitted)                                                                                                                                                    |
 | `--env KEY=VAL`            | set a WASI environment variable for the guest (repeatable; bare `KEY` sets empty)                                                                                                                                                            |
 | `--fuel <N>`               | trap (`all fuel consumed`) after a deterministic budget. Units are engine-specific by design: interp counts instructions, jit counts function entries + loop iterations                                                                     |
@@ -60,9 +60,9 @@ WASI / sandbox / `--invoke` behaviour to running the source `.wasm`
   `--engine interp` with a `.cwasm` is a contradictory request (the
   artifact is precompiled JIT code) and is refused loudly (exit 2).
 - `.wasm` input → **`auto` by default** (prefers the JIT, transparently falls
-  back to the interpreter). `--engine interp` forces the interpreter;
-  `--engine jit` forces the JIT (full WASI, plus SIMD execution). `auto` is the
-  default only — it is not a spellable `--engine` value.
+  back to the interpreter); `--engine auto` spells the default explicitly.
+  `--engine interp` forces the interpreter; `--engine jit` forces the JIT
+  (full WASI, plus SIMD execution).
 - `--cache` affects `.wasm` runs only (a `.cwasm` input IS the artifact;
   components have no artifact format) and is bypassed under
   `--engine interp`.
@@ -73,8 +73,8 @@ WASI / sandbox / `--invoke` behaviour to running the source `.wasm`
 |------|--------------------------------------------------------------------------------------------------|
 | `0`  | Success — guest returned normally, or called `proc_exit(0)`                                     |
 | `N`  | Guest called `proc_exit(N)` (the guest's own status surfaces verbatim)                           |
-| `1`  | Guest trapped (OOB access, `unreachable`, integer divide-by-zero, fuel/timeout, …), OR a file read / load failure, OR any `compile` error (incl. a `compile` usage error) |
-| `2`  | Usage error at dispatch — unknown subcommand, or a `run` flag parse error / a requested limit refused (loud). (`compile` usage errors exit `1`, not `2`.)                 |
+| `1`  | Guest trapped (OOB access, `unreachable`, integer divide-by-zero, fuel/timeout, …), OR a file read / load failure, OR a `compile` build/IO error                          |
+| `2`  | Usage error — unknown subcommand, a `run` flag parse error, a requested limit refused (loud), or a `compile` usage error                                                  |
 | `70` | Internal zwasm fault — a fatal signal/panic caught by the diagnostic fault handler              |
 
 Source of truth: the `run` exit-code mapping (`src/cli/run.zig`) +

--- a/src/cli/dispatch.zig
+++ b/src/cli/dispatch.zig
@@ -47,7 +47,7 @@ pub const usage =
     \\Usage:
     \\  zwasm run <file.wasm|file.cwasm> [args...]   Run a module (WASI _start / main)
     \\    [--invoke <name>[=a,b,...]]                Invoke a named export (optional call args)
-    \\    [--engine <interp|jit>]                    Engine: default auto (prefers JIT, interp fallback); interp|jit force one (both full WASI; jit adds SIMD)
+    \\    [--engine <auto|interp|jit>]                    Engine: default auto (prefers JIT, interp fallback); interp|jit force one (both full WASI; jit adds SIMD)
     \\    [--dir <host>[:<guest>]]                   Preopen a host directory for WASI
     \\    [--env <KEY=VAL>]                          Set an environment variable for the guest
     \\    [--fuel <N>]                               Trap after a fuel budget (units are engine-specific:

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -16,7 +16,7 @@
 //!                             export; exit with the guest's
 //!                             `proc_exit` code.
 //!   run --invoke <name>       Invoke the named func export (zero-args)
-//!   run --engine <interp|jit> Engine: default (omitted) = auto, prefers JIT
+//!   run --engine <auto|interp|jit> Engine: default auto, prefers JIT
 //!                             with interp fallback; interp|jit force one — BOTH do full
 //!                             WASI (D-244); jit additionally executes SIMD
 //!                             (the interp does not). `--engine=jit` accepted.
@@ -157,10 +157,15 @@ pub fn main(init: std.process.Init) !void {
                         a[eq.len..]
                     else
                         arg_it.next() orelse {
-                            try printlnErr(io, "usage: zwasm run --engine <interp|jit> <path.wasm> [args...]");
+                            try printlnErr(io, "usage: zwasm run --engine <auto|interp|jit> <path.wasm> [args...]");
                             std.process.exit(2);
                         };
-                    if (std.mem.eql(u8, mode, "jit")) {
+                    if (std.mem.eql(u8, mode, "auto")) {
+                        // Explicit spelling of the default: JIT-preferring
+                        // with interp fallback (last flag wins).
+                        engine_jit = false;
+                        limits.engine = .auto;
+                    } else if (std.mem.eql(u8, mode, "jit")) {
                         engine_jit = true;
                         // Last flag wins: undo a preceding `--engine interp`'s
                         // sticky force (read by the cache + .cwasm gates).
@@ -171,7 +176,7 @@ pub fn main(init: std.process.Init) !void {
                         // JIT, so an EXPLICIT `--engine interp` must force interp.
                         limits.engine = .interp;
                     } else {
-                        try printlnErr(io, "zwasm run: --engine must be 'interp' or 'jit'");
+                        try printlnErr(io, "zwasm run: --engine must be 'auto', 'interp' or 'jit'");
                         std.process.exit(2);
                     }
                     next_arg = arg_it.next();
@@ -258,7 +263,7 @@ pub fn main(init: std.process.Init) !void {
                 } else break;
             }
             const path_arg = next_arg orelse {
-                try printlnErr(io, "usage: zwasm run [--invoke <name>] [--engine <interp|jit>] [--dir <host>[:<guest>]] [--env KEY=VAL] [--fuel <N>] [--timeout <ms>] [--max-memory <bytes>] [--max-table-elements <N>] [--cache[=DIR]] [--cache-clear] <path.wasm> [args...]");
+                try printlnErr(io, "usage: zwasm run [--invoke <name>] [--engine <auto|interp|jit>] [--dir <host>[:<guest>]] [--env KEY=VAL] [--fuel <N>] [--timeout <ms>] [--max-memory <bytes>] [--max-table-elements <N>] [--cache[=DIR]] [--cache-clear] <path.wasm> [args...]");
                 std.process.exit(2);
             };
             const path = try gpa.dupe(u8, path_arg);
@@ -399,6 +404,12 @@ pub fn main(init: std.process.Init) !void {
         }
         if (std.mem.eql(u8, subcmd, "compile")) {
             const code = cli_compile.run(gpa, io, &arg_it) catch |err| {
+                if (err == error.UsageError) {
+                    // Usage errors exit 2 uniformly across subcommands.
+                    // EXEMPT-FALLBACK: ADR-0016 phase 1 — usage-line stderr report is last-resort; the process exits 2 regardless.
+                    printlnErr(io, "usage: zwasm compile <file.wasm> -o <out.cwasm>") catch {};
+                    std.process.exit(2);
+                }
                 var buf: [256]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, "zwasm compile: {s}", .{@errorName(err)}) catch "zwasm compile: failed";
                 // EXEMPT-FALLBACK: ADR-0016 phase 1 — compile-error stderr report is last-resort; the process exits 1 regardless.

--- a/src/wasi/p2_sockets.zig
+++ b/src/wasi/p2_sockets.zig
@@ -1041,7 +1041,6 @@ fn winUdpBind(family: AddressFamily, addr: net.IpAddress) !net.Socket {
 // Tests
 // ============================================================
 const testing = std.testing;
-const skip = @import("../test_support/skip.zig");
 
 test "tcp client lifecycle: create → connect → echo against a loopback listener" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});


### PR DESCRIPTION
## What

The sweep's S3 axis: the runtime/CLI option surface, audited against the あるべき論 bar.

- **`--engine auto` is now spellable**: the help text has always described `auto` as the default, but the value itself was rejected. It now parses as the explicit spelling of the default (JIT-preferring with interp fallback, last-flag-wins); usage strings and the error message name all three values.
- **Usage errors exit `2` uniformly**: `compile` usage errors previously exited `1` (lumped with build/IO failures) while `run` and the dispatcher used `2`. `compile` usage now prints a usage line and exits `2`; `1` stays for genuine build/IO failures. The exit-code table in `docs/reference/cli.md` drops its asymmetry footnote.
- **Env-var inventory audited**: `ZWASM_DEBUG` / `ZWASM_DIAG` are the only real runtime env vars and both were already documented; `ZWASM_ENGINE_*` / `ZWASM_TRAP_*` are C-header macros (not env vars); `ZWASM_TEST_SENTINEL_KEY` is test-internal. All 13 parsed CLI flags are documented — no hidden surface.
- Drops `p2_sockets.zig`'s unused test-section `skip` import (same one-line deletion as #169/#170 — identical hunks merge cleanly).

## Verification

`--engine auto` runs with trap exit 1 on both engines · bogus engine value exits 2 · `compile` with no args exits 2 + usage line · unit tests 3049 pass / 12 skip · lint No issues · pre-commit gate all green.