### PR TITLE
docs: extended CI checks run on the merge, not on every PR

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,10 +75,14 @@ text or code identifiers.
   proceed without stopping (no user-flip). Default posture =
   autonomous-with-ADR; surface only for bucket-2/3 genuine blocks.
 - **CI gate is authoritative (post-v2.0.0 maintenance; ADR-0076 D9)**: `main`
-  is PR-only, and CI's `ci-required` runs `scripts/ci_gate.sh` (zig fmt +
-  `test-all` + extended: lint / build-option DCE / ReleaseSafe JIT smoke / AOT
-  cross-compile / **`zone_check`**) on **all 3 OSes** (aarch64-macos +
-  x86_64-linux + x86_64-windows) for **every** PR. That IS the merge gate.
+  is PR-only, and CI's `ci-required` runs `scripts/ci_gate.sh` on **all 3 OSes**
+  (aarch64-macos + x86_64-linux + x86_64-windows) for **every** PR. That IS the
+  merge gate. A PR run gets the **core** gate — zig fmt + `test-all` +
+  `run-rust-host` + the test-discovery guard. The **extended** checks (lint /
+  build-option DCE / ReleaseSafe JIT smoke / AOT cross-compile / `zone_check` /
+  `spill_aware`) are gated on `ZWASM_CI_EXTENDED`, which `ci.yml` sets only on
+  the **push to `main`** — they are up to ~20 cold-cache ReleaseSafe builds and
+  would dominate every PR's wall-clock (rationale in `ci.yml`).
   Doc-only PRs auto-skip the heavy legs (still green via `ci-required`). The
   local `scripts/gate_merge.sh` (3-host SSH fan-out) + `scripts/gate_commit.sh`
   (pre-commit) are now **optional pre-PR pre-flight** mirroring CI — no longer

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,9 +77,12 @@ shells — contributors never need it; the `.wasm` files are committed.
 
 `main` is protected: every change lands via a branch → pull request → the
 required **`ci-required`** status check. CI runs
-[`scripts/ci_gate.sh`](../scripts/ci_gate.sh) (fmt + `test-all`, plus
-extended static/build checks) on **all three supported OSes** — macOS
-aarch64, Linux x86_64, Windows x86_64. The macOS and Linux legs are
+[`scripts/ci_gate.sh`](../scripts/ci_gate.sh) on **all three supported OSes** —
+macOS aarch64, Linux x86_64, Windows x86_64. Your PR gets the *core* gate: fmt
++ `test-all` + the rust-host consumer + the test-discovery guard. The extended
+static/build checks (lint, the build-option DCE matrix, AOT cross-compile,
+`zone_check`) run on the merge to `main`, not per PR — they are up to ~20
+cold-cache builds and would dominate every PR's wall-clock. The macOS and Linux legs are
 blocking; the Windows leg currently runs **advisory** (reported on every PR,
 not merge-blocking — see the `advisory` flag in
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)). There is no


### PR DESCRIPTION
## Summary

`.claude/CLAUDE.md` and `docs/development.md` both say `ci-required` runs the
extended checks (lint / build-option DCE / ReleaseSafe JIT smoke / AOT
cross-compile / `zone_check`) on all three OSes **for every PR**.
`.github/workflows/ci.yml` sets `ZWASM_CI_EXTENDED` only when
`github.event_name == 'push'`, so a PR run gets the core gate alone — fmt,
`test-all`, the rust-host consumer, the test-discovery guard.

Verifiable in a run: PR #182's `gate` legs went green with zero `extended:`
lines in the log.

This corrects the prose only. The split is deliberate and its rationale is
already in `ci.yml` — the extended matrix is up to ~20 cold-cache ReleaseSafe
builds and would dominate every PR's wall-clock. Nothing about the gate changes
here.

## Related

Found while measuring conformance for ADR-0208 (#183); independent of it.

## Checklist

- [x] `zig build test-all` passes locally — doc-only, so CI skips the 3-OS gate
      and `doc-truth` gates instead
- [x] `zig fmt src/` is clean — no `src/` changes
- [ ] Tests / fixtures added or updated for the change (if applicable) — n/a,
      prose only
- [x] Docs updated (if user-facing behavior changed) — this PR is the doc fix