### PR TITLE
chore: repoint the project at the zwasm org and drop maintainer-host defaults

### DIFF
--- a/.dev/README.md
+++ b/.dev/README.md
@@ -37,9 +37,10 @@ of what CI runs anyway (ADR-0076 D9, ADR-0206). A contributor never needs
 them; see [`docs/development.md`](../docs/development.md).
 
 - [`ubuntunote_setup.md`](./ubuntunote_setup.md) — Linux x86_64 SSH gate
-  host (host alias overridable via `ZWASM_UBUNTU_HOST`).
+  host; the alias these docs use is one example of `ZWASM_UBUNTU_HOST`,
+  which the scripts read from `scripts/dev_hosts.env` and never default.
 - [`windows_ssh_setup.md`](./windows_ssh_setup.md) — Windows x86_64 SSH gate
-  host (`ZWASM_WINDOWS_HOST`).
+  host (`ZWASM_WINDOWS_HOST`, same contract).
 - [`orbstack_setup.md`](./orbstack_setup.md) — ARCHIVED (Mac-local scratch
   only, retired from the gate per ADR-0067).
 

--- a/.dev/decisions/0206_reproducible_dev_env.md
+++ b/.dev/decisions/0206_reproducible_dev_env.md
@@ -90,3 +90,17 @@ campaign-era `.claude/skills/continue/` sub-docs (labeled historical, D4).
 - ROADMAP §A7/A8 gate framing is NOT edited here (campaign-era history);
   the maintenance-mode reality (CI authoritative) is already recorded in
   CLAUDE.md + ADR-0076 D9 and now in the SSOT doc.
+
+## Revision history
+
+- 2026-08-12 (D2 revision, user-directed) — **the two SSH host names lost
+  their in-repo defaults.** `ZWASM_UBUNTU_HOST` / `ZWASM_WINDOWS_HOST` no
+  longer fall back to the maintainer's aliases: unset now means "no such
+  host", so `gate_merge.sh` WARNs and skips that leg and the per-host
+  runners exit 2 pointing at `dev_hosts.env.example`. `ZWASM_REMOTE_DIR`
+  keeps a default, now the neutral `zwasm` instead of the maintainer's
+  `Documents/MyProducts/zwasm`. D2's parameterization stands as written;
+  what changed is that the parameter is genuinely unset out of the box, so
+  a clone carries no machine identity — the same reason D1 exists. The
+  maintainer's own values live in the gitignored `dev_hosts.env`, which
+  D2 already requires.

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -15,6 +15,13 @@ publishes; ADR-0156 — never autonomous). Prior line v2.4.1; v1 frozen
 at `v1.11.1`. Dev model: `develop/<slug>` from `main` → PR → CI
 `ci-required` green → merge.
 
+**The repo moved to its own org 2026-08-12**: `clojurewasm/zwasm` →
+**`zwasm/zwasm`** (`.dev/org_transfer_plan.md` phases 1-3 done; stars /
+issues / releases / ruleset intact). Still open there: **phase 4** — the
+Homebrew tap split (`zwasm/homebrew-tap` does not exist yet, so README's
+install command deliberately still reads `clojurewasm/tap/zwasm`) and
+**phase 5** (cljw pin + wind-down). Both are user actions.
+
 ## Closed campaigns (details in the cited ADR/CHANGELOG)
 
 - **wasi03-full + windows port — SHIPPED to main 2026-08-11** (PR #165, merge

--- a/.dev/org_transfer_plan.md
+++ b/.dev/org_transfer_plan.md
@@ -1,7 +1,8 @@
 # Org transfer plan — `clojurewasm/zwasm` → a dedicated `zwasm` org
 
-> **Doc-state**: ACTIVE. Written 2026-08-12, before the transfer. Retire it
-> (ARCHIVED) once the post-transfer checklist below is fully ticked.
+> **Doc-state**: ACTIVE. Written 2026-08-12, before the transfer. Phases 1-3
+> are done (the repo lives at `zwasm/zwasm`); phases 4-5 (tap split, cljw
+> wind-down) are still open. Retire it (ARCHIVED) once they are ticked too.
 
 ## Context
 
@@ -68,13 +69,13 @@ Sequencing matters in one place: **cljw's final zwasm pin should be written
 after the transfer**, so its last commit names the new canonical URL rather
 than relying on a redirect it will never be able to fix.
 
-### Phase 1 — new org
+### Phase 1 — new org ✅
 
 1. Create the `zwasm` GitHub organization; add the co-maintainer as an owner.
 2. Enable Actions for the org and allow the workflow permissions the release
    job needs (`contents: write`).
 
-### Phase 2 — transfer the repo
+### Phase 2 — transfer the repo ✅ (2026-08-12)
 
 3. `Settings → General → Transfer ownership` on `clojurewasm/zwasm` → `zwasm`.
 4. Immediately re-point local clones: `git remote set-url origin
@@ -86,7 +87,10 @@ than relying on a redirect it will never be able to fix.
    `git ls-remote https://github.com/clojurewasm/zwasm.git | head -1` and
    `curl -sIL -o /dev/null -w '%{http_code}\n' https://github.com/clojurewasm/zwasm/releases/download/v2.5.0/SHA256SUMS`.
 
-### Phase 3 — in-repo references
+Post-transfer state: `zwasm/zwasm`, 159 stars, Discussions on, ruleset
+`main branch protection` present.
+
+### Phase 3 — in-repo references ✅ (2026-08-12)
 
 7. Sweep the live (non-historical) references — inventory taken 2026-08-12:
    `README.md` (CI badge, Releases links, brew command, v1 link),
@@ -94,6 +98,13 @@ than relying on a redirect it will never be able to fix.
    `.github/SECURITY.md`, `docs/development.md` (clone URL),
    `scripts/run_remote_ubuntu.sh` (comment).
    `.dev/decisions/**` and `.dev/lessons/**` are dated records — leave them.
+
+   Swept, plus two the inventory missed: `.dev/ubuntunote_setup.md` and
+   `.dev/windows_ssh_setup.md` (both ACTIVE, both carry a `git clone` URL).
+   The **brew command is deliberately still `clojurewasm/tap/zwasm`** — it
+   must not name a tap before phase 4 creates it. Also left alone: the
+   `CHANGELOG.md` 2.3.0 entry naming the old tap (dated record of what that
+   release shipped) and `.dev/archive/**`.
 
 ### Phase 4 — the tap split
 
@@ -108,6 +119,11 @@ than relying on a redirect it will never be able to fix.
 
    as `tap_migrations.json` at the repo root, and trim the README to cljw.
    One commit, e.g. `zwasm: migrate to zwasm/tap`.
+
+   Then flip README.md's install command to `brew install zwasm/tap/zwasm`
+   — it is the one in-repo reference phase 3 could not sweep, because a
+   command naming a tap that does not exist is worse than one naming the
+   old one.
 10. Verify from a clean state: `brew update` on a machine with the old tap
     prints the migration guidance, and `brew install zwasm/tap/zwasm` installs
     2.5.0 (`brew audit --formula --online` clean, version infers from the tag).

--- a/.dev/ubuntunote_setup.md
+++ b/.dev/ubuntunote_setup.md
@@ -106,13 +106,15 @@ nix flake --help | head -3
 ```bash
 mkdir -p ~/Documents/MyProducts
 cd ~/Documents/MyProducts
-git clone -b main git@github.com:clojurewasm/zwasm.git zwasm
+git clone -b main git@github.com:zwasm/zwasm.git zwasm
 cd zwasm
 nix develop --command zig version   # should print 0.16.0
 ```
 
 The first `nix develop` fetches Zig 0.16.0 + project deps from
-the flake's pinned inputs (~5 min, one-time per host).
+the flake's pinned inputs (~5 min, one-time per host). The clone path
+must match `ZWASM_REMOTE_DIR` in `scripts/dev_hosts.env` (relative to
+the remote `$HOME`) — that is what the runners `cd` into.
 
 ### 5. Per-chunk gate smoke
 

--- a/.dev/windows_ssh_setup.md
+++ b/.dev/windows_ssh_setup.md
@@ -96,13 +96,14 @@ Only the directory name differs.
 ssh windowsmini bash -lc "'
   mkdir -p ~/Documents/MyProducts &&
   cd ~/Documents/MyProducts &&
-  git clone -b main git@github.com:clojurewasm/zwasm.git zwasm
+  git clone -b main git@github.com:zwasm/zwasm.git zwasm
 '"
 ```
 
-`origin` ends up pointing at the same `clojurewasm/zwasm` GitHub
-remote that v1 uses; `main` is the trunk (the long-lived v2
-branch was merged into it).
+`origin` ends up pointing at `zwasm/zwasm`; `main` is the trunk
+(the long-lived v2 branch was merged into it). The clone path must
+match `ZWASM_REMOTE_DIR` in `scripts/dev_hosts.env` (relative to the
+remote `$HOME`) — that is what the runners `cd` into.
 
 ## Phase 0 smoke
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,10 +9,10 @@ This is a small, resource-limited project, so please keep the following in mind
 to make review sustainable:
 
 - **Bugs / feature requests** — open an
-  [Issue](https://github.com/clojurewasm/zwasm/issues/new/choose) using the
+  [Issue](https://github.com/zwasm/zwasm/issues/new/choose) using the
   templates. A minimal `.wasm` / `.wat` reproducer helps enormously.
 - **Questions & ideas** — start a thread in
-  [Discussions](https://github.com/clojurewasm/zwasm/discussions).
+  [Discussions](https://github.com/zwasm/zwasm/discussions).
 - **Pull requests** — welcome. For anything non-trivial, please open an issue
   or discussion first so we can agree on the approach before you invest time.
   Keep PRs focused; make sure `zig build test-all` and `zig fmt src/` are clean.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,13 +4,13 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Questions & general discussion
-    url: https://github.com/clojurewasm/zwasm/discussions
+    url: https://github.com/zwasm/zwasm/discussions
     about: >-
       For questions, ideas, and general discussion, please start a Discussion.
       Use the issue templates above for concrete bug reports and feature
       requests.
   - name: 🔒 Report a security vulnerability (private)
-    url: https://github.com/clojurewasm/zwasm/security/advisories/new
+    url: https://github.com/zwasm/zwasm/security/advisories/new
     about: >-
       Do NOT report security problems in public issues. Use private
       vulnerability reporting — see SECURITY.md.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -19,7 +19,7 @@ longer receive updates.
 
 **Please do not open a public issue or Discussion for security problems.**
 
-Report privately via GitHub's **[Private Vulnerability Reporting](https://github.com/clojurewasm/zwasm/security/advisories/new)**
+Report privately via GitHub's **[Private Vulnerability Reporting](https://github.com/zwasm/zwasm/security/advisories/new)**
 (the "Report a vulnerability" button under the repository's *Security* tab).
 If that is unavailable to you, open a minimal public Discussion asking a
 maintainer to reach out — **without any exploit detail** — and mention

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A from-scratch WebAssembly runtime in Zig 0.16.0.
 
-[![CI](https://github.com/clojurewasm/zwasm/actions/workflows/ci.yml/badge.svg)](https://github.com/clojurewasm/zwasm/actions/workflows/ci.yml)
+[![CI](https://github.com/zwasm/zwasm/actions/workflows/ci.yml/badge.svg)](https://github.com/zwasm/zwasm/actions/workflows/ci.yml)
 [![Zig](https://img.shields.io/badge/Zig-0.16.0-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)
 [![WebAssembly 3.0](https://img.shields.io/badge/WebAssembly-3.0-654ff0?logo=webassembly&logoColor=white)](https://webassembly.org/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -13,9 +13,9 @@ A from-scratch WebAssembly runtime in Zig 0.16.0.
 > (arm64 / x86_64) + AOT (`.cwasm`), and the C / Zig / CLI surfaces are
 > settled. **`v2.0.0` is the first stable release** (SemVer starts here;
 > v1 is frozen at `v1.11.1`); the current line is on
-> [Releases](https://github.com/clojurewasm/zwasm/releases).
+> [Releases](https://github.com/zwasm/zwasm/releases).
 
-v2 is a ground-up redesign of [zwasm v1](https://github.com/clojurewasm/zwasm)
+v2 is a ground-up redesign of [zwasm v1](https://github.com/zwasm/zwasm)
 with day-one design for WebAssembly 3.0, wasm-c-api conformance, and
 dual-backend (interpreter + JIT-arm64 + JIT-x86) differential testing.
 v1 ABI compatibility is out of scope (v1 is frozen at `v1.11.1`; the v2
@@ -180,7 +180,7 @@ xattr -d com.apple.quarantine "$(which zwasm)"
 ```
 
 Or grab a prebuilt binary straight from the
-[Releases](https://github.com/clojurewasm/zwasm/releases) page (macOS arm64,
+[Releases](https://github.com/zwasm/zwasm/releases) page (macOS arm64,
 Linux x86_64/aarch64, Windows x86_64). Building from source is in
 [Quick start](#quick-start) below.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,7 +13,7 @@ machines, SSH hosts, Nix, or any maintainer-specific setup to contribute.
 ## Quick start
 
 ```sh
-git clone https://github.com/clojurewasm/zwasm
+git clone https://github.com/zwasm/zwasm
 cd zwasm
 zig build                # compile the CLI + library
 zig build test           # unit tests
@@ -127,7 +127,9 @@ toolchains — see [`.dev/toolchain_provisioning.md`](../.dev/toolchain_provisio
   gate — you never need these. To use them, copy
   [`scripts/dev_hosts.env.example`](../scripts/dev_hosts.env.example) to
   `scripts/dev_hosts.env` (gitignored) and point the three values at your own
-  hosts; every remote-gate script sources it.
+  hosts; every remote-gate script sources it. No host name is baked into the
+  repo, so until you write that file `gate_merge.sh` simply skips the remote
+  legs.
 - **Gitignored local scratch**: a few scripts probe gitignored local paths and
   skip cleanly when they are absent. No build, test, or review path requires
   any file outside the committed tree.

--- a/scripts/check_three_host_diff.sh
+++ b/scripts/check_three_host_diff.sh
@@ -2,10 +2,9 @@
 # scripts/check_three_host_diff.sh — §9.7 / 7.11 three-way
 # differential gate.
 #
-# Verifies that the same critical runner totals appear on all
-# three hosts (Mac aarch64, ubuntunote native Linux x86_64,
-# windowsmini x86_64) by reading the most-recent test-all log
-# files at /tmp/{mac,ubuntu,win}.log. Each runner's total line is
+# Verifies that the same critical runner totals appear on all three
+# hosts (Mac aarch64, Linux x86_64, Windows x86_64) by reading the
+# most-recent test-all log files at /tmp/{mac,ubuntu,win}.log. Each runner's total line is
 # grep'd from each log; the script flags any host whose total
 # deviates from the consensus.
 #

--- a/scripts/dev_hosts.env.example
+++ b/scripts/dev_hosts.env.example
@@ -15,6 +15,10 @@
 # variable still wins over it (the `: "${VAR:=…}"` form only assigns
 # when unset/empty).
 #
+# The two host names have NO in-repo default — no maintainer's machine is
+# baked into the scripts. Unset means "no such host": `gate_merge.sh`
+# WARNs and skips that leg, the per-host runners exit 2 pointing here.
+#
 # Host requirements (see .dev/ubuntunote_setup.md / windows_ssh_setup.md
 # for full provisioning notes):
 #   - an SSH alias reachable with BatchMode (key auth, no prompt)
@@ -28,8 +32,8 @@
 : "${ZWASM_WINDOWS_HOST:=my-windows-host}"
 
 # Repo clone path on the remote hosts (relative to the remote $HOME).
-# Matches the scripts' built-in default; change it to wherever you
+# `zwasm` is the scripts' built-in default; change it to wherever you
 # cloned the repo on YOUR hosts.
-: "${ZWASM_REMOTE_DIR:=Documents/MyProducts/zwasm}"
+: "${ZWASM_REMOTE_DIR:=zwasm}"
 
 export ZWASM_UBUNTU_HOST ZWASM_WINDOWS_HOST ZWASM_REMOTE_DIR

--- a/scripts/gate_merge.sh
+++ b/scripts/gate_merge.sh
@@ -2,9 +2,10 @@
 # OPTIONAL local pre-PR pre-flight that MIRRORS CI. Runs the commit gate plus a
 # three-host test:
 #   - zig build test-all on Mac native
-#   - zig build test-all on `ubuntunote` Linux x86_64 SSH host
-#     (per ADR-0067; native, not OrbStack-Rosetta)
-#   - zig build test-all on `windowsmini` SSH host (if reachable)
+#   - zig build test-all on the configured Linux x86_64 SSH host
+#     (`ZWASM_UBUNTU_HOST`; per ADR-0067 native, not OrbStack-Rosetta)
+#   - zig build test-all on the configured Windows SSH host
+#     (`ZWASM_WINDOWS_HOST`, if reachable)
 #
 # `main` is ruleset-protected (no direct pushes) — changes land via a
 # develop/<slug> branch → PR → CI. The AUTHORITATIVE 3-OS merge gate is the
@@ -13,8 +14,8 @@
 # hardware so a maintainer CAN verify locally before opening a PR — but it is
 # not required, and green here is not a substitute for green ci-required.
 #
-# Missing ubuntunote SSH or unreachable windowsmini → WARN and continue (the
-# local Mac gate is the firm floor).
+# An unconfigured or unreachable SSH host → WARN and continue (the local Mac
+# gate is the firm floor).
 #
 # `test-all` aggregates every layer in ROADMAP §A13's "v1 regression suite"
 # definition that v2 has stood up:
@@ -63,16 +64,20 @@ bash scripts/check_jit_releasesafe.sh
 echo "[gate_merge] AOT cross-compile portability (§12.3) ..."
 bash scripts/check_aot_cross_compile.sh
 
-# The Linux/Windows SSH hosts default to the maintainer's aliases; override
-# with ZWASM_UBUNTU_HOST / ZWASM_WINDOWS_HOST, or set them once in the
-# per-machine scripts/dev_hosts.env (see dev_hosts.env.example). The cwd
-# is the repo root here (the cd at the top), so the path is literal.
+# The Linux/Windows SSH hosts are per-machine and have no in-repo default:
+# set ZWASM_UBUNTU_HOST / ZWASM_WINDOWS_HOST, or write them once into
+# scripts/dev_hosts.env (see dev_hosts.env.example). The cwd is the repo
+# root here (the cd at the top), so the path is literal.
 [ -f scripts/dev_hosts.env ] && source scripts/dev_hosts.env
-UBUNTU_HOST="${ZWASM_UBUNTU_HOST:-ubuntunote}"
-WINDOWS_HOST="${ZWASM_WINDOWS_HOST:-windowsmini}"
+UBUNTU_HOST="${ZWASM_UBUNTU_HOST:-}"
+WINDOWS_HOST="${ZWASM_WINDOWS_HOST:-}"
+UNCONFIGURED="not configured — set it in scripts/dev_hosts.env (see dev_hosts.env.example)"
 
 # ---- native Linux x86_64 via SSH ----
-if ssh -o ConnectTimeout=5 -o BatchMode=yes "$UBUNTU_HOST" "echo ok" >/dev/null 2>&1; then
+if [ -z "$UBUNTU_HOST" ]; then
+    SKIPPED_HOSTS+=("Linux x86_64 — ZWASM_UBUNTU_HOST $UNCONFIGURED")
+    echo "[gate_merge] WARN: ZWASM_UBUNTU_HOST unset; skipping Linux gate." >&2
+elif ssh -o ConnectTimeout=5 -o BatchMode=yes "$UBUNTU_HOST" "echo ok" >/dev/null 2>&1; then
     echo "[gate_merge] zig build test-all on $UBUNTU_HOST (native x86_64) ..."
     bash scripts/run_remote_ubuntu.sh test-all
 else
@@ -81,7 +86,10 @@ else
 fi
 
 # ---- Windows x86_64 via SSH ----
-if ssh -o ConnectTimeout=5 -o BatchMode=yes "$WINDOWS_HOST" "echo ok" >/dev/null 2>&1; then
+if [ -z "$WINDOWS_HOST" ]; then
+    SKIPPED_HOSTS+=("Windows x86_64 — ZWASM_WINDOWS_HOST $UNCONFIGURED")
+    echo "[gate_merge] WARN: ZWASM_WINDOWS_HOST unset; skipping Windows gate." >&2
+elif ssh -o ConnectTimeout=5 -o BatchMode=yes "$WINDOWS_HOST" "echo ok" >/dev/null 2>&1; then
     echo "[gate_merge] zig build test-all on $WINDOWS_HOST SSH ..."
     bash scripts/run_remote_windows.sh test-all
 else

--- a/scripts/record_merge_bench.sh
+++ b/scripts/record_merge_bench.sh
@@ -14,7 +14,7 @@
 # commit `bench/results/history.yaml` INTO THE SAME PR — NOT as a post-merge
 # follow-up (that would need its own PR each merge). Put the PR intent in
 # `--reason`; the entry's commit SHA is the branch tip (cosmetic — reason/PR#/
-# date identify it). Run on Mac; ubuntunote / windowsmini for Linux / Windows
+# date identify it). Run on Mac; the configured Linux / Windows SSH hosts for their
 # rows when needed. Auto-CI (push-triggered bench.yml) stays disabled
 # (2026-05-25; CI was not consumed, auto-runs produced noise).
 #

--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -13,7 +13,7 @@
 #   bash scripts/run_bench.sh --bench=<name>      # single bench by name
 #   bash scripts/run_bench.sh --windows-subset    # 5-fixture fast subset
 #                                                 # (§9.8 / 8.3) — for use on
-#                                                 # windowsmini SSH host where
+#                                                 # the Windows SSH host where
 #                                                 # the full inventory takes
 #                                                 # 5+ hours; ~250-400ms/fixture
 #                                                 # × 5 × 3-runs ≈ 6s total.
@@ -130,8 +130,8 @@ done
 
 # §9.8 / 8.3 — Windows subset: 5 fast fixtures (all <30ms on Linux
 # baseline). At Mac:Win ~12x ratio observed in Phase 7 close, this
-# is ~250-400ms/fixture × 3 quick-runs ≈ 6s total. Use on
-# windowsmini SSH host where the full 26-fixture inventory takes
+# is ~250-400ms/fixture × 3 quick-runs ≈ 6s total. Use on the
+# Windows SSH host where the full 26-fixture inventory takes
 # 5+ hours and is incompatible with inline gate cadence.
 WINDOWS_SUBSET_NAMES=(
     "shootout/nestedloop"

--- a/scripts/run_remote_ubuntu.sh
+++ b/scripts/run_remote_ubuntu.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# scripts/run_remote_ubuntu.sh — drive build/test on the
-# ubuntunote SSH host (native x86_64 Linux, real hardware).
+# scripts/run_remote_ubuntu.sh — drive build/test on the configured
+# Linux x86_64 SSH gate host (`ZWASM_UBUNTU_HOST`; native hardware).
 #
 # Replacement for the OrbStack `my-ubuntu-amd64` path
 # (Rosetta-translated x86_64; tripped D-134 SIGSEGV race —
 # closed per ADR-0067). Mirrors `run_remote_windows.sh`:
-# `git fetch + reset --hard` the ubuntunote clone to the
+# `git fetch + reset --hard` the remote clone to the
 # latest pushed `origin/main`, then run the
 # requested `zig build` step. (`main` is the merged trunk — reached only via
 # PR now; CI runs this same gate on each PR head. Pass `--branch develop/<slug>`
@@ -30,11 +30,13 @@
 # passes `--branch` (it expects to verify the just-pushed
 # origin HEAD of the main dev branch per ADR-0076 D3).
 #
-# Prerequisites: SSH alias `ubuntunote` configured; Zig 0.16.0
-# available remotely via the project's flake.nix dev shell;
-# the repo cloned at ~/Documents/MyProducts/zwasm
-# with `origin` pointing at clojurewasm/zwasm. Setup procedure
-# in `.dev/ubuntunote_setup.md`.
+# Prerequisites (all per-machine, none baked into the repo — see
+# `scripts/dev_hosts.env.example`): `ZWASM_UBUNTU_HOST` naming an SSH
+# alias that resolves without a prompt; Zig 0.16.0 available remotely
+# via the project's flake.nix dev shell; this repo cloned at
+# `$ZWASM_REMOTE_DIR` (relative to the remote `$HOME`) with `origin`
+# pointing at `zwasm/zwasm`. Provisioning notes in
+# `.dev/ubuntunote_setup.md`.
 #
 # Failure attribution: each remote step (preflight / sync /
 # build) emits a labelled `[run_remote_ubuntu] FAIL: <step>`
@@ -47,11 +49,22 @@
 _sd="$(cd "$(dirname "$0")" && pwd)"
 [ -f "$_sd/dev_hosts.env" ] && source "$_sd/dev_hosts.env"
 
+# The host is per-machine and has no in-repo default. Resolving it before
+# the orphan guard also keeps the guard's `pgrep -f "ssh <host>"` reap
+# anchored to a real alias instead of matching every ssh client.
+HOST="${ZWASM_UBUNTU_HOST:-}"
+if [ -z "$HOST" ]; then
+    echo "[run_remote_ubuntu] FAIL: config — ZWASM_UBUNTU_HOST is unset." >&2
+    echo "  cp scripts/dev_hosts.env.example scripts/dev_hosts.env and set your own SSH alias (ADR-0206)." >&2
+    echo "  This local fan-out is OPTIONAL — CI's ci-required check is the authoritative 3-OS gate." >&2
+    exit 2
+fi
+
 # Orphan guard — reap prior orphans + self-bound under timeout before
 # any work (see scripts/orphan_guard.sh + orphan_prevention.md). Must
 # run before `set -e` so the reap's empty-pgrep exits don't abort.
 _og="$_sd/orphan_guard.sh"
-[ -f "$_og" ] && source "$_og" && orphan_guard "$0" "${ZWASM_UBUNTU_HOST:-ubuntunote}" "$@"
+[ -f "$_og" ] && source "$_og" && orphan_guard "$0" "$HOST" "$@"
 
 set -euo pipefail
 cd "$_sd/.."
@@ -59,15 +72,10 @@ cd "$_sd/.."
 # SSH keepalive: a dead local client (parent-session kill / timeout)
 # makes the remote sshd drop the channel — and the remote `zig build` —
 # within ~2 min, so a reaped/timed-out gate doesn't leave a build
-# running on ubuntunote (the "timeout does NOT propagate" caveat).
+# running on the gate host (the "timeout does NOT propagate" caveat).
 SSH_OPTS="-o ServerAliveInterval=30 -o ServerAliveCountMax=4"
 
-# Maintainer SSH gate — the Linux x86_64 host and its clone path are
-# env-configurable (defaults are the project maintainer's hosts). Point
-# ZWASM_UBUNTU_HOST at your own SSH alias, or set it once in the
-# per-machine scripts/dev_hosts.env (sourced above).
-HOST="${ZWASM_UBUNTU_HOST:-ubuntunote}"
-REMOTE_DIR="${ZWASM_REMOTE_DIR:-Documents/MyProducts/zwasm}"
+REMOTE_DIR="${ZWASM_REMOTE_DIR:-zwasm}"
 REMOTE_BRANCH="main"
 if [ "${1:-}" = "--branch" ]; then
     if [ -z "${2:-}" ]; then
@@ -107,7 +115,7 @@ ssh $SSH_OPTS "$HOST" bash -lc "'
 #    what was actually tested. `git fetch` failure (network) vs
 #    `reset --hard` failure (concurrent mod) are distinguished
 #    by exit code below.
-echo "[run_remote_ubuntu] sync ubuntunote:~/$REMOTE_DIR to origin/$REMOTE_BRANCH ..."
+echo "[run_remote_ubuntu] sync $HOST:~/$REMOTE_DIR to origin/$REMOTE_BRANCH ..."
 remote_sha="$(ssh $SSH_OPTS "$HOST" bash -lc "'
     cd $REMOTE_DIR || exit 21
     git fetch origin $REMOTE_BRANCH >&2 || exit 22
@@ -151,6 +159,6 @@ esac
 echo "[run_remote_ubuntu] $REMOTE_CMD ..."
 ssh $SSH_OPTS "$HOST" bash -lc "'
     cd $REMOTE_DIR && nix develop --command bash -c \"$REMOTE_CMD\"
-'" || die_step "build — '$REMOTE_CMD' failed on ubuntunote (HEAD=$remote_sha)"
+'" || die_step "build — '$REMOTE_CMD' failed on $HOST (HEAD=$remote_sha)"
 
 echo "[run_remote_ubuntu] OK (HEAD=$remote_sha)."

--- a/scripts/run_remote_windows.sh
+++ b/scripts/run_remote_windows.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# scripts/run_remote_windows.sh — drive build/test on the windowsmini SSH host.
+# scripts/run_remote_windows.sh — drive build/test on the configured
+# Windows x86_64 SSH gate host (`ZWASM_WINDOWS_HOST`).
 #
-# `git fetch + reset --hard` the windowsmini clone to the latest
+# `git fetch + reset --hard` the remote clone to the latest
 # pushed `origin/main`, then run the requested
 # `zig build` step there. Phase 15+ may extend this with a
 # `git bundle` path so unpushed commits can also be exercised; for
@@ -19,10 +20,11 @@
 # `develop/value16`) before merging to the trunk
 # (`main`).
 #
-# Prerequisites: SSH alias `windowsmini` configured; Zig 0.16.0
-# installed remotely; the repo cloned at
-# ~/Documents/MyProducts/zwasm (see
-# `.dev/windows_ssh_setup.md`).
+# Prerequisites (all per-machine, none baked into the repo — see
+# `scripts/dev_hosts.env.example`): `ZWASM_WINDOWS_HOST` naming an SSH
+# alias that resolves without a prompt; Zig 0.16.0 installed remotely;
+# this repo cloned at `$ZWASM_REMOTE_DIR` (relative to the remote
+# `$HOME`). Provisioning notes in `.dev/windows_ssh_setup.md`.
 
 # Orphan guard — reap prior orphans + self-bound under timeout before
 # any work (see scripts/orphan_guard.sh + orphan_prevention.md). Must
@@ -35,24 +37,30 @@
 _sd="$(cd "$(dirname "$0")" && pwd)"
 [ -f "$_sd/dev_hosts.env" ] && source "$_sd/dev_hosts.env"
 
+# The host is per-machine and has no in-repo default. Resolving it before
+# the orphan guard also keeps the guard's `pgrep -f "ssh <host>"` reap
+# anchored to a real alias instead of matching every ssh client.
+HOST="${ZWASM_WINDOWS_HOST:-}"
+if [ -z "$HOST" ]; then
+    echo "[run_remote_windows] FAIL: config — ZWASM_WINDOWS_HOST is unset." >&2
+    echo "  cp scripts/dev_hosts.env.example scripts/dev_hosts.env and set your own SSH alias (ADR-0206)." >&2
+    echo "  This local fan-out is OPTIONAL — CI's ci-required check is the authoritative 3-OS gate." >&2
+    exit 2
+fi
+
 _og="$_sd/orphan_guard.sh"
-[ -f "$_og" ] && source "$_og" && orphan_guard "$0" "${ZWASM_WINDOWS_HOST:-windowsmini}" "$@"
+[ -f "$_og" ] && source "$_og" && orphan_guard "$0" "$HOST" "$@"
 
 set -euo pipefail
 cd "$_sd/.."
 
 # SSH keepalive: a dead local client makes the remote sshd drop the
 # channel — and the remote `zig build` — within ~2 min (the "timeout
-# does NOT propagate" caveat; especially load-bearing on windowsmini
-# where Defender scan stalls have wedged runs — D-028).
+# does NOT propagate" caveat; especially load-bearing on the Windows
+# host where Defender scan stalls have wedged runs — D-028).
 SSH_OPTS="-o ServerAliveInterval=30 -o ServerAliveCountMax=4"
 
-# Maintainer SSH gate — the Windows x86_64 host and its clone path are
-# env-configurable (defaults are the project maintainer's hosts). Point
-# ZWASM_WINDOWS_HOST at your own SSH alias, or set it once in the
-# per-machine scripts/dev_hosts.env (sourced above).
-HOST="${ZWASM_WINDOWS_HOST:-windowsmini}"
-REMOTE_DIR="${ZWASM_REMOTE_DIR:-Documents/MyProducts/zwasm}"
+REMOTE_DIR="${ZWASM_REMOTE_DIR:-zwasm}"
 REMOTE_BRANCH="main"
 if [ "${1:-}" = "--branch" ]; then
     if [ -z "${2:-}" ]; then

--- a/scripts/win64_debug/attach_dump.sh
+++ b/scripts/win64_debug/attach_dump.sh
@@ -1,30 +1,37 @@
 #!/usr/bin/env bash
-# attach_dump.sh — run zwasm-spec-wasm-2-0-assert on windowsmini against
-# a manifest dir, attach lldb after N seconds, dump register + backtrace
-# + selected memory, detach, kill. Output collected to /tmp/d165-attach.log.
+# attach_dump.sh — run zwasm-spec-wasm-2-0-assert on the Windows gate host
+# against a manifest dir, attach lldb after N seconds, dump register +
+# backtrace + selected memory, detach, kill. Output collected to
+# /tmp/d165-attach.log.
 #
 # Usage:
 #   bash scripts/win64_debug/attach_dump.sh <local-manifest-dir> [wait-sec]
 #
-# Pre-req: windowsmini SSH alias set up per .dev/windows_ssh_setup.md.
-# scratch dir at test/private/d-165/ used on both sides.
+# Pre-req: ZWASM_WINDOWS_HOST set (scripts/dev_hosts.env) for an SSH alias
+# provisioned per .dev/windows_ssh_setup.md. scratch dir at
+# test/private/d-165/ used on both sides.
 
 set -euo pipefail
 
 LOCAL_DIR="${1:-test/private/d-165}"
 WAIT_SEC="${2:-3}"
 [ -f "$(dirname "$0")/../dev_hosts.env" ] && source "$(dirname "$0")/../dev_hosts.env"
-WIN_HOST="${ZWASM_WINDOWS_HOST:-windowsmini}"
-WIN_REPO="${ZWASM_REMOTE_DIR:-Documents/MyProducts/zwasm}"
+WIN_HOST="${ZWASM_WINDOWS_HOST:-}"
+WIN_REPO="${ZWASM_REMOTE_DIR:-zwasm}"
 REMOTE_DIR="$WIN_REPO/test/private/d-165"
 LOG="/tmp/d165-attach.log"
+
+if [ -z "$WIN_HOST" ]; then
+  echo "ZWASM_WINDOWS_HOST is unset — set it in scripts/dev_hosts.env (see dev_hosts.env.example)" >&2
+  exit 2
+fi
 
 if [ ! -d "$LOCAL_DIR/fac" ]; then
   echo "missing $LOCAL_DIR/fac/" >&2
   exit 2
 fi
 
-# Sync the manifest dir contents to windowsmini.
+# Sync the manifest dir contents to the Windows host.
 scp -q -r "$LOCAL_DIR/fac/" "$WIN_HOST:$REMOTE_DIR/" >&2
 
 # Build a remote bash script (single-quoted heredoc so $vars resolve on remote).

--- a/scripts/windows/install_tools.ps1
+++ b/scripts/windows/install_tools.ps1
@@ -12,8 +12,8 @@
     Tools land in %LOCALAPPDATA%\zwasm-tools\<name>-<version>\
     and are added to the user-scoped PATH.
 
-    The sysinternals entry exists to give windowsmini-side JIT
-    debugging the same "actively wired" status as Mac+ubuntunote
+    The sysinternals entry exists to give Windows-side JIT debugging
+    the same "actively wired" status as the Mac and Linux hosts
     (per close-plan §0.2.1 + debug_jit_auto skill Windows recipes).
     Without these tools D-028 / D-136 / future Win64-specific JIT
     bugs are debuggable only via lldb, which lacks process / file


### PR DESCRIPTION
The repository moved from `clojurewasm/zwasm` to `zwasm/zwasm`. This sweeps
the in-repo references (org_transfer_plan phase 3) and, while in the same
places, removes the last spots where the local verification fan-out assumed
the maintainer's own machines.

## Org references

Repointed at `zwasm/zwasm`:

- `README.md` — CI badge, both Releases links, the v1 link
- `.github/CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/config.yml`,
  `.github/SECURITY.md` — issues / discussions / private-advisory URLs
- `docs/development.md` — clone URL
- `.dev/ubuntunote_setup.md`, `.dev/windows_ssh_setup.md` — clone URLs (both
  ACTIVE; the plan's inventory missed them)
- `scripts/run_remote_ubuntu.sh` — prerequisites comment

Deliberately left naming the old org:

- **README's `brew install clojurewasm/tap/zwasm`.** `zwasm/homebrew-tap`
  does not exist yet (verified: 404) — phase 4 of the plan creates it. A
  command naming a tap that does not exist is worse than one naming the old
  tap, which still works. The plan now carries the README flip as part of
  phase 4.
- `CHANGELOG.md` 2.3.0's Homebrew line, `.dev/archive/**`,
  `.dev/decisions/**`, `.dev/lessons/**` — dated records.

`.github/workflows/**` needed no change: no workflow hardcodes the org.

## Maintainer-host defaults

ADR-0206 made the SSH fan-out configurable but kept the maintainer's aliases
as the built-in fallback, so a clone still carried one machine's identity.
Now:

- `ZWASM_UBUNTU_HOST` / `ZWASM_WINDOWS_HOST` have **no in-repo default**.
  Unset means "no such host": `gate_merge.sh` WARNs and skips that leg,
  `run_remote_ubuntu.sh` / `run_remote_windows.sh` / `win64_debug/attach_dump.sh`
  exit 2 pointing at `dev_hosts.env.example`.
- `ZWASM_REMOTE_DIR` keeps a default, now the neutral `zwasm` rather than
  `Documents/MyProducts/zwasm`.
- The runners resolve the host **before** the orphan guard, so its
  `pgrep -f "ssh <host>"` reap can no longer degrade into matching every ssh
  client when nothing is configured.
- Script comments that stated a host alias as a prerequisite now name the
  variable instead. Comments recording a past incident on a specific host
  (`orphan_guard.sh` D-028, `track_heisenbug.sh` ADR-0067) stay as they are.

Recorded as a D2 revision note on ADR-0206.

## Verification

- Unconfigured path exercised with `dev_hosts.env` moved aside: all three
  runners exit 2 with the pointer; configured path resolves unchanged.
- `bash -n` on every touched script.
- `scripts/gate_commit.sh --fast` green; the three `doc-truth` job checks
  (`check_engine_default_claims` / `check_wasi03_coverage_claims` /
  `check_doc_fossils`) green locally.

No source, build, or test-path changes — CI's `ci-required` is the gate.
