### PR TITLE
ci: sweep S5 mechanization — growth ratchet, test-discovery guard, doc-fossil guard, blocked-by ladder

### DIFF
--- a/.claude/references/context_budget.md
+++ b/.claude/references/context_budget.md
@@ -77,7 +77,7 @@ structurally broken**:
 
 ## Audit hook
 
-`audit_scaffolding §G` (or a future `scripts/check_rule_size.sh`): flag any
+`audit_scaffolding §G` (or a future rule-size check script): flag any
 `.claude/rules/*.md` whose auto-loaded body exceeds ~60 lines without a
 matching `.claude/references/<name>.md` — that is the stub-pattern regression
 signal.

--- a/.claude/skills/dispatch_consistency_audit/SKILL.md
+++ b/.claude/skills/dispatch_consistency_audit/SKILL.md
@@ -116,9 +116,9 @@ done
 
 ```sh
 # Cross-reference each op file's wasm_level against the canonical mapping.
-python3 scripts/check_wasm_level_mapping.py \
-  src/instruction/wasm_X_Y \
-  .dev/wasm_3_0_zirop_mapping.md
+# (no dedicated checker script exists — cross-reference manually:)
+grep -rh 'wasm_level' src/instruction/wasm_X_Y/*.zig | sort | uniq -c
+# ...and compare the per-level counts against .dev/wasm_3_0_zirop_mapping.md
 ```
 
 (Python helper lands alongside §9.12-G when the mapping doc is

--- a/.dev/archive/consuming_prerelease_zwasm.md
+++ b/.dev/archive/consuming_prerelease_zwasm.md
@@ -1,6 +1,6 @@
 # Consuming pre-release zwasm reproducibly (for cljw / ClojureWasmFromScratch and others)
 
-> **Doc-state**: ACTIVE. Audience: any downstream that depends on `zwasm` while it
+> **Doc-state**: ARCHIVED (2026-08-12 sweep S5 — premise obsolete: stable v2 line shipped; the rc-era pin guidance is a version fossil). Audience: any downstream that depends on `zwasm` while it
 > is still pre-`v1`-parity / pre-`v2.0.0` final — primarily cljw (`build.zig.zon`
 > `.zwasm`). Answers: *"how do I reference zwasm so it also builds for others,
 > reproducibly?"*

--- a/.dev/archive/cw_v1_consumer_contracts.md
+++ b/.dev/archive/cw_v1_consumer_contracts.md
@@ -1,5 +1,7 @@
 # CW v1 consumer contracts — enforceable rails for Phase A-F
 
+> **Doc-state**: ARCHIVED (2026-08-12 sweep S5 — v1-era consumer contract; v2 surfaces superseded it, see docs/zig_api_design.md).
+
 **Date**: 2026-05-24 cycle 37 (post-CW-v1 deep feedback review)
 **Source**: ClojureWasmFromScratch consumer feedback (maintainer-local notes)
 (CW v1 private; gitignored on their side)

--- a/.dev/phase9_value_widen_plan.md
+++ b/.dev/phase9_value_widen_plan.md
@@ -211,7 +211,7 @@ green + commit. Windows reconcile at Phase 4 completion.
 
 **CW v1 consumer contract verification** (added cycle 37
 post-CW-v1 feedback; rails per
-[`../docs/cw_v1_consumer_contracts.md`](../docs/cw_v1_consumer_contracts.md)
+[`../docs/cw_v1_consumer_contracts.md`](archive/cw_v1_consumer_contracts.md)
 §6 checklist):
 
 - C-1: `comptime std.debug.assert(@alignOf(FuncEntity) >= 8)`

--- a/.dev/ubuntunote_setup.md
+++ b/.dev/ubuntunote_setup.md
@@ -158,7 +158,7 @@ overnight autonomous loop runs. If suspend is unavoidable:
   refused`).
 
 For now treat sleep as out-of-scope; if it becomes an issue,
-add a `scripts/wake_ubuntunote.sh` helper.
+add a wake helper script under `scripts/`.
 
 ## Gate integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
       - name: WASI 0.3 coverage claims
         shell: bash
         run: bash scripts/check_wasi03_coverage_claims.sh --gate
+      - name: Doc fossils (prerelease pins + dead script refs)
+        shell: bash
+        run: bash scripts/check_doc_fossils.sh --gate
 
   gate:
     name: gate (${{ matrix.name }})

--- a/build.zig
+++ b/build.zig
@@ -519,6 +519,18 @@ pub fn build(b: *std.Build) void {
     core_p3.addImport("build_options", p3_options_mod);
     core_p3.addIncludePath(b.path("include"));
     core_p3.addImport("zwasm", core_p3);
+    // `zig build test-list` — print every DISCOVERED test name (custom list
+    // runner; sweep S5(c)). Runs on the p3-forced module (the maximal file
+    // set); `scripts/check_test_discovery.sh` diffs this against the named
+    // `test "…"` blocks present in source to catch dead test blocks.
+    const list_tests = b.addTest(.{
+        .root_module = core_p3,
+        .test_runner = .{ .path = b.path("src/test_support/list_tests_runner.zig"), .mode = .simple },
+    });
+    const run_list_tests = b.addRunArtifact(list_tests);
+    const test_list_step = b.step("test-list", "List every discovered test name (S5 test-discovery guard input)");
+    test_list_step.dependOn(&run_list_tests.step);
+
     const p3_tests = b.addTest(.{
         .root_module = core_p3,
         .filters = if (b.option([]const u8, "test-filter", "run only tests whose name contains this string (test-wasi-p3)")) |f| b.dupeStrings(&.{f}) else &.{},

--- a/scripts/audit_blocked_by_age.sh
+++ b/scripts/audit_blocked_by_age.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# blocked-by staleness ladder (audit_scaffolding §F.2a; promised by the
+# 2026-05-21 blocked-by sweep, delivered by the 2026-08 S5 mechanization).
+#
+# Every `status: "blocked-by"`-class row in .dev/debt.yaml carries a
+# `last_reviewed` date; a barrier nobody has re-walked in >30 days is being
+# TRUSTED silently, which is how dissolved barriers (a closed campaign
+# removing the blocker) go unnoticed. Ladder: >14d WARN, >30d STALE.
+#
+# Modes:
+#   bash scripts/audit_blocked_by_age.sh          informational (always 0)
+#   bash scripts/audit_blocked_by_age.sh --gate   exit 1 when any row is STALE
+
+set -euo pipefail
+MODE="${1:-info}"
+cd "$(dirname "$0")/.."
+
+python3 - "$MODE" <<'PYEOF'
+import re, sys, datetime
+
+mode = sys.argv[1]
+text = open('.dev/debt.yaml').read()
+today = datetime.date.today()
+warn = stale = 0
+# rows are "- id:" blocks; a blocked-by row declares status: "blocked-by"
+for m in re.finditer(r'- id: "(D-\d+)"(.*?)(?=\n  - id: |\Z)', text, re.S):
+    rid, body = m.group(1), m.group(2)
+    if '"blocked-by"' not in body:
+        continue
+    lr = re.search(r'last_reviewed: "(\d{4}-\d{2}-\d{2})"', body)
+    if not lr:
+        print(f'STALE: {rid} — blocked-by row has NO last_reviewed date', file=sys.stderr)
+        stale += 1
+        continue
+    age = (today - datetime.date.fromisoformat(lr.group(1))).days
+    if age > 30:
+        print(f'STALE: {rid} — blocked-by barrier last reviewed {age}d ago ({lr.group(1)}); re-walk it', file=sys.stderr)
+        stale += 1
+    elif age > 14:
+        print(f'WARN: {rid} — blocked-by barrier last reviewed {age}d ago', file=sys.stderr)
+        warn += 1
+
+if stale or warn:
+    print(f'[audit_blocked_by_age] {stale} stale / {warn} aging blocked-by row(s)', file=sys.stderr)
+else:
+    print('[audit_blocked_by_age] OK — all blocked-by barriers recently reviewed', file=sys.stderr)
+sys.exit(1 if (mode == '--gate' and stale) else 0)
+PYEOF

--- a/scripts/check_doc_fossils.sh
+++ b/scripts/check_doc_fossils.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Doc-fossil guard (sweep S5(b)) — the doc-truth job's third leg.
+#
+# Two mechanized fossil classes the 2026-08 sweep found live instances of:
+#
+# 1. VERSION fossils: a hardcoded zwasm version string in the always-current
+#    docs (README, docs/**, .github/**) that does not match build.zig.zon's
+#    `.version`. Historical files are exempt: CHANGELOG (a ledger),
+#    .dev/decisions + .dev/lessons + .dev/phase_log + .dev/archive +
+#    .dev/meta_audits (dated records), and migration_v1_to_v2.md's v1 rows.
+#    The class instance: docs recommending a `v2.0.0-rc.1` pin long after
+#    stable shipped.
+#
+# 2. DEAD SCRIPT references: a `scripts/<name>.sh` mention in living docs
+#    (README, docs/**, .claude/**, .dev/*.md top level) whose target does
+#    not exist — the deleted-campaign-script class (e.g. docs instructing
+#    `should_gate_windows.sh` after its removal).
+#
+# Modes:
+#   bash scripts/check_doc_fossils.sh          informational
+#   bash scripts/check_doc_fossils.sh --gate   exit 1 on findings
+
+set -euo pipefail
+MODE="${1:-info}"
+cd "$(dirname "$0")/.."
+
+findings=0
+current_version=$(grep -oE '\.version = "[^"]+"' build.zig.zon | sed -E 's/.*"([^"]+)"/\1/')
+if [ -z "$current_version" ]; then
+    echo "[check_doc_fossils] FAIL — cannot read .version from build.zig.zon" >&2
+    exit 1
+fi
+
+# --- 1) version fossils -----------------------------------------------------
+# PRERELEASE version strings (v2.x.y-rc.N / -alpha.N / -beta.N) in living docs
+# are always fossils once the stable line ships (a stable "vX.Y.Z" can be a
+# permanent historical fact — "v2.0.0 is the first stable release" never rots —
+# so bare stable versions are NOT flagged).
+while IFS=: read -r file line content; do
+    [ -z "$file" ] && continue
+    for v in $(echo "$content" | grep -oE 'v2\.[0-9]+\.[0-9]+-(rc|alpha|beta)\.[0-9]+' | sort -u); do
+        echo "VERSION-FOSSIL: $file:$line — prerelease pin '$v' (current is v$current_version)" >&2
+        findings=$((findings + 1))
+    done
+done < <(grep -rnE 'v2\.[0-9]+\.[0-9]+-(rc|alpha|beta)\.[0-9]+' README.md docs .github --include='*.md' 2>/dev/null || true)
+
+# --- 2) dead script references ---------------------------------------------
+while IFS=: read -r file line content; do
+    [ -z "$file" ] && continue
+    # Historical docs (retired campaign machinery kept as reference) are exempt.
+    if head -5 "$file" 2>/dev/null | grep -qE 'RETIRED|Loop-era doc|ARCHIVED'; then continue; fi
+    # Negated mentions — a doc RECORDING a deletion or striking a name
+    # through is not a live instruction to run it.
+    case "$content" in *DELETED* | *deleted\ * | *~~*) continue ;; esac
+    for sref in $(echo "$content" | grep -oE 'scripts/[A-Za-z0-9_./-]+\.(sh|py)' | sort -u); do
+        if [ ! -f "$sref" ]; then
+            echo "DEAD-SCRIPT-REF: $file:$line — '$sref' does not exist" >&2
+            findings=$((findings + 1))
+        fi
+    done
+done < <(grep -rnE 'scripts/[A-Za-z0-9_./-]+\.(sh|py)' README.md docs .claude .dev/*.md --include='*.md' 2>/dev/null || true)
+
+if [ "$findings" -gt 0 ]; then
+    echo >&2
+    echo "[check_doc_fossils] $findings fossil(s) — update the doc to current reality (or move a historical doc under .dev/archive/)" >&2
+    [ "$MODE" = "--gate" ] && exit 1
+fi
+echo "[check_doc_fossils] OK (version v$current_version)" >&2
+exit 0

--- a/scripts/check_test_discovery.sh
+++ b/scripts/check_test_discovery.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Test-discovery guard (sweep S5(c); the D-444/ADR-0207 II-2a incident class).
+#
+# Zig runs a file's named `test "…"` blocks only when the file participates
+# in the test module's discovery graph — a plain `const x = @import(...)`
+# whose namespace is only partially analyzed does NOT reliably pull tests
+# in. `component_wasi_p2.zig` sat outside the graph and its in-file tests
+# (including a pre-existing one) never ran in ANY test step.
+#
+# Rather than approximate the compiler's discovery rules statically, this
+# guard asks the compiler: `zig build test-list` (a custom list runner over
+# the maximal, p3-forced module) prints every DISCOVERED test name; every
+# named test block present under src/ must appear in that listing.
+#
+# A file whose tests intentionally live outside the core test module can
+# carry `// TEST-DISCOVERY-EXEMPT: <reason>` on lines 1-5.
+#
+# Modes:
+#   bash scripts/check_test_discovery.sh          informational
+#   bash scripts/check_test_discovery.sh --gate   exit 1 on findings
+
+set -euo pipefail
+MODE="${1:-info}"
+cd "$(dirname "$0")/.."
+
+listing=$(mktemp)
+trap 'rm -f "$listing"' EXIT
+if ! zig build test-list > "$listing" 2>/dev/null; then
+    echo "[check_test_discovery] FAIL — 'zig build test-list' did not run" >&2
+    exit 1
+fi
+# Qualified names look like "<namespace>.test.<name>"; membership is checked
+# on the raw <name> (first ".test." split).
+sed -E 's/^.*\.test\.//' "$listing" | sort -u > "$listing.names"
+
+# Name extraction + comparison in python: test names may contain escaped
+# quotes/backslashes, which the listing prints raw.
+findings=$(python3 - "$listing.names" <<'PYEOF'
+import re, sys, pathlib
+names = set(pathlib.Path(sys.argv[1]).read_text().splitlines())
+count = 0
+for f in sorted(pathlib.Path('src').rglob('*.zig')):
+    text = f.read_text()
+    head = "\n".join(text.splitlines()[:5])
+    if 'TEST-DISCOVERY-EXEMPT' in head:
+        continue
+    for m in re.finditer(r'^test "((?:\\.|[^"\\])*)"', text, re.M):
+        name = m.group(1).replace('\\"', '"').replace('\\\\', '\\')
+        if name not in names:
+            print(f'DEAD-TEST: {f} — test "{name}" is NOT discovered by any test step', file=sys.stderr)
+            count += 1
+print(count)
+PYEOF
+)
+rm -f "$listing.names"
+
+if [ "$findings" -gt 0 ]; then
+    echo >&2
+    echo "[check_test_discovery] $findings dead named test block(s) — wire the file into the test-discovery graph ('_ = @import(\"<file>\");' in src/zwasm.zig's test block or a discovered sibling's), or mark the file TEST-DISCOVERY-EXEMPT with a reason" >&2
+    [ "$MODE" = "--gate" ] && exit 1
+fi
+echo "[check_test_discovery] OK" >&2
+exit 0

--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -75,6 +75,15 @@ if [ "${ZWASM_CI_EXTENDED:-0}" = "1" ]; then
     # FP spill stage-2, D-506). Baseline is 0; --gate rejects any regression.
     echo "[ci_gate] extended: spill-aware op-handler check (spill_aware_check --gate)"
     bash scripts/spill_aware_check.sh --gate
+
+    # Sweep S5 (2026-08-12): the growth ratchet gates DELTA on already-over-cap
+    # files (the absolute caps stay advisory per ADR-0099); the discovery guard
+    # compares source test blocks against the compiler's own test listing
+    # (the ADR-0207 II-2a dead-test incident class).
+    echo "[ci_gate] extended: file growth ratchet (file_growth_ratchet --gate)"
+    RATCHET_BASE="${RATCHET_BASE:-origin/main}" bash scripts/file_growth_ratchet.sh --gate
+    echo "[ci_gate] extended: test-discovery guard (check_test_discovery --gate)"
+    bash scripts/check_test_discovery.sh --gate
 fi
 
 echo "[ci_gate] OK ($(uname -s))"

--- a/scripts/file_growth_ratchet.sh
+++ b/scripts/file_growth_ratchet.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# File-size GROWTH ratchet (sweep S5(a), ADR-0099 companion).
+#
+# The absolute caps in file_size_check.sh are ADVISORY (ADR-0099 amended
+# 2026-07-03) — which is exactly how component_wasi_p2.zig grew 2228→5470
+# lines silently. This ratchet gates the DELTA instead of the absolute:
+# a .zig file that is ALREADY over its effective hard cap may not grow
+# further in a change, unless the same change adds or edits its
+# FILE-SIZE-EXEMPT marker line (= the growth was re-justified, not silent).
+#
+# Cap resolution mirrors file_size_check.sh: hard 2000; a FILE-SIZE-EXEMPT
+# marker citing an ADR raises it to 2500; `(cap=N)` overrides; `(cap=UNCAPPED)`
+# and AUTO-GENERATED files are never ratcheted.
+#
+# Base selection:
+#   RATCHET_BASE=<git-ref>   compare HEAD-tree paths against this ref
+#                            (CI: the PR merge-base, e.g. origin/main)
+#   default                  compare the working tree / index against HEAD
+#                            (pre-commit shape)
+#
+# Modes:
+#   bash scripts/file_growth_ratchet.sh          informational
+#   bash scripts/file_growth_ratchet.sh --gate   exit 1 on ratchet violation
+
+set -euo pipefail
+
+MODE="${1:-info}"
+BASE="${RATCHET_BASE:-HEAD}"
+HARD_CAP=2000
+EXEMPT_CAP=2500
+
+cd "$(dirname "$0")/.."
+
+if ! git rev-parse --verify --quiet "$BASE^{commit}" > /dev/null 2>&1; then
+    # A shallow CI checkout may lack the base ref — say so loudly and skip
+    # (the ratchet needs history; set RATCHET_BASE or deepen the fetch).
+    echo "[file_growth_ratchet] SKIP — base '$BASE' is not resolvable in this checkout" >&2
+    exit 0
+fi
+
+effective_cap_of() {
+    # $1 = file content on stdin? No — bash: pass content via a temp file.
+    local file="$1"
+    local marker
+    marker=$(head -5 "$file" 2>/dev/null | grep -E '^// FILE-SIZE-EXEMPT:.*ADR-[0-9]+' | head -1 || true)
+    if head -3 "$file" 2>/dev/null | grep -q 'AUTO-GENERATED'; then
+        echo "skip"
+        return
+    fi
+    if [ -n "$marker" ]; then
+        if echo "$marker" | grep -q '(cap=UNCAPPED)'; then
+            echo "skip"
+            return
+        fi
+        local cap_extract
+        cap_extract=$(echo "$marker" | sed -nE 's/.*\(cap=([0-9]+)\).*/\1/p' || true)
+        if [ -n "$cap_extract" ] && [ "$cap_extract" -gt "$EXEMPT_CAP" ]; then
+            echo "$cap_extract"
+            return
+        fi
+        echo "$EXEMPT_CAP"
+        return
+    fi
+    echo "$HARD_CAP"
+}
+
+violations=0
+tmp_old=$(mktemp)
+trap 'rm -f "$tmp_old"' EXIT
+
+while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    case "$f" in src/*.zig | src/**/*.zig) ;; *) continue ;; esac
+    [ -f "$f" ] || continue # deleted file — never a growth
+
+    if ! git cat-file -e "$BASE:$f" 2>/dev/null; then
+        continue # new file — absolute caps (file_size_check) own it
+    fi
+    git show "$BASE:$f" > "$tmp_old"
+    old_lines=$(wc -l < "$tmp_old" | tr -d ' ')
+    new_lines=$(wc -l < "$f" | tr -d ' ')
+    [ "$new_lines" -le "$old_lines" ] && continue # shrink/steady is always fine
+
+    old_cap=$(effective_cap_of "$tmp_old")
+    [ "$old_cap" = "skip" ] && continue
+    [ "$old_lines" -le "$old_cap" ] && continue # was under cap — absolute checks own it
+
+    # Already-over-cap file grew. A changed FILE-SIZE-EXEMPT marker line in
+    # this diff = deliberate re-justification; otherwise it is silent growth.
+    old_marker=$(head -5 "$tmp_old" | grep -E '^// FILE-SIZE-EXEMPT:' | head -1 || true)
+    new_marker=$(head -5 "$f" | grep -E '^// FILE-SIZE-EXEMPT:' | head -1 || true)
+    if [ -n "$new_marker" ] && [ "$new_marker" != "$old_marker" ]; then
+        echo "RATCHET-EXEMPT: $f ($old_lines → $new_lines) — over-cap growth re-justified by an updated FILE-SIZE-EXEMPT marker" >&2
+        continue
+    fi
+
+    echo "RATCHET: $f ($old_lines → $new_lines, cap=$old_cap) — an already-over-cap file grew without an updated FILE-SIZE-EXEMPT marker" >&2
+    violations=$((violations + 1))
+done < <(git diff --name-only "$BASE" -- 'src/*.zig' 'src/**/*.zig'; git diff --name-only --cached -- 'src/*.zig' 'src/**/*.zig')
+
+if [ "$violations" -gt 0 ]; then
+    echo >&2
+    echo "[file_growth_ratchet] $violations over-cap file(s) grew silently — split per ADR-0099 P/N, or update the FILE-SIZE-EXEMPT marker with the re-justification" >&2
+    if [ "$MODE" = "--gate" ]; then
+        exit 1
+    fi
+fi
+echo "[file_growth_ratchet] OK (base=$BASE)" >&2
+exit 0

--- a/scripts/gate_commit.sh
+++ b/scripts/gate_commit.sh
@@ -158,6 +158,8 @@ else
 
     echo "[gate_commit] file_size_check --gate ..."
     bash scripts/file_size_check.sh --gate
+    echo "[gate_commit] file_growth_ratchet --gate ..."
+    bash scripts/file_growth_ratchet.sh --gate
 
     # D-505: spill-aware op-handler convention (bare resolveGpr/Fp on a spilled
     # vreg → UnsupportedOp JIT-reject). Cheap pure-awk walk of the codegen

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1,3 +1,4 @@
+// TEST-DISCOVERY-EXEMPT: tested as its own root module by build.zig's cli_tests (exe_mod addTest) — outside the core_p3 listing that check_test_discovery.sh compares against.
 //! `zwasm` CLI exe entry.
 //!
 //! Per ADR-0024 D-4: lives at `src/cli/main.zig` (not at the

--- a/src/test_support/list_tests_runner.zig
+++ b/src/test_support/list_tests_runner.zig
@@ -1,0 +1,17 @@
+//! Custom test runner that LISTS discovered test names instead of running
+//! them — the compiler-truth side of `scripts/check_test_discovery.sh`
+//! (sweep S5(c)): a named `test "…"` block that exists in source but does
+//! not appear in this listing is dead (never executed by any test step),
+//! the D-444/ADR-0207 II-2a incident class.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn main(init: std.process.Init) !void {
+    var buf: [4096]u8 = undefined;
+    var w = std.Io.File.stdout().writerStreaming(init.io, &buf);
+    for (builtin.test_functions) |t| {
+        try w.interface.print("{s}\n", .{t.name});
+    }
+    try w.interface.flush();
+}

--- a/src/wasi/p2_sockets.zig
+++ b/src/wasi/p2_sockets.zig
@@ -1041,7 +1041,6 @@ fn winUdpBind(family: AddressFamily, addr: net.IpAddress) !net.Socket {
 // Tests
 // ============================================================
 const testing = std.testing;
-const skip = @import("../test_support/skip.zig");
 
 test "tcp client lifecycle: create → connect → echo against a loopback listener" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});

--- a/src/zwasm.zig
+++ b/src/zwasm.zig
@@ -402,6 +402,14 @@ test {
     _ = @import("instruction/wasm_2_0/reference_types.zig");
     _ = @import("instruction/wasm_2_0/table_ops.zig");
     _ = @import("api/wasm.zig");
+    // S5 test-discovery guard (check_test_discovery.sh) backfill: these
+    // files carried named tests that no test step discovered.
+    _ = @import("engine/codegen/x86_64/frame_chain.zig");
+    _ = @import("engine/codegen/x86_64/sp_restore.zig");
+    _ = @import("engine/codegen/arm64/sp_restore.zig");
+    _ = @import("engine/codegen/shared/frame_teardown.zig");
+    _ = @import("ir/feature_level_check.zig");
+    _ = @import("test_support/skip.zig");
     _ = @import("wasi/preview1.zig");
     _ = @import("wasi/host.zig");
     _ = @import("wasi/proc.zig");


### PR DESCRIPTION
## What

The sweep's S5 axis: mechanize the drift classes the sweep found live instances of, so they cannot recur silently.

- **`scripts/file_growth_ratchet.sh`** (pre-commit + CI extended): ADR-0099's absolute caps stay advisory, but an **already-over-cap** src file may no longer *grow* in a change unless the same change updates its `FILE-SIZE-EXEMPT` marker (deliberate re-justification). This is the delta-gate that would have caught `component_wasi_p2.zig`'s silent 2228→5470 growth. Verified both ways (fires on growth, clean otherwise); skips loudly when the base ref is unresolvable.
- **`scripts/check_test_discovery.sh`** (CI extended) + a **`zig build test-list`** step (custom list runner printing `builtin.test_functions`): every named `test "…"` block under `src/` must appear in the compiler's own discovered-test listing — static approximations of Zig's discovery rules proved unreliable in both directions, so the guard asks the compiler. **It found 28 never-executed tests** (x86_64 `frame_chain`/`sp_restore`, arm64 `sp_restore`, shared `frame_teardown`, `feature_level_check`, `test_support/skip`) — now wired into discovery and all passing; `cli/main.zig` carries a marker-exemption (tested by its own `cli_tests` root module).
- **`scripts/check_doc_fossils.sh`** (the `doc-truth` CI job's third leg): prerelease version pins (`v2.x.y-rc.N` class) and dead `scripts/` references in living docs; historical/negated mentions are exempt. Baseline is 0 after fixing the 12 live fossils it caught — two obsolete docs (`consuming_prerelease_zwasm.md`, `cw_v1_consumer_contracts.md`) moved to `.dev/archive/` with Doc-state flips, three stale instructions corrected to reality.
- **`scripts/audit_blocked_by_age.sh`**: the blocked-by staleness ladder the 2026-05-21 sweep promised (>14d WARN / >30d STALE). It currently reports 17 STALE rows — that re-walk is queued as sweep follow-up; the script stays informational until it lands.

Also drops `p2_sockets.zig`'s unused `skip` import (the same one-line deletion rides on #169/#170/#171; identical hunks merge cleanly).

## Verification

All four guards green on this branch (fossil baseline 0, discovery 0 dead, ratchet clean) · unit tests 3077 pass (was 3048 — +29 newly-discovered tests all pass) · p3 suite 3153 pass · lint No issues.