### PR TITLE
docs(debt): D-586 (a) — the tableSetRef comment no longer lies

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -54,9 +54,9 @@ entries:
       Exactly ONE path reaches them: `JitInstance.tableSetRef`, which clears the
       funcptr mirror while leaving the parallel typeidx intact so the D-294
       sentinel does NOT fire — an ordinary embedder operation, and the reason
-      that function's "traps cleanly" comment only became true with (2). Its
-      "uninitialized sentinel" wording still does not match what the code
-      writes. (An earlier revision of this row also claimed `fidx >=
+      that function's "traps cleanly" comment only became true with (2); its
+      doc comment now spells out the zero-vs-sentinel split and cites this
+      row. (An earlier revision of this row also claimed `fidx >=
       dispatch.len`; that is unreachable — `dispatch` is allocated with
       `num_imports` slots and every slot is pre-seeded with `&hostDispatchTrap`,
       so an import's `fe.funcptr` is never 0.) The site is load-bearing; what is


### PR DESCRIPTION
Patch PR into #186 (review outcome — one sentence).

D-586 (a) still said tableSetRef's "uninitialized sentinel" wording
"does not match what the code writes" — but #186's own `runner.zig`
edit rewrote that doc comment to spell out the zero-vs-sentinel split
(funcptr mirror ZEROED, typeidx mirror untouched). The sentence
described the pre-PR comment, so at merge time the row would have
re-opened a gap the same PR closed. (a) now carries only what is
actually still open: which trap kind fits, owned by the D-293/D-294
taxonomy.

Everything else in #186 was verified as-is during review: the eight
null-test sites are exactly the {arm64, x86_64} × {call_indirect,
return_call_indirect} × {single-, multi-table} product, byte-offset
expectations in emit_test_call.zig / emit_test_int.zig shift
consistently, and the null test on the tail-call paths sits before
frame teardown so the trap stub's own-epilogue discipline holds.

https://claude.ai/code/session_01Tx663FxULaE5e4Nfhy26uk