### PR TITLE
docs(lessons): bring _TEMPLATE.md under the 50-line cap it prescribes

### DIFF
--- a/.dev/lessons/_TEMPLATE.md
+++ b/.dev/lessons/_TEMPLATE.md
@@ -34,16 +34,16 @@ observational knowledge worth keeping.>
 ## Related
 
 <Optional. Link to:
-- ADRs seeded or amended (per `lessons_vs_adr.md` "Lesson alongside ADR amend")
+- ADRs seeded or amended (per `.claude/references/lessons_vs_adr.md`
+  "Lesson alongside ADR amend")
 - Sibling lessons (same domain, same shape)
 - Debt rows that reference this lesson>
 
-<!--
-Template hygiene:
+<!-- Template hygiene:
 - Keep ≤ 50 lines total per `.claude/rules/lessons_vs_adr.md`.
 - Add one row to `.dev/lessons/INDEX.md` in the SAME commit.
-- If `Citing` is `<backfill>`, fix it at next phase boundary alongside
-  the SHA-pointer backfill pass.
-- Promotion to ADR: see `lessons_vs_adr.md` "Promotion: lesson → ADR" —
-  delete the lesson + INDEX row in the same commit as the new ADR.
+- `Citing: <backfill>` → fix at the next phase-boundary SHA-pointer pass.
+- Promotion to ADR ("Promotion: lesson → ADR" in
+  `.claude/references/lessons_vs_adr.md`) — delete the lesson + INDEX row
+  in the same commit as the new ADR.
 -->

--- a/.dev/lessons/_TEMPLATE.md
+++ b/.dev/lessons/_TEMPLATE.md
@@ -6,51 +6,44 @@
 
 ## What happened
 
-<2-5 sentences: the surprise / observation / spike outcome.
-What did the loop expect, what did it actually find?>
+<2-5 sentences: the surprise / observation / spike outcome. What did the
+loop expect, what did it actually find?>
 
 ## Root cause
 
-<3-8 sentences: the mechanism. Why did the surprise happen?
-Cite specific files + line numbers when applicable.
-If the lesson is observational (no single root cause), state
-that explicitly.>
+<3-8 sentences: the mechanism. Why did the surprise happen? Cite specific
+files + line numbers when applicable. If the lesson is observational (no
+single root cause), state that explicitly.>
 
 ## Fix (or path forward)
 
-<For observational lessons: "No fix — record for awareness."
-For derivable fixes: 2-5 sentences naming what changed.
-Cite the production commit SHA in **Citing** above.>
+<Observational: "No fix — record for awareness." Derivable: 2-5 sentences
+naming what changed; cite the production commit SHA in **Citing** above.>
 
 ## Why this didn't surface earlier
 
-<Optional but recommended for surprise-class lessons.
-Names the conditions that masked the issue. Helps prevent
-"why didn't we catch this in CI?" re-investigation.>
+<Optional but recommended for surprise-class lessons. Names the conditions
+that masked the issue — prevents "why didn't we catch this in CI?"
+re-investigation.>
 
 ## Re-derivability
 
-<One sentence: can a future session re-discover this by
-reading the code + ADRs + git log? If yes, the lesson is a
-shortcut. If no, it's load-bearing observational knowledge
-worth keeping.>
+<One sentence: can a future session re-discover this by reading the code +
+ADRs + git log? If yes, the lesson is a shortcut. If no, it's load-bearing
+observational knowledge worth keeping.>
 
 ## Related
 
-<Optional. Link to:
-- ADRs that this lesson seeded or amends (per
-  `.claude/rules/lessons_vs_adr.md` "Lesson alongside ADR
-  amend" — both coexist)
-- Sibling lessons (same domain, same shape)
-- Debt rows that reference this lesson>
+<Optional. ADRs this lesson seeded or amends (per
+`.claude/rules/lessons_vs_adr.md` "Lesson alongside ADR amend" — both
+coexist); sibling lessons (same domain, same shape); debt rows citing it.>
 
 <!--
 Template hygiene:
 - Keep ≤ 50 lines total per `.claude/rules/lessons_vs_adr.md`.
 - Add one row to `.dev/lessons/INDEX.md` in the SAME commit.
-- If `Citing` is `<backfill>`, fix it at next phase boundary
-  alongside the SHA-pointer backfill pass.
-- Promotion to ADR: see `lessons_vs_adr.md` "Promotion: lesson
-  → ADR" — delete the lesson + INDEX row in the same commit
-  as the new ADR.
+- If `Citing` is `<backfill>`, fix it at next phase boundary alongside
+  the SHA-pointer backfill pass.
+- Promotion to ADR: see `lessons_vs_adr.md` "Promotion: lesson → ADR" —
+  delete the lesson + INDEX row in the same commit as the new ADR.
 -->

--- a/.dev/lessons/_TEMPLATE.md
+++ b/.dev/lessons/_TEMPLATE.md
@@ -23,8 +23,7 @@ naming what changed; cite the production commit SHA in **Citing** above.>
 ## Why this didn't surface earlier
 
 <Optional but recommended for surprise-class lessons. Names the conditions
-that masked the issue — prevents "why didn't we catch this in CI?"
-re-investigation.>
+that masked the issue, preventing "why didn't CI catch this?" re-investigation.>
 
 ## Re-derivability
 
@@ -34,9 +33,10 @@ observational knowledge worth keeping.>
 
 ## Related
 
-<Optional. ADRs this lesson seeded or amends (per
-`.claude/rules/lessons_vs_adr.md` "Lesson alongside ADR amend" — both
-coexist); sibling lessons (same domain, same shape); debt rows citing it.>
+<Optional. Link to:
+- ADRs seeded or amended (per `lessons_vs_adr.md` "Lesson alongside ADR amend")
+- Sibling lessons (same domain, same shape)
+- Debt rows that reference this lesson>
 
 <!--
 Template hygiene:


### PR DESCRIPTION
Surfaced by the #191 external review. `_TEMPLATE.md` prescribes "Keep ≤ 50
lines total" and was 56. Tightened the placeholder prose to 49; every field,
section heading, hygiene bullet, and the `## Related` bullet skeleton (43 of
43 lessons use one) survives. One file — that is the whole diff.

## How far the corpus is from what the template prescribes

192 lessons (`.dev/lessons/*.md` less `_TEMPLATE.md` / `INDEX.md`), measured
on `origin/main` at `d35e6a6`, 2026-08-16.

| Prescribed by `_TEMPLATE.md` | Lessons carrying it | |
|---|---:|---:|
| `**Date**` | 113 | 59% |
| `**Citing**` (bold form) | 61 | 32% |
| `**Keywords**` | 19 | 9.9% |
| `## What happened` | 30 | 16% |
| `## Root cause` | 10 | 5.2% |
| `## Fix (or path forward)` | 4 | 2.1% |
| `## Why this didn't surface earlier` | 6 | 3.1% |
| `## Re-derivability` | 3 | 1.6% |
| `## Related` | 43 | 22% |
| ≤ 50 lines | 94 | 49% |

158 of the 192 carry none of the five body sections; 6 carry three or more.
The most common heading in the corpus is `## Observation` (51 files), which
the template does not name — then `## Related` (43) and `## Rule` (36).
Median lesson 51 lines, longest 284. Nothing checks any of this
mechanically, which is why 9.9% went unnoticed.

Re-derive with an explicit path — `rg` skips dot-directories, so a bare
search drops `.dev/` entirely:

```sh
L=$(ls .dev/lessons/*.md | grep -vE '/(_TEMPLATE|INDEX)\.md$')
echo "$L" | wc -l                                        # 192
echo "$L" | xargs grep -lF  -- '**Keywords**'   | wc -l   # 19
echo "$L" | xargs grep -lxF -- '## Root cause'  | wc -l   # 10
for f in $L; do wc -l < "$f"; done | awk '$1>50' | wc -l  # 98 over the cap
```

## Two things the sweep turned up

**`INDEX.md` already is the keyword index, at full coverage.** Its table has
a Keywords column with exactly one row per lesson — 192 rows, 192 files, no
orphan either way (this prints nothing):

```sh
diff <(grep -oE '^\| 20[0-9]{2}-[0-9]{2}-[0-9]{2} +\| [a-z0-9][a-z0-9._-]* ' .dev/lessons/INDEX.md \
        | sed -E 's/^\| ([0-9-]+) +\| ([^ ]+) $/\1-\2/' | sort -u) \
     <(ls .dev/lessons/*.md | grep -vE '/(_TEMPLATE|INDEX)\.md$' | xargs -n1 basename | sed 's/\.md$//' | sort)
```

**`scripts/check_lesson_citing.sh` passes vacuously.** It prints `OK: all
lessons have resolved Citing fields` while 105 of 192 carry no Citing field
at all, and all five real `<backfill>` markers are invisible to it — its
regex wants `**Citing**` and the marker on one line, and those five write
`> Citing:`, `` `Citing:` ``, or a bare bullet. Reported, not touched here.

## Open — owner's call, not decided in this PR

The numbers say the conventions are not being followed. They do not say the
conventions should be dropped; that is a separate judgment. Both files were
written by chaploud (`_TEMPLATE.md` 2026-05-16, the rule 2026-06-02), so the
"drop it" direction changes someone else's design intent.

### 1. `**Keywords**` in the lesson body — keep or drop?

- **Drop, INDEX-only.** Matches `.claude/CLAUDE.md:136`, which already calls
  INDEX.md "the keyword index for Step 0.4". Cost: one template line, plus
  optionally 19 body lines — not a free strip, since 12 of the 19 word their
  keywords differently from their INDEX row (7 are identical).
- **Keep, backfill 173.** Cost: 173 edits, each a judgment on which keywords
  belong; duplicates a column already at 192/192, with nothing mechanical
  keeping the two in sync afterwards.

### 2. The ≤ 50-line cap — what happens to it?

Stated in four places, so any change touches all four:
`.claude/rules/lessons_vs_adr.md:15`, `.claude/references/lessons_vs_adr.md:36`,
`.dev/lessons/INDEX.md:19`, `.dev/lessons/_TEMPLATE.md:49`.

- **Drop or raise it.** Cost: 4 edits.
- **Bring the 98 under it.** Cost: 3,988 lines to remove across 98 files (30
  exceed 100 lines, longest 284) — every cut decides which observation
  survives.
- **Demote to template-only guidance**, binding new lessons and
  grandfathering the rest. Cost: 1–2 edits, but leaves 98 files permanently
  non-conforming with nothing marking grandfathered apart from drifted.

Not in this PR: no rule edit, no lesson edits, no `.dev/debt.yaml` row.
