### PR TITLE
docs(lessons): drop the Keywords line from _TEMPLATE.md

### DIFF
--- a/.dev/lessons/_TEMPLATE.md
+++ b/.dev/lessons/_TEMPLATE.md
@@ -1,7 +1,6 @@
 # <one-line title in imperative or descriptive form>
 
 **Date**: YYYY-MM-DD
-**Keywords**: <comma-separated keywords for INDEX grep — domain + symptom + remediation>
 **Citing**: <commit SHA or §9.<N> / N.M chunk id; use `<backfill>` until commit lands>
 
 ## What happened


### PR DESCRIPTION
## What

Delete the `**Keywords**` line from `.dev/lessons/_TEMPLATE.md`. One file,
one line, 49 -> 48. No other file changes.

## Why

`.claude/CLAUDE.md:136` defines `INDEX.md` as the keyword index for Step 0.4.
The template's body field was a second, weaker copy of that index: filled in
by 19 of 192 lessons (9.9%), and by 1 of the last 10. All 192 lessons have an
INDEX row and no row has an empty keywords column, so consolidating on INDEX
loses no lookup path.

Nothing depends on the field. A scan of `.claude/**`, `scripts/**`, `docs/**`
and `.github/**` found no reference to it; `audit_scaffolding/CHECKS.md:258`
("INDEX row's keyword column empty -> `soon`") reads the INDEX side. And
`_TEMPLATE.md:44` separately tells authors to add the INDEX row in the same
commit, so the instruction to populate the index survives the deletion.

## Scope

Owner decision, 2026-08-16. The two items reviewed alongside this one are
**settled as keep-as-is, not left untouched**: the 6-section structure stays,
and the `<= 50 lines` convention stays.

The 19 existing lessons that carry a body-level `**Keywords**` are untouched.
Whether to clean them up is undecided and does not need deciding here; if it
is ever done, only two of the 19 have body-only terms that would need moving
to INDEX first (`2026-05-13-br-liveness-target-depth` and
`2026-07-09-failure-path-tests-certified-the-defect`) — the other 17 are
either an exact match or a stale subset of their INDEX row.

## Testing

Doc-only: `ci-required` + `doc-truth`. Local `scripts/gate_commit.sh` green
on the docs-only path.
