### PR TITLE
docs: point the Homebrew install at the new tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ FFI-capable language, not just C.
 **Homebrew** (macOS arm64 / Linux):
 
 ```sh
-brew install clojurewasm/tap/zwasm
+brew install zwasm/tap/zwasm
 ```
 
 The `zwasm` binary is not code-signed. Homebrew installs it without a


### PR DESCRIPTION
One line in the README:

```diff
-brew install clojurewasm/tap/zwasm
+brew install zwasm/tap/zwasm
```

## Why now

The org-repoint sweep (#180) deliberately left this line alone, because at
that point `zwasm/homebrew-tap` did not exist and an install command naming a
tap that does not exist is worse than one naming the old tap, which still
works through the redirect.

The tap exists now. Its CI installs the formula for real on `macos-latest`
and `ubuntu-latest` on every push and runs the binary, so the command in this
diff is exercised end to end rather than assumed:

```
zwasm v2.5.0 (wasm: v3_0, wasi: p2, engine: both)
```

## What is not changing

`clojurewasm/tap` keeps serving zwasm until its formula is deleted there,
which is the other maintainer's step and happens on its own schedule. Both
install paths work during the overlap, so nobody is broken mid-switch.

This was the last live `clojurewasm` reference in the tree. What is left is
dated records that were true when written and are not instructions to a
reader: `.dev/archive/**`, `.dev/decisions/**`, `.dev/handover.md`,
`.dev/org_transfer_plan.md`, and the CHANGELOG entry for the release that
shipped under the old name.

## Checks

Doc-only, so the heavy legs skip and `ci-required` comes from the `doc-truth`
job. All four doc gates pass locally: `check_engine_default_claims`,
`check_wasi03_coverage_claims`, `check_doc_fossils`, `check_doc_state`.
