### PR TITLE
docs(handover): name what is in flight, not only what is done

### DIFF
--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -33,11 +33,12 @@ clean `brew` state) and **phase 5** (cljw pin + wind-down).
   the ADR once the review answers.
 - **Next dispatchable — the wasmtime differential is double fail-open.**
   `test/realworld/diff_runner.zig` has a `matched < 30` denominator gate that is
-  unreachable: two early returns precede it — the oracle missing
-  (`SKIP-WASMTIME-MISSING`) and the oracle resolving but every spawn failing
-  (`SKIP-WASMTIME-UNUSABLE`). `.github/workflows/ci.yml` installs wasmtime with
-  `continue-on-error: true`, so absent OR broken, the lane goes GREEN without
-  running. Fixing it touches `ci.yml`, so it is not a maintainer-free change.
+  bypassed on any host without a working wasmtime: two early returns precede it
+  — the oracle missing (`SKIP-WASMTIME-MISSING`) and the oracle resolving but
+  every spawn failing (`SKIP-WASMTIME-UNUSABLE`). `.github/workflows/ci.yml`
+  installs wasmtime with `continue-on-error: true`, so absent OR broken, the
+  lane goes GREEN without running. Fixing it touches `ci.yml`, so it is not a
+  maintainer-free change.
 
 ## Closed campaigns (details in the cited ADR/CHANGELOG)
 

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -5,9 +5,8 @@
 
 ## Current state — MAINTENANCE MODE (post-v2.0.0)
 
-**v2.5.0 TAGGED and published** — the pre-tag cleanliness sweep (S1-S6)
-is DONE (S1-S5 merged as #175, S6 as #176). Prior line v2.4.1; v1 frozen
-at `v1.11.1`. Dev model: `develop/<slug>` from `main` → PR → CI
+**v2.5.0 TAGGED and published**; prior line v2.4.1; v1 frozen at
+`v1.11.1`. Dev model: `develop/<slug>` from `main` → PR → CI
 `ci-required` green → merge. Release stays user-only (ADR-0156) — an
 agent-autonomy guardrail, not a bar to release automation.
 
@@ -18,6 +17,23 @@ issues / releases / ruleset intact). **Phase 4's repo side is done too** —
 `cljw.rb` plus `tap_migrations.json`, and README installs from
 `zwasm/tap/zwasm` (#181). Left to the user: phase 4 item 10 (verify from a
 clean `brew` state) and **phase 5** (cljw pin + wind-down).
+
+## In flight (2026-08-16)
+
+- **#186** (jit: trap on a null table funcptr instead of executing it) and
+  **#183** (ADR-0208 — gate WASI preview1 on the official testsuite): both
+  CI-green and mergeable, **awaiting maintainer review since 2026-08-14**.
+  Do not refresh them against `main` until the review lands.
+- **Landed 2026-08-16**: #190 (D-592 retracted — the build-cache mechanism it
+  claimed does not hold; the real defect was `run_oob_trap` never re-running),
+  #192 (the JIT realworld differential had no caller — now in `test-all` with
+  denominator accounting), #191 / #193 (records).
+- **Next dispatchable — the wasmtime differential is double fail-open.**
+  `.github/workflows/ci.yml:194` installs the oracle with
+  `continue-on-error: true`, and `test/realworld/diff_runner.zig` returns early
+  at 143 and 509 — both ahead of the `matched < 30` gate at 511. A host without
+  wasmtime therefore leaves the lane GREEN without running it. Fixing it
+  touches `ci.yml`, so it is not a maintainer-free change.
 
 ## Closed campaigns (details in the cited ADR/CHANGELOG)
 
@@ -32,27 +48,14 @@ clean `brew` state) and **phase 5** (cljw pin + wind-down).
 - **reproducible-dev-env** (#166, ADR-0206): `docs/development.md` SSOT +
   `dev_hosts.env` config + dead-script sweep. Post-merge main CI green
   (incl. extended) for #165; #166's run superseded-cancelled by #167's.
+- **Pre-v2.5.0 cleanliness sweep S1-S6 — COMPLETE 2026-08-12** (#175 + #176;
+  ADR-0207): `file_size_check` 0 WARN repo-wide, -Dgc/run-repro retired
+  (D-525), CLI + build-option surfaces audited, four mechanized guards live
+  (growth ratchet · test-discovery · doc-fossil · blocked-by ladder),
+  README/docs final-form with zero personal-infra mentions.
 - Doc-truth gaps #153/#154 + #163 CLOSED (prose gates live in the always-on
   CI **`doc-truth` job**). Binary-size CLOSED (ADR-0204). AOT full-fidelity
   CLOSED (ADR-0203; residual D-515(2)+D-514).
-
-## Cleanliness sweep S1-S6 — COMPLETE (2026-08-12)
-
-All six axes closed (plan was #168; S1-S5 consolidated+merged as #175):
-- **S1** D-444 three-way split (ADR-0207) + full over-cap triage —
-  `file_size_check` 0 WARN repo-wide (was 30); canon/types P1 seams
-  scheduled post-tag (D-580/D-581).
-- **S2** -Dgc + run-repro retired (D-525; ADR-0115/0015 revision notes);
-  Windows sanitize rejects loudly; build-option table in development.md.
-- **S3** --engine auto spellable; usage errors exit 2 uniformly; env
-  surface audited (no hidden flags).
-- **S4** audit fixes: ROADMAP links, blocked-by re-walk (6 dissolved
-  barriers flipped w/ evidence), doc-states.
-- **S5** four guards live: growth ratchet, compiler-truth test-discovery
-  (28 dead tests revived), doc-fossil guard (doc-truth job), blocked-by
-  age ladder. 
-- **S6** README+docs final-form: 6 history docs archived w/ Doc-state,
-  public docs carry ZERO personal-infra/private/ mentions, links verified.
 
 ## Operational invariants (keep using)
 

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -28,12 +28,16 @@ clean `brew` state) and **phase 5** (cljw pin + wind-down).
   claimed does not hold; the real defect was `run_oob_trap` never re-running),
   #192 (the JIT realworld differential had no caller — now in `test-all` with
   denominator accounting), #191 / #193 (records).
+- `develop/wasi-p1-official-impl` carries #183's implementation — 147 files
+  (vendored corpus + runner + advisory gate), pushed, **no PR**; it lands with
+  the ADR once the review answers.
 - **Next dispatchable — the wasmtime differential is double fail-open.**
-  `.github/workflows/ci.yml:194` installs the oracle with
-  `continue-on-error: true`, and `test/realworld/diff_runner.zig` returns early
-  at 143 and 509 — both ahead of the `matched < 30` gate at 511. A host without
-  wasmtime therefore leaves the lane GREEN without running it. Fixing it
-  touches `ci.yml`, so it is not a maintainer-free change.
+  `test/realworld/diff_runner.zig` has a `matched < 30` denominator gate that is
+  unreachable: two early returns precede it — the oracle missing
+  (`SKIP-WASMTIME-MISSING`) and the oracle resolving but every spawn failing
+  (`SKIP-WASMTIME-UNUSABLE`). `.github/workflows/ci.yml` installs wasmtime with
+  `continue-on-error: true`, so absent OR broken, the lane goes GREEN without
+  running. Fixing it touches `ci.yml`, so it is not a maintainer-free change.
 
 ## Closed campaigns (details in the cited ADR/CHANGELOG)
 


### PR DESCRIPTION
## Why

`.dev/handover.md` is the canonical fresh-session entry point.
[`handover_doc_discipline.md`](.claude/rules/handover_doc_discipline.md) §1
requires it to name the current state **plus the concrete next work, or a
specific dependency provably waiting on external input**.

It did neither. All seven sections described finished or static things —
measured on `origin/main`:

| pattern | hits |
|---|---|
| `#183` / `#186` / `#19x` | 0 |
| `next` / `awaiting` / `in flight` / `review` | 0 |
| `blocked` | 2, both inside the S4/S5 sweep prose — not a current dependency |

A session reading this file could not learn that two PRs have been waiting on
maintainer review since 2026-08-14, nor what was dispatchable.

## What changed

- **`## In flight (2026-08-16)`** — the two blocked PRs and why, what landed on
  2026-08-16, and the next dispatchable item.
- The next item is stated as a **mechanism with line numbers**, not a label:
  `ci.yml:194` installs the oracle with `continue-on-error: true`, and
  `diff_runner.zig` returns early at **143** and **509**, both ahead of the
  `matched < 30` gate at **511** — so a host without wasmtime leaves the lane
  green without running it.
- **S1-S6 sweep section collapsed** into one `Closed campaigns` entry (it was
  17 lines describing work finished 2026-08-12), and the sentence it duplicated
  in `Current state` dropped.

**101 → 109 lines.** Inside the 120 hard cap; §6 says explicitly not to
micro-trim for length alone.

## Follow-up commits

- Names `develop/wasi-p1-official-impl` (#183's 147-file implementation, pushed
  with no PR) — a session reading In flight otherwise saw the four-file ADR and
  no sign of where the implementation lives.
- Drops the hardcoded line numbers from the fail-open citation. The work that
  section names as next edits `diff_runner.zig` and `ci.yml`, so the numbers rot
  on its first commit. Anchored instead on the `matched < 30` gate (which that
  work must preserve) plus the two SKIP labels.
- External review flag 3: "unreachable" → "bypassed on any host without a
  working wasmtime". The gate is reached and enforced where wasmtime works.

## What this PR does not do

- Does not refresh #186 / #183 against `main` — they are waiting on review, and
  refreshing before it lands only re-runs CI for nothing.
- Does not touch `.dev/debt.yaml`, so it cannot conflict with the two open PRs.
- Does not fix the wasmtime fail-open it describes. That is its own change and
  touches `ci.yml`.

## Considered and deliberately not done

- **The collapsed sweep entry drops the `D-580` / `D-581` pointer** (canon/types
  P1 seams). Raised by review twice. Not restored here: both rows are live at
  `.dev/debt.yaml:238,252`, and `## Parked / gated` already carries
  `(see debt.yaml)`, so the pointer survives one indirection. The file is at
  109 of a 120 hard cap, and §6 forbids spending lines to restore what the SSOT
  already holds. **Candidate for the next handover rewrite**, not for this PR.
- **Refreshing #186 / #183 against `main`.** Both are awaiting maintainer
  review; refreshing before it lands re-runs CI for nothing.

## Checklist

- [x] `zig fmt src/` clean — no `src/` changes
- [x] Docs updated — this PR is the doc change
- [ ] Tests — n/a, doc-only



