### PR TITLE
docs: correct the stale claims in the handover's current-state section

### DIFF
--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -5,15 +5,11 @@
 
 ## Current state — MAINTENANCE MODE (post-v2.0.0)
 
-**v2.5.0 READY TO TAG (sweep COMPLETE 2026-08-12)**: the user-directed
-pre-tag cleanliness sweep (S1-S6) is DONE — S1-S5 merged as #175, S6
-(docs final-form) is the PR in flight / just merged. main carries
-`build.zig.zon = 2.5.0` + the CHANGELOG section; remote tags end at
-v2.4.1. **The only remaining step is the USER pushing the tag**
-(`git tag v2.5.0 <sha> && git push origin v2.5.0` → release.yml
-publishes; ADR-0156 — never autonomous). Prior line v2.4.1; v1 frozen
+**v2.5.0 TAGGED and published** — the pre-tag cleanliness sweep (S1-S6)
+is DONE (S1-S5 merged as #175, S6 as #176). Prior line v2.4.1; v1 frozen
 at `v1.11.1`. Dev model: `develop/<slug>` from `main` → PR → CI
-`ci-required` green → merge.
+`ci-required` green → merge. Release stays user-only (ADR-0156) — an
+agent-autonomy guardrail, not a bar to release automation.
 
 **The repo moved to its own org 2026-08-12**: `clojurewasm/zwasm` →
 **`zwasm/zwasm`** (`.dev/org_transfer_plan.md` phases 1-3 done; stars /
@@ -80,11 +76,16 @@ All six axes closed (plan was #168; S1-S5 consolidated+merged as #175):
 
 ## State (release = USER-ONLY, ADR-0156)
 
-- **Wasm 1.0/2.0/3.0**: 100% spec, 0 skip. **WASI 0.1** complete; **0.2/CM**
-  default-ON; **0.3 FULL on all 3 OSes** (official 45/45, 0 skip). Sandbox
-  triad cross-engine.
+- **Wasm 1.0/2.0/3.0**: 100% spec, 0 skip **on the engine CI runs**. The JIT
+  spec lane is opt-in (`ZWASM_SPEC_ENGINE=jit`) and is NOT in CI, so that row
+  is not currently re-derivable for both engines.
+- **WASI 0.1**: syscall SURFACE complete (46/46, ADR-0161). Behaviour against
+  the official wasi-testsuite was measured 2026-08-14 at **58/72 interp,
+  54/72 jit** (x86_64-linux; wasmtime 47.0.3 scores 72/72 through the same
+  harness) — nothing gated that until now. **0.2/CM** default-ON; **0.3 FULL
+  on all 3 OSes** (official 45/45, 0 skip). Sandbox triad cross-engine.
 - **Surfaces**: C-API · Zig-API · lean CLI · memory-safety sound · dogfooded
-  into cljw. Realworld 56 interp 56/0; JIT diff-gated. Debt: 0 `now`-class.
+  into cljw. Realworld 56 interp 56/0; JIT diff-gated.
 
 ## Key refs
 

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -13,10 +13,11 @@ agent-autonomy guardrail, not a bar to release automation.
 
 **The repo moved to its own org 2026-08-12**: `clojurewasm/zwasm` →
 **`zwasm/zwasm`** (`.dev/org_transfer_plan.md` phases 1-3 done; stars /
-issues / releases / ruleset intact). Still open there: **phase 4** — the
-Homebrew tap split (`zwasm/homebrew-tap` does not exist yet, so README's
-install command deliberately still reads `clojurewasm/tap/zwasm`) and
-**phase 5** (cljw pin + wind-down). Both are user actions.
+issues / releases / ruleset intact). **Phase 4's repo side is done too** —
+`zwasm/homebrew-tap` carries `Formula/zwasm.rb`, the old tap keeps only
+`cljw.rb` plus `tap_migrations.json`, and README installs from
+`zwasm/tap/zwasm` (#181). Left to the user: phase 4 item 10 (verify from a
+clean `brew` state) and **phase 5** (cljw pin + wind-down).
 
 ## Closed campaigns (details in the cited ADR/CHANGELOG)
 


### PR DESCRIPTION
## Summary

Four claims in `.dev/handover.md`'s current-state section had outrun what is
true:

- **v2.5.0** is tagged and published; the section still said READY TO TAG with
  remote tags ending at v2.4.1.
- **Wasm 1.0/2.0/3.0 "100% spec, 0 skip"** describes what CI runs. The JIT spec
  lane is opt-in (`ZWASM_SPEC_ENGINE=jit`) and is not in CI, so the row is not
  re-derivable for both engines. Gating it is #12.
- **"WASI 0.1 complete"** rested on the 46/46 syscall surface (ADR-0161), which
  is complete. Behaviour is a separate question and nothing gated it: measured
  2026-08-14 at 58/72 interp / 54/72 jit on x86_64-linux, with wasmtime 47.0.3
  at 72/72 through the same harness. ADR-0208 (#183) proposes the gate.
- **Homebrew phase 4** was listed as still open, saying the tap "does not exist
  yet" and that README deliberately still named the old one. The tap has
  existed since 2026-08-13 with `Formula/zwasm.rb`, the old tap carries
  `tap_migrations.json`, and README was repointed in #181. Only the
  clean-state `brew` verification is left. (Found by review, in the paragraph
  next to the ones already being fixed.)

No product change and no claim is being lowered — the surface and spec numbers
stand. What changes is that each says which engine and which suite it holds for.

Split out of the in-flight #186 branch so it lands without waiting on that PR:
these are true today regardless of it.

## Checklist

- [x] `gate_commit.sh --fast` passed; doc-only, so CI gates via `doc-truth`
- [x] Handover length 95 lines (soft 100 / hard 120)
