### PR TITLE
docs: drop bogus task references that link to unrelated PRs

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -96,7 +96,7 @@ entries:
       of those dimensions. `status: note` (record only, do not chase) is in
       the same tension and is itself provisional; `now` would pre-empt the
       question in the other direction, so neither is asserted here.
-      Both the disposition and the status are decided at #12, when the JIT
+      Both the disposition and the status are decided when the JIT
       lane's CI gating is designed, with maintainer confirmation. Whoever
       designs it must also resolve a PRE-EXISTING asymmetry in what the jit
       lane already gates (not introduced by ADR-0210, verified against
@@ -1984,7 +1984,7 @@ entries:
       was WRONG — that text is the `|| echo` in `ci.yml` echoed into the log, the D-590 shape.
       REJECTED: making the CI install mandatory. It trades a rare, partial, logged loss for every PR
       going red on one download flake, and `wasm-tools` (genuinely required) has the same exposure.
-      THIRD OPTION, unexplored and out of #13's scope: `ci.yml` caches `zig-pkg` and
+      THIRD OPTION, unexplored and out of scope for the realworld-JIT work: `ci.yml` caches `zig-pkg` and
       `~/.local/zig-0.16.0` (lines 148-160) but caches NEITHER wasmtime nor wasm-tools. Caching them
       would cut the download-failure probability and change the mandatory-install trade-off.
       ALSO UNVERIFIED: CI pins the oracle at wasmtime 45.0.0 (`.github/versions.lock`); the 56/56 JIT

--- a/.dev/decisions/0210_spec_runner_enumeration_accounting.md
+++ b/.dev/decisions/0210_spec_runner_enumeration_accounting.md
@@ -150,7 +150,7 @@ defect is in `invokeMulti` itself or in the runner's use of it was not
 isolated, and is not claimed either way.
 
 Its disposition is **out of scope for this ADR and unsettled** — recorded
-as **D-590**, decided at #12 when the JIT lane's CI gating is designed.
+as **D-590**, decided when the JIT lane's CI gating is designed.
 Leaving it unfixed and gating the lane with one accepted fail is one
 candidate; it conflicts with ADR-0153 (a measured violation of a 完成形
 dimension "schedules a rework"), and 100% spec is one of those dimensions.

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -1773,7 +1773,8 @@ pub fn main(init: std.process.Init) !void {
     // reported only. Read that narrowly: `trap.fail` below IS summed
     // unconditionally, and in jit mode the assert_trap arm evaluates `cur_jit`,
     // so a JIT-only trap regression already exits non-zero. That asymmetry
-    // predates this file's accounting rework; D-590 hands it to #12.
+    // predates this file's accounting rework; D-590 hands it to whoever
+    // gates the JIT lane.
     // In jit mode `ret.fail` mirrors the JIT verdict, which ADR-0128 keeps
     // report-only — gating it here would silently promote the opt-in JIT
     // lane into a merge gate. That promotion is a deliberate decision for


### PR DESCRIPTION
## Why

Four places carried a bare issue-style number when naming follow-up work.
The numbers refer to nothing in this repo, so GitHub linked them to unrelated
v1-era PRs.

`.dev/debt.yaml:99` is the worst of the four: it tells the next person that
the disposition "is decided at" one of them, and that "whoever designs it"
must also resolve a pre-existing asymmetry — i.e. it actively routes someone
to the wrong change.

## What changed

| file | before | after |
|---|---|---|
| `.dev/debt.yaml` (D-590) | `decided at #12, when the JIT lane's CI gating is designed` | `decided when the JIT lane's CI gating is designed` |
| `.dev/debt.yaml` (D-283) | `out of #13's scope` | `out of scope for the realworld-JIT work` |
| `.dev/decisions/0210_…` | `decided at #12 when the JIT lane's CI gating is designed` | `decided when the JIT lane's CI gating is designed` |
| `test/spec/spec_assert_runner_wasm_3_0.zig` | `D-590 hands it to #12` | `D-590 hands it to whoever gates the JIT lane` |

**Every site already described the work in the same sentence**, so the numbers
were redundant before they were wrong.

## Scope

Swept the whole tree for the pattern, not just the four known sites.
Identifiers that resolve inside the repo are untouched: PR numbers, commit
SHAs, `D-NNN`, `ADR-NNNN`, ROADMAP sections, file paths. Assembly immediates
(`[SP, #16]`), `regret #N` in ADR-0022, `ClojureWasm Discussion #11`, and the
v1 contributor issues in ADR-0179 are all legitimate and unchanged.

## Checklist

- [x] `zig fmt` clean — the one `.zig` change is a comment
- [x] `scripts/check_debt_yaml.sh --gate` passes (82 entries, schema valid)
- [ ] Tests — n/a, comments and records only. Note: the `.zig` file puts this
      outside the doc-only short-circuit, so the full 3-OS gate runs.
