### PR TITLE
docs(adr): flip ADR-0208 to Accepted + pin the stale step count

### DIFF
--- a/.dev/decisions/0208_wasip1_official_corpus.md
+++ b/.dev/decisions/0208_wasip1_official_corpus.md
@@ -2,7 +2,8 @@
 
 > **Doc-state**: ACTIVE
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-08-18 — maintainer sign-off on PR #183; the
+  official suite is the bar, D1–D3 as written)
 - **Date**: 2026-08-14
 - **Front**: B-hardening (D-582 infrastructure, D-583 the behaviour gaps it exposes)
 - **Findings base**: measured conformance run 2026-08-14 at `2e40d4314` on
@@ -92,7 +93,8 @@ separately.
 
 The step is **not** added to §11.1's table. That table has not been touched
 since the Phase-0 bootstrap (`9bd21b2fc`): it lists 8 steps where `build.zig`
-now declares 42 (31 of them `test*`), and `test-wasi-p1`, `test-wasi-p3`, `test-component-spec`,
+declared 42 at the findings base (31 of them `test*`; the count only grows —
+ADR-0209/0210 pushed it to 47), and `test-wasi-p1`, `test-wasi-p3`, `test-component-spec`,
 `test-spec-simd` and `test-spec-assert` are all absent — including steps added
 as recently as the ADR-0205 campaign. It is a frozen Phase-era overview, not a
 live registry, and adding one step to it would misrepresent it as maintained.


### PR DESCRIPTION
Patch PR into #183 (review outcome — two edits, both to the ADR):

1. **Status: Proposed → Accepted** (2026-08-18 — maintainer sign-off on
   PR #183). The maintainer's answer to the PR's one question: yes, the
   official wasi-testsuite is the right bar; D1–D3 as written. Recorded
   in the Status line per the house "Accepted names who approved"
   convention.

2. **Pin the D2 step-count aside to its findings base.** "build.zig now
   declares 42 (31 test*)" was true at `2e40d4314` but ADR-0209/0210
   merged since and the count is 47 today; the sentence now names the
   findings base and the growth direction, so it cannot rot again.

Everything else in #183 was verified as-is during review: ADR number
free, D-582/D-583 unclaimed on main, `test/component/wasip3_official/`
+ `vendor_wasip3_official.sh` exist as the §11.2 row describes, and the
handover edit merges cleanly against current main.

https://claude.ai/code/session_01Tx663FxULaE5e4Nfhy26uk