### PR TITLE
docs(bench): the bench workflow is workflow_dispatch, not per-push

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -63,8 +63,9 @@ preserved long-term.
   (aarch64-darwin) + `ubuntu-latest` (x86_64-linux). **Trigger is
   `workflow_dispatch` only** — the push trigger was disabled
   2026-05-25 because local development is the primary path and the
-  auto-runs produced noise; start it with `gh workflow run
-  bench.yml --ref main`. Each arch uploads a YAML
+  auto-runs produced noise. It watched `zwasm-from-scratch`, the
+  then-current dev branch, not `main`. Start a run with
+  `gh workflow run bench.yml --ref main`. Each arch uploads a YAML
   fragment as an artifact; an `aggregate` job merges them in
   arch-name-sorted order into `history.yaml` and pushes one bot
   commit tagged `[skip ci]`. windowsmini stays a local-only path
@@ -117,7 +118,8 @@ cranelift, wasmer singlepass) is recorded but not gated.
 
 ## Current status (post-Phase-7, Phase-8 onward)
 
-`scripts/run_bench.sh` is hyperfine-driven; CI records two arch
-rows per push (per the cadence above). Local phase-boundary
-rows continue to land via `--phase-record`. The pre-Phase-6
+`scripts/run_bench.sh` is hyperfine-driven; the CI job records two
+arch rows when it is dispatched (per the cadence above) — nothing
+runs it automatically. Local phase-boundary rows continue to land
+via `--phase-record`, and are the path that actually gets used. The pre-Phase-6
 trap-time baseline rows are preserved per ADR-0011 §3.

--- a/bench/README.md
+++ b/bench/README.md
@@ -58,10 +58,13 @@ preserved long-term.
   separate PR per merge). Put the PR intent in `--reason`; the
   entry's SHA is the branch tip (cosmetic). Skip for trivial /
   doc-only changes.
-- **Per-push CI**: [`.github/workflows/bench.yml`](../.github/workflows/bench.yml)
-  runs `--quick --phase-record` on every push to
-  `main` across `macos-latest` (aarch64-darwin) +
-  `ubuntu-latest` (x86_64-linux). Each arch uploads a YAML
+- **On-demand CI**: [`.github/workflows/bench.yml`](../.github/workflows/bench.yml)
+  runs `--quick --phase-record` across `macos-latest`
+  (aarch64-darwin) + `ubuntu-latest` (x86_64-linux). **Trigger is
+  `workflow_dispatch` only** — the push trigger was disabled
+  2026-05-25 because local development is the primary path and the
+  auto-runs produced noise; start it with `gh workflow run
+  bench.yml --ref main`. Each arch uploads a YAML
   fragment as an artifact; an `aggregate` job merges them in
   arch-name-sorted order into `history.yaml` and pushes one bot
   commit tagged `[skip ci]`. windowsmini stays a local-only path
@@ -96,8 +99,9 @@ ADR-0056.)
 
 `bench/results/history.yaml` is append-only (ROADMAP §A9). Rows
 are added by `scripts/run_bench.sh --phase-record` (manual /
-phase boundary) and the per-push CI bench-aggregate job
-([`.github/workflows/bench.yml`](../.github/workflows/bench.yml)).
+phase boundary) and the CI bench-aggregate job
+([`.github/workflows/bench.yml`](../.github/workflows/bench.yml),
+`workflow_dispatch` only).
 Never edit historical rows.
 
 `bench/results/recent.yaml` is gitignored and overwritten on

--- a/bench/README.md
+++ b/bench/README.md
@@ -120,6 +120,7 @@ cranelift, wasmer singlepass) is recorded but not gated.
 
 `scripts/run_bench.sh` is hyperfine-driven; the CI job records two
 arch rows when it is dispatched (per the cadence above) — nothing
-runs it automatically. Local phase-boundary rows continue to land
-via `--phase-record`, and are the path that actually gets used. The pre-Phase-6
+runs it automatically. Local phase-boundary rows continue to
+land via `--phase-record`, and are the path that actually gets
+used. The pre-Phase-6
 trap-time baseline rows are preserved per ADR-0011 §3.


### PR DESCRIPTION
## Summary

`bench/README.md` claimed the bench workflow runs on every push to `main`, in
two places. `.github/workflows/bench.yml` says otherwise in its own header:

> Trigger: **manual only** (`workflow_dispatch`). Auto-trigger on push to
> zwasm-from-scratch was DISABLED 2026-05-25 per user direction — local
> development is the primary path and CI was not actually consumed.

So the README was wrong twice over: the trigger is manual, and the trigger that
was removed watched `zwasm-from-scratch`, not `main`. Corrected to name
`workflow_dispatch`, why it was disabled, and how to start a run.

`.dev/phase10_prep/track_a_9.10_scope.md:51` also calls it "per-push CI runs"
and is deliberately left alone: it carries `Doc-state: ARCHIVED-IN-PLACE`, so it
records what was true when written. That is the same reason
`check_wasi03_coverage_claims.sh` exempts `.dev/archive/` and `CHANGELOG.md` —
chasing claims into archived docs rewrites history rather than correcting it.

Third of the claim-vs-reality sweep (after #184 for CLAUDE.md's extended-CI
line and #187 for the handover). No behaviour change — the workflow is
untouched.

## Found but not fixed here

The aggregate job pushes a bot commit straight to `main`
(`.github/workflows/bench.yml:214-229`), which the current ruleset should
refuse: its rules are `deletion` / `non_fast_forward` / `pull_request` /
`required_status_checks`, with zero bypass actors. So a dispatched run would
likely fail at the push step — likely, not certainly, because the workflow is
`workflow_dispatch`-only and has not run since the org transfer applied that
ruleset. Pre-existing, and the fix is on the workflow side (route through a PR,
or grant the bot a bypass), not in this README. Tracked separately.

## Checklist

- [x] `gate_commit.sh --fast` passed; doc-only, so CI gates via `doc-truth`
