### PR TITLE
docs: README + referenced docs final-form — history archived, personal-infra mentions zeroed (sweep S6)

### DIFF
--- a/.dev/archive/handoff_cw_v1.md
+++ b/.dev/archive/handoff_cw_v1.md
@@ -1,6 +1,6 @@
 # zwasm → ClojureWasm v1 handoff (v2 shipped to main 2026-07-01)
 
-> **Doc-state**: ACTIVE
+> **Doc-state**: ARCHIVED (2026-08-12 sweep S6 — v1-era cljw handoff narrative (campaign pause record)).
 >
 > zwasm v2 shipped to `main` (2026-07-01) and its dev is **demand-driven**,
 > verified green on Mac aarch64 + ubuntu x86_64. The runtime is feature-complete

--- a/.dev/archive/handoff_cw_v2_zig_api.md
+++ b/.dev/archive/handoff_cw_v2_zig_api.md
@@ -1,5 +1,7 @@
 # zwasm v2 — Zig embedding API, current-state handoff (ClojureWasm)
 
+> **Doc-state**: ARCHIVED (2026-08-12 sweep S6 — point-in-time cljw handoff (hardcoded release line); superseded by docs/reference/zig_api.md).
+
 > Audience: ClojureWasm (cljw / CWFS) maintainers embedding zwasm **v2** from Zig.
 > This is a **current-state reference** — "here is the API as it stands now",
 > not a changelog. For deep design rationale see

--- a/.dev/archive/migration_v1_to_v2.md
+++ b/.dev/archive/migration_v1_to_v2.md
@@ -1,5 +1,7 @@
 # zwasm v1 → v2 migration guide
 
+> **Doc-state**: ARCHIVED (2026-08-12 sweep S6 — v1→v2 migration guide; audience (~zero v1 users) evaporated post-stable — the live fact (MIT→Apache-2.0 relicense) moved to README).
+
 zwasm **v2** is a ground-up rewrite (releases `v1.0.0`–`v1.11.1` are v1, now
 frozen; v2 ships as `v2.x.x` tags, first stable `v2.0.0`).
 It keeps full Wasm spec coverage (Wasm 1.0/2.0/3.0, WASI 0.1/0.2, plus an

--- a/.dev/archive/runtime_deep_comparison.md
+++ b/.dev/archive/runtime_deep_comparison.md
@@ -1,5 +1,7 @@
 # Wasm runtime deep comparison — Value / Globals / 17-dimension audit
 
+> **Doc-state**: ARCHIVED (2026-08-12 sweep S6 — 2026-05 runtime survey citing maintainer-local sources).
+
 **Date**: 2026-05-24 (post-repo-update audit; HEAD SHAs cited
 per-runtime below).
 **Scope**: 8 runtimes surveyed at internal-representation depth,

--- a/.dev/archive/v1_contributor_history.md
+++ b/.dev/archive/v1_contributor_history.md
@@ -1,5 +1,7 @@
 # zwasm v1 — contributor PR / issue history
 
+> **Doc-state**: ARCHIVED (2026-08-12 sweep S6 — v1 community contributor record; groundwork done).
+
 > **Scope**: this records the *community* contribution history of **zwasm v1**
 > (the published `clojurewasm/zwasm` repository, releases `v1.0.0` → `v1.11.0`),
 > as groundwork for the v2 release. Both now live in `$MY/zwasm` (unified working

--- a/.dev/archive/zig_api_design.md
+++ b/.dev/archive/zig_api_design.md
@@ -1,5 +1,7 @@
 # zwasm v2 — Zig API design spec (target)
 
+> **Doc-state**: ARCHIVED (2026-08-12 sweep S6 — ADR-0109 design derivation; superseded by docs/reference/zig_api.md).
+
 **Status**: Live consumer spec for the native Zig API. ADR-0109
 **Accepted 2026-05-25** authorizes the rewrite; ROADMAP §10 /
 10.J carries the implementation cycles.

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -5,15 +5,15 @@
 
 ## Current state — MAINTENANCE MODE (post-v2.0.0)
 
-**v2.5.0 TAG ON HOLD (user 2026-08-11)**: main (`f4157226d`, #167) already
-carries `build.zig.zon = 2.5.0` + the cut CHANGELOG section — prepared but
-NOT tagged (remote tags end at v2.4.1; verified). The user paused the tag to
-run the cleanliness sweep (front below) first; the sweep is internal-only,
-so it ships under the same v2.5.0 when the user tags
-(`git tag v2.5.0 <sha> && git push origin v2.5.0` → release.yml publishes).
-Prior line v2.4.1; v1 frozen at `v1.11.1`. Dev model: `develop/<slug>` from
-`main` → PR → CI `ci-required` green → merge. **Release stays user-only
-(ADR-0156)** — never autonomously tag / publish / cut over.
+**v2.5.0 READY TO TAG (sweep COMPLETE 2026-08-12)**: the user-directed
+pre-tag cleanliness sweep (S1-S6) is DONE — S1-S5 merged as #175, S6
+(docs final-form) is the PR in flight / just merged. main carries
+`build.zig.zon = 2.5.0` + the CHANGELOG section; remote tags end at
+v2.4.1. **The only remaining step is the USER pushing the tag**
+(`git tag v2.5.0 <sha> && git push origin v2.5.0` → release.yml
+publishes; ADR-0156 — never autonomous). Prior line v2.4.1; v1 frozen
+at `v1.11.1`. Dev model: `develop/<slug>` from `main` → PR → CI
+`ci-required` green → merge.
 
 ## Closed campaigns (details in the cited ADR/CHANGELOG)
 
@@ -32,53 +32,23 @@ Prior line v2.4.1; v1 frozen at `v1.11.1`. Dev model: `develop/<slug>` from
   CI **`doc-truth` job**). Binary-size CLOSED (ADR-0204). AOT full-fidelity
   CLOSED (ADR-0203; residual D-515(2)+D-514).
 
-## Active front — 完成形 cleanliness sweep (user-directed 2026-08-11, PRE-TAG)
+## Cleanliness sweep S1-S6 — COMPLETE (2026-08-12)
 
-The NEXT session's mandate (user: 腰を据えて — design / build flags / runtime
-options / directory+file organization all genuinely clean, PLUS mechanize
-what failed to prevent the drift). Concrete axes, each → its own PR(s):
-
-- **S1 file/dir organization**: 30 files over ADR-0099 caps (advisory since
-  2026-07-03 — which is exactly why `component_wasi_p2.zig` grew 2228→5470
-  SILENTLY, now over even its exempt cap; `jit_abi.zig` 2027 > hard cap).
-  D-444 Phase-I is DONE (findings in the row, 2026-08-11): the one-way split
-  premise is WRONG — 3 reverse deps + a generation-neutral host-stream
-  engine ⇒ THREE-way split (shared substrate / P2 / P3) with vtable
-  inversion. Run as ADR-0153 rework (II characterization net = 76+61
-  sibling tests BEFORE moving code). Then triage the remaining over-cap
-  list per ADR-0099 P/N conditions (split on positive, EXEMPT with real
-  rationale otherwise).
-- **S2 build-flag surface**: D-525 `-Dgc` is INERT (option exists, reader
-  is dead) — fix or remove; audit the whole `-D` surface for tier
-  coherence (`-Dwasm`/`-Dwasi` orderings, `-Dengine`, `-Dcompiler-rt`,
-  `-Dtask`…) against docs/development.md + README claims.
-- **S3 runtime/CLI option surface**: `zwasm --help` あるべき論 audit —
-  naming/defaults/coverage vs the engine reality (auto/interp/jit), env
-  vars (ZWASM_*) inventoried + documented or removed.
-- **S4 doc/claim fossils**: the class found twice today (CLAUDE.md stuck at
-  v2.0.0-rc.1; ubuntunote_setup referencing deleted scripts) — run
-  `audit_scaffolding` §A–G full pass now that two campaigns closed
-  back-to-back.
-- **S5 mechanization (prevention)**: (a) file-size GROWTH ratchet — advisory
-  cap can stay, but a file ALREADY over cap growing further in a PR should
-  gate (delta-ratchet, not absolute); (b) version/claim fossil guard —
-  extend the doc-truth job pattern; (c) whatever S2/S3 finds systemic.
-- **S6 README+docs 完成形化 (user 2026-08-11, runs AFTER S1–S5)**: README +
-  every doc it references — delete / archive / update to current state;
-  final-form only (spec・status・guides), no development history (assume
-  ~zero v1 users; cut docs/ sprawl). HARD: public docs get ZERO mentions
-  of the personal 3-host SSH setup or `private/` (PC-local).
-- Exit: axes S1–S6 each closed-or-ADR'd, THEN user tags v2.5.0.
-
-## S1 status (campaign CLOSED 2026-08-12)
-
-- **D-444 DISCHARGED** — ADR-0207 three-way split landed on this branch
-  (M1-M4 + Phase V retrospective in the ADR; ctx 1342 / facade 2017 EXEMPT /
-  p3_host 2493 EXEMPT; hooks inversion; full net green each commit). Branch
-  `develop/s1-d444-three-way-split` → PR to main next.
-- **S1 remainder**: triage the other over-cap files (jit_abi 2027 hard-cap +
-  ~28 WARN-class incl. component_wasi_p3.zig 1471) per ADR-0099 P/N — next
-  branch after this PR merges.
+All six axes closed (plan was #168; S1-S5 consolidated+merged as #175):
+- **S1** D-444 three-way split (ADR-0207) + full over-cap triage —
+  `file_size_check` 0 WARN repo-wide (was 30); canon/types P1 seams
+  scheduled post-tag (D-580/D-581).
+- **S2** -Dgc + run-repro retired (D-525; ADR-0115/0015 revision notes);
+  Windows sanitize rejects loudly; build-option table in development.md.
+- **S3** --engine auto spellable; usage errors exit 2 uniformly; env
+  surface audited (no hidden flags).
+- **S4** audit fixes: ROADMAP links, blocked-by re-walk (6 dissolved
+  barriers flipped w/ evidence), doc-states.
+- **S5** four guards live: growth ratchet, compiler-truth test-discovery
+  (28 dead tests revived), doc-fossil guard (doc-truth job), blocked-by
+  age ladder. 
+- **S6** README+docs final-form: 6 history docs archived w/ Doc-state,
+  public docs carry ZERO personal-infra/private/ mentions, links verified.
 
 ## Operational invariants (keep using)
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in zwasm.
 
 ## How to contribute
 
-zwasm v2 has reached its first release candidate and welcomes contributions.
+zwasm v2 is on its stable release line and welcomes contributions.
 This is a small, resource-limited project, so please keep the following in mind
 to make review sustainable:
 
@@ -54,8 +54,8 @@ zig fmt src/           # format
 
 **[`docs/development.md`](../docs/development.md) is the full development
 reference** — test layers, optional tools (wasmtime oracle, Nix shells,
-`yq`), git-hook activation, and an explicit list of the maintainer-only
-things you do NOT need (SSH gate hosts, `private/`, fixture-regeneration
+`yq`), git-hook activation, and an explicit list of the optional tooling
+you do NOT need (remote pre-flight scripts, fixture-regeneration
 toolchains). CI runs the complete 3-OS gate on every PR, so a single
 machine of any supported OS is enough to contribute.
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,19 @@ A from-scratch WebAssembly runtime in Zig 0.16.0.
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/chaploud?logo=githubsponsors&logoColor=white&color=ea4aaa)](https://github.com/sponsors/chaploud)
 
-> **Status: feature-complete and green on the 3-host gate**
-> (Mac aarch64 + Linux x86_64 + Windows x86_64). Full WebAssembly 3.0 + WASI
-> preview1 & preview2 (Component Model), interpreter + JIT (arm64 / x86_64) +
-> AOT (`.cwasm`), and the C / Zig / CLI surfaces are settled. **`v2.0.0` is the
-> first stable release** (SemVer starts here; v1 is frozen at `v1.11.1`).
+> **Status: feature-complete and green on the 3-OS CI matrix**
+> (macOS aarch64 + Linux x86_64 + Windows x86_64). Full WebAssembly 3.0 + WASI
+> 0.1, 0.2 (Component Model) and 0.3 (native async), interpreter + JIT
+> (arm64 / x86_64) + AOT (`.cwasm`), and the C / Zig / CLI surfaces are
+> settled. **`v2.0.0` is the first stable release** (SemVer starts here;
+> v1 is frozen at `v1.11.1`); the current line is on
+> [Releases](https://github.com/clojurewasm/zwasm/releases).
 
 v2 is a ground-up redesign of [zwasm v1](https://github.com/clojurewasm/zwasm)
 with day-one design for WebAssembly 3.0, wasm-c-api conformance, and
 dual-backend (interpreter + JIT-arm64 + JIT-x86) differential testing.
-v1 ABI compatibility is out of scope — see the
-[migration guide](docs/migration_v1_to_v2.md).
+v1 ABI compatibility is out of scope (v1 is frozen at `v1.11.1`; the v2
+line also relicensed from v1's MIT to Apache-2.0).
 
 ## Supported platforms
 
@@ -42,9 +44,9 @@ now (demand-driven).
 
 | Spec                                                                                                            | Status  | Notes                                                    |
 |-----------------------------------------------------------------------------------------------------------------|---------|----------------------------------------------------------|
-| Wasm 1.0                                                                                                        | ✅ 100% | spec testsuite green on the 3-host gate                  |
+| Wasm 1.0                                                                                                        | ✅ 100% | spec testsuite green on the 3-OS CI matrix                |
 | Wasm 2.0 (multi-value, SIMD-128, bulk-memory, reference-types, non-trapping FP→int, sign-ext, mutable globals) | ✅ 100% | `skip-impl == 0`; bit-identical across hosts             |
-| Wasm 3.0 (GC, EH, tail-call, memory64, multi-memory, typed func refs, extended-const, relaxed-simd, custom annotations) | ✅ 100% | all 9 proposals; spec testsuite green on the 3-host gate |
+| Wasm 3.0 (GC, EH, tail-call, memory64, multi-memory, typed func refs, extended-const, relaxed-simd, custom annotations) | ✅ 100% | all 9 proposals; spec testsuite green on the 3-OS CI matrix |
 
 ### WASI
 
@@ -212,13 +214,12 @@ src/         Zig sources (parse/ validate/ ir/ runtime/ instruction/ feature/
 include/     Public C headers (wasm.h / wasi.h / zwasm.h)
 build.zig    Build script
 flake.nix    Nix dev shell pinned to Zig 0.16.0
-docs/        Migration guide + design docs
+docs/        Tutorial + API reference + benchmarks
 .dev/        ROADMAP + handover + ADRs + lessons + setup notes
 .claude/     Claude Code settings, skills, rules (auto-loaded)
-scripts/     gate_commit, zone_check, file_size_check, bench, run_remote_*
+scripts/     pre-commit gate + integrity checks + bench tooling
 test/        per-layer suites; unified `zig build test-all`
 bench/       benchmark history (append-only)
-private/     gitignored maintainer scratch (never required; docs/development.md)
 ```
 
 ## Documentation
@@ -227,9 +228,6 @@ private/     gitignored maintainer scratch (never required; docs/development.md)
 - [`docs/reference/`](docs/reference/) — API reference:
   [Zig](docs/reference/zig_api.md) · [C](docs/reference/c_api.md) · [CLI](docs/reference/cli.md)
 - [`docs/benchmarks.md`](docs/benchmarks.md) — performance vs other runtimes + across engines
-- [`docs/migration_v1_to_v2.md`](docs/migration_v1_to_v2.md) — v1 → v2 migration + the honest v1-vs-v2 gap analysis
-- [`docs/handoff_cw_v2_zig_api.md`](docs/handoff_cw_v2_zig_api.md) — current-state Zig embedding API (ClojureWasm handoff)
-- [`docs/v1_contributor_history.md`](docs/v1_contributor_history.md) — v1 community contributors + their PRs/issues
 - [`CHANGELOG.md`](CHANGELOG.md) — release notes
 
 ## References

--- a/docs/development.md
+++ b/docs/development.md
@@ -121,21 +121,18 @@ toolchains — see [`.dev/toolchain_provisioning.md`](../.dev/toolchain_provisio
 
 ## Things you may see referenced but do NOT need
 
-- **SSH gate hosts** (`ubuntunote`, `windowsmini`): the maintainer's private
-  pre-PR mirror of the CI matrix
-  ([`scripts/gate_merge.sh`](../scripts/gate_merge.sh),
-  `scripts/run_remote_*.sh`). Entirely optional — CI is the gate. To run the
-  same fan-out against **your own** hosts (matching architectures: x86_64
-  Linux + x86_64 Windows), copy
+- **Remote pre-flight scripts** (`scripts/gate_merge.sh`,
+  `scripts/run_remote_*.sh`): an *optional* local mirror of the CI matrix for
+  anyone with spare x86_64 Linux / Windows machines. CI is the authoritative
+  gate — you never need these. To use them, copy
   [`scripts/dev_hosts.env.example`](../scripts/dev_hosts.env.example) to
-  `scripts/dev_hosts.env` (gitignored) and edit the three values — every
-  remote-gate script sources it. Host provisioning notes:
-  `.dev/ubuntunote_setup.md` / `.dev/windows_ssh_setup.md`.
-- **`private/`**: a gitignored maintainer scratch directory (spikes, notes,
-  debug repros). No build or test path requires it; scripts that look inside
-  it skip cleanly when it is absent. Never create it for a contribution.
-- **Reference clones** (`~/Documents/OSS/...` paths in `.dev/` docs): the
-  maintainer's local layout for reading other runtimes' source
+  `scripts/dev_hosts.env` (gitignored) and point the three values at your own
+  hosts; every remote-gate script sources it.
+- **Gitignored local scratch**: a few scripts probe gitignored local paths and
+  skip cleanly when they are absent. No build, test, or review path requires
+  any file outside the committed tree.
+- **Reference clones** (`~/Documents/OSS/...` paths in `.dev/` docs): a local
+  layout for reading other runtimes' source
   ([`.dev/reference_clones.md`](../.dev/reference_clones.md)) — not required
   to build, test, or review.
 - **`.claude/`**: AI-agent workflow scaffolding (skills, session rules).

--- a/docs/reference/c_api.md
+++ b/docs/reference/c_api.md
@@ -35,7 +35,7 @@ Full coverage of the wasm-c-api families:
 Residual *semantic* limits (functions exist + behave honestly, not
 link-stubbed): `wasm_val` `of.ref` = raw payload (D-269); standalone /
 instance / foreign `_copy` → null (D-253-D); `serialize` = source bytes,
-no AOT cache (D-271). Audit: [`.dev/c_api_surface_audit_2026-06-04.md`](../../.dev/c_api_surface_audit_2026-06-04.md).
+no AOT cache (D-271).
 
 ## WASI host-setup (`wasi.h`)
 

--- a/docs/reference/zig_api.md
+++ b/docs/reference/zig_api.md
@@ -76,7 +76,3 @@ full `Trap` set, so callers branch on the exact spec condition.
 `StartTrapped` (the `(start)` function trapped) / `MemoryLimitExceeded` /
 `TableLimitExceeded` (declared initial exceeds the `opts` cap) / `InstantiateFailed`
 (any other link/alloc failure).
-
-## Design docs
-
-- [`docs/zig_api_design.md`](../zig_api_design.md) — the rationale + ADR-0109 derivation.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -93,7 +93,8 @@ is configured via [`include/wasi.h`](../include/wasi.h). Runnable:
 [`docs/examples/c_host/`](examples/c_host/). Reference:
 [`reference/c_api.md`](reference/c_api.md).
 
-## 6. Migrating from v1
+## 6. Coming from v1
 
-v2 breaks v1's ABI by design. See
-[`migration_v1_to_v2.md`](migration_v1_to_v2.md).
+v2 breaks v1's ABI by design (v1 is frozen at `v1.11.1`): re-embed against
+the current C / Zig / CLI surfaces documented in
+[`reference/`](reference/).

--- a/scripts/check_engine_default_claims.sh
+++ b/scripts/check_engine_default_claims.sh
@@ -30,7 +30,7 @@ cd "$repo_root" || exit 2
 ANCHOR_FILE="src/cli/dispatch.zig"
 
 # Paths whose interp-is-default text is a dated record, not a live claim.
-EXEMPT_RE='^(bench/|CHANGELOG\.md$|docs/handoff_cw_v1\.md$|\.dev/lessons/|\.dev/decisions/|\.dev/phase_log/|\.dev/meta_audits/|\.dev/debt\.yaml$|\.devils-advocate/|scripts/check_engine_default_claims\.sh$)'
+EXEMPT_RE='^(bench/|CHANGELOG\.md$|\.dev/archive/|\.dev/lessons/|\.dev/decisions/|\.dev/phase_log/|\.dev/meta_audits/|\.dev/debt\.yaml$|\.devils-advocate/|scripts/check_engine_default_claims\.sh$)'
 
 # Phrasings that assert the interpreter is zwasm's default. Matched
 # case-insensitively; `[`*]*` absorbs the markdown emphasis these names almost

--- a/scripts/check_wasi03_coverage_claims.sh
+++ b/scripts/check_wasi03_coverage_claims.sh
@@ -33,7 +33,7 @@ cd "$repo_root" || exit 2
 ANCHOR_FILE="src/api/component_wasi_p3.zig"
 
 # Dated records, not live claims.
-EXEMPT_RE='^(bench/|CHANGELOG\.md$|docs/handoff_cw_v1\.md$|\.dev/lessons/|\.dev/decisions/|\.dev/phase_log/|\.dev/meta_audits/|\.dev/debt\.yaml$|\.dev/handover\.md$|\.dev/proposal_watch\.md$|\.devils-advocate/|scripts/check_wasi03_coverage_claims\.sh$)'
+EXEMPT_RE='^(bench/|CHANGELOG\.md$|\.dev/archive/|\.dev/lessons/|\.dev/decisions/|\.dev/phase_log/|\.dev/meta_audits/|\.dev/debt\.yaml$|\.dev/handover\.md$|\.dev/proposal_watch\.md$|\.devils-advocate/|scripts/check_wasi03_coverage_claims\.sh$)'
 
 # Phrasings that assert a WASI 0.3 proposal is NOT served. Matched
 # case-insensitively; the proposal name must co-occur with a not-done word on


### PR DESCRIPTION
## What

The sweep's final axis (S6, user-directed): public documentation describes the **current** spec / status / guides only — no development history, no maintainer-personal infrastructure.

- **Six history docs archived** to `.dev/archive/` with ARCHIVED doc-states: `migration_v1_to_v2` (audience of v1 users is ~zero post-stable; the one live fact — the MIT→Apache-2.0 relicense — moved into README), `handoff_cw_v1`, `handoff_cw_v2_zig_api` (hardcoded a release line, superseded by `reference/zig_api.md`), `v1_contributor_history`, `zig_api_design` (superseded by `reference/zig_api.md`), `runtime_deep_comparison` (cited maintainer-local sources).
- **README**: the status blurb now says *3-OS CI matrix* (not the personal-gate phrasing), covers WASI 0.1/0.2/0.3, and points at Releases for the current line; the layout section drops the `private/` row and remote-script naming; the Documentation section lists only living docs.
- **`development.md`'s "things you do NOT need" section reworded to name zero personal infrastructure** — the optional remote pre-flight is described generically through `scripts/dev_hosts.env.example` pointed at *your own* hosts. CONTRIBUTING likewise, plus its stale "first release candidate" → stable-line wording.
- `tutorial.md` §6 made self-contained; `reference/zig_api.md` / `reference/c_api.md` drop links into archived/`.dev` material.
- `.dev/handover.md` rewritten: **sweep S1–S6 COMPLETE; v2.5.0 awaits the user-only tag push (ADR-0156).**

## Verification

Zero `ubuntunote`/`windowsmini`/`private/`/"3-host" mentions across README + `docs/**` + `.github/**` · doc-fossil guard OK · doc-state 71/71 marked · all relative links resolve · doc-only diff (the fast `doc-truth` CI path gates it).